### PR TITLE
fix math in city picker to use scale factor

### DIFF
--- a/game/src/common/city_picker.rs
+++ b/game/src/common/city_picker.rs
@@ -36,8 +36,9 @@ impl CityPicker {
             &mut abstutil::Timer::throwaway(),
         ) {
             let bounds = city.boundary.get_bounds();
-            let zoom = (0.8 * ctx.canvas.window_width / bounds.width())
+            let zoom_no_scale_factor = (0.8 * ctx.canvas.window_width / bounds.width())
                 .min(0.8 * ctx.canvas.window_height / bounds.height());
+            let zoom = zoom_no_scale_factor / ctx.get_scale_factor();
 
             batch.push(app.cs.map_background, city.boundary);
             for (area_type, polygon) in city.areas {
@@ -51,7 +52,7 @@ impl CityPicker {
                 } else {
                     batch.push(color, polygon.to_outline(Distance::meters(200.0)));
                 }
-                regions.push((name, color, polygon.scale(zoom)));
+                regions.push((name, color, polygon.scale(zoom_no_scale_factor)));
             }
             batch = batch.scale(zoom);
         }


### PR DESCRIPTION
Thought I'd try to fix the issue I opened (#101 ).

First, the zoom was not using the scale factor, so the city picker window was too large (bigger than the screen) for larger scale factors (e.g. 2.0 on my Mac).  Adding the scale factor to the calculation of `zoom` fixes this.

But, it appears that `regions` shouldn't be scaled according to the scale factor. (A comment says it's in "untranslated screen-space".)  In any case, using the zoom without the scale factor for the regions, while using the zoom with the scale factor for the batch, appears to fix this issue.  I tested it using different scale factors.

Since I don't really know what I'm doing, there may be a more sensible way to name or structure these calculations.  Let me know.