### PR TITLE
Fix cs2cs call when generating popdat.bin

### DIFF
--- a/popdat/src/psrc.rs
+++ b/popdat/src/psrc.rs
@@ -165,9 +165,9 @@ fn import_parcels(
     let output = std::process::Command::new("cs2cs")
         // cs2cs +init=esri:102748 +to +init=epsg:4326 -f '%.5f' foo
         .args(vec![
-            "+init=esri:102748",
+            "esri:102748",
             "+to",
-            "+init=epsg:4326",
+            "epsg:4326",
             "-f",
             "%.5f",
             "/tmp/parcels",

--- a/popdat/src/psrc.rs
+++ b/popdat/src/psrc.rs
@@ -163,7 +163,7 @@ fn import_parcels(
         prettyprint_usize(parcel_metadata.len())
     ));
     let output = std::process::Command::new("cs2cs")
-        // cs2cs +init=esri:102748 +to +init=epsg:4326 -f '%.5f' foo
+        // cs2cs esri:102748 +to epsg:4326 -f '%.5f' foo
         .args(vec![
             "esri:102748",
             "+to",


### PR DESCRIPTION
I got the following error when running `cs2cs`

```
cannot instantiate source coordinate system
program abnormally terminated
```

[The "+init=esri:1234" syntax is deprecated](https://pyproj4.github.io/pyproj/dev/gotchas.html#init-auth-auth-code-should-be-replaced-with-auth-auth-code). This just uses
the new "esri:1234" syntax, which runs on Mac OSx.