### PR TITLE
Round time to 10 minutes in jump to dialog

### DIFF
--- a/game/src/sandbox/speed.rs
+++ b/game/src/sandbox/speed.rs
@@ -446,7 +446,8 @@ impl State for JumpToTime {
             .primary
             .sim
             .get_end_of_day()
-            .percent_of(self.composite.area_slider("time slider").get_percent());
+            .percent_of(self.composite.area_slider("time slider").get_percent())
+            .round_seconds(600.0);
         if target != self.target {
             self.target = target;
             self.composite.replace(

--- a/geom/src/time.rs
+++ b/geom/src/time.rs
@@ -185,6 +185,10 @@ impl Time {
     pub fn clamped_sub(self, dt: Duration) -> Time {
         Time::seconds_since_midnight((self.0 - dt.inner_seconds()).max(0.0))
     }
+
+    pub fn round_seconds(self, s: f64) -> Time {
+        Time::seconds_since_midnight(s * (self.0 / s).round())
+    }
 }
 
 // 24-hour format by default


### PR DESCRIPTION
This allows me to quickly and precisely jump to the same time every
time.