### PR TITLE
Auto-pan map when cursor is at edge of screen

### DIFF
--- a/ezgui/src/managed.rs
+++ b/ezgui/src/managed.rs
@@ -195,7 +195,6 @@ impl Widget {
     }
 
     pub fn named<I: Into<String>>(mut self, id: I) -> Widget {
-        assert!(self.id.is_none());
         self.id = Some(id.into());
         self
     }

--- a/game/src/common/mod.rs
+++ b/game/src/common/mod.rs
@@ -260,10 +260,6 @@ impl CommonState {
         let draw = g.upload(batch);
         let top_left = ScreenPt::new(0.0, g.canvas.window_height - 1.5 * g.default_line_height());
         g.redraw_at(top_left, &draw);
-        g.canvas.mark_covered_area(ScreenRectangle::top_left(
-            top_left,
-            ScreenDims::new(g.canvas.window_width, 1.5 * g.default_line_height()),
-        ));
     }
 
     // Meant to be used for launching from other states

--- a/game/src/options.rs
+++ b/game/src/options.rs
@@ -64,6 +64,13 @@ impl OptionsPanel {
                     .margin(5),
                     Checkbox::text(
                         ctx,
+                        "Enable panning map when cursor is at edge of screen",
+                        None,
+                        ctx.canvas.edge_auto_panning,
+                    )
+                    .named("disable pan"),
+                    Checkbox::text(
+                        ctx,
                         "Use touchpad to pan and hold Control to zoom",
                         None,
                         ctx.canvas.touchpad_to_move,
@@ -180,6 +187,7 @@ impl State for OptionsPanel {
                     ctx.canvas.touchpad_to_move = self
                         .composite
                         .is_checked("Use touchpad to pan and hold Control to zoom");
+                    ctx.canvas.edge_auto_panning = self.composite.is_checked("disable pan");
                     app.opts.dev = self.composite.is_checked("Enable developer mode");
 
                     let style = self.composite.dropdown_value("Traffic signal rendering");


### PR DESCRIPTION
## Purpose

Resolve #11

## Approach

I created two bounding boxes, an inner bounding box in screen space and a map bounding box in map space. The presence of the cursor within the inner bounding box is used to determine whether or not the cursor is at the edge of the screen and the presence of the cursor within the map bounding box is used to determine whether further panning would bring the user out of the map. I've also implemented a setting to disable panning if the user doesn't like it.

Once, it's determined that panning should take place, I calculate the centre of the screen and then calculate the displacement vector from the cursor position to the centre of the screen. Then, I calculate the magnitude of the displacement and use it to convert the displacement vector to a unit vector. The resulting unit vector is then multiplied by the `PANNING_SPEED` to get the vector components that are then added to the camera position. 

## Potential Questions

### Why is auto-panning the default?

It felt more intuitive to me than click and drag but that might just be my own personal opinion.

### Why didn't you use the `get_cursor_in_screen_space` or `get_cursor_in_map_space` functions

When grabbing a cursor in those cases, it seems to prevent auto-panning from occurring either when the cursor wasn't on a GUI element (`get_cursor_in_map_space`) or when the cursor was on a  GUI element (`get_cursor_in_screen_space`).