### PR TITLE
Add 'libssl-dev' dependency

### DIFF
--- a/docs/dev.md
+++ b/docs/dev.md
@@ -5,7 +5,7 @@
 You will first need:
 
 - Stable Rust, at least 1.43. https://www.rust-lang.org/tools/install
-- On Linux, `sudo apt-get install xorg-dev libxcb-shape0-dev libxcb-xfixes0-dev`
+- On Linux, `sudo apt-get install xorg-dev libxcb-shape0-dev libxcb-xfixes0-dev libssl-dev`
   or the equivalent for your distro
 
 One-time setup:


### PR DESCRIPTION
Hi,

When trying to build from source, I encountered the problem that openSSL was not found. I followed the solution [here](https://github.com/sfackler/rust-openssl/issues/649) which fixed it, and thought on improving the docs.

Kind regards,
Pieter