### PR TITLE
Commuter Patterns: Show secondary stats for commute on hover

### DIFF
--- a/game/src/sandbox/dashboards/commuter.rs
+++ b/game/src/sandbox/dashboards/commuter.rs
@@ -353,7 +353,16 @@ impl State for CommuterPatterns {
         let block_selection = if let Some(pt) = ctx.canvas.get_cursor_in_map_space() {
             if let Some(b) = self.blocks.iter().find(|b| b.shape.contains_pt(pt)) {
                 if app.per_obj.left_click(ctx, "clicked block") {
-                    BlockSelection::LockedWithoutComparison(b.id)
+                    match self.current_block.0 {
+                        BlockSelection::LockedWithoutComparison(old_locked) => {
+                            if old_locked == b.id {
+                                BlockSelection::Unlocked(b.id)
+                            } else {
+                                BlockSelection::LockedWithoutComparison(b.id)
+                            }
+                        }
+                        _ => BlockSelection::LockedWithoutComparison(b.id),
+                    }
                 } else {
                     match self.current_block.0 {
                         BlockSelection::LockedWithoutComparison(locked)

--- a/game/src/sandbox/dashboards/commuter.rs
+++ b/game/src/sandbox/dashboards/commuter.rs
@@ -281,8 +281,9 @@ impl CommuterPatterns {
                             .unwrap_or(0);
                         let label_text = format!("{}", abstutil::prettyprint_usize(count));
                         batch.append(
-                            Text::from(Line(label_text).fg(Color::WHITE))
+                            Text::from(Line(label_text).fg(Color::BLACK))
                                 .render_to_batch(ctx.prerender)
+                                .scale(2.0)
                                 .centered_on(compare_to_block.shape.polylabel()),
                         );
                     }

--- a/game/src/sandbox/dashboards/commuter.rs
+++ b/game/src/sandbox/dashboards/commuter.rs
@@ -336,7 +336,10 @@ impl State for CommuterPatterns {
                 self.block_drawables.insert(key, primary_drawable);
 
                 let mut txt = Text::new();
-                txt.add(Line(format!("Total: {} trips", total_trips)));
+                txt.add(Line(format!(
+                    "Total: {} trips",
+                    abstutil::prettyprint_usize(total_trips)
+                )));
                 for (name, cnt) in building_counts {
                     if cnt != 0 {
                         txt.add(Line(format!("{}: {}", name, cnt)));
@@ -402,7 +405,7 @@ impl State for CommuterPatterns {
                         .find(|(block, _)| block.id == hovered)
                         .map(|(_, count)| count)
                         .unwrap_or(0);
-                    let label_text = format!("{}", count);
+                    let label_text = format!("{}", abstutil::prettyprint_usize(count));
                     batch.append(
                         Text::from(Line(label_text).fg(Color::WHITE))
                             .render_to_batch(ctx.prerender)

--- a/game/src/sandbox/dashboards/commuter.rs
+++ b/game/src/sandbox/dashboards/commuter.rs
@@ -344,58 +344,50 @@ impl State for CommuterPatterns {
             None => {}
         }
 
-        let block_selection = if let Some(pt) = ctx.canvas.get_cursor_in_map_space() {
-            if let Some(b) = self.blocks.iter().find(|b| b.shape.contains_pt(pt)) {
-                if app.per_obj.left_click(ctx, "clicked block") {
-                    match self.current_block.0 {
-                        BlockSelection::Locked { base: old_base, .. } => {
-                            if old_base == b.id {
-                                BlockSelection::Unlocked(b.id)
-                            } else {
-                                BlockSelection::Locked {
-                                    base: b.id,
-                                    compare_to: None,
-                                }
-                            }
-                        }
-                        _ => BlockSelection::Locked {
-                            base: b.id,
-                            compare_to: None,
-                        },
-                    }
-                } else {
-                    match self.current_block.0 {
-                        BlockSelection::Locked { base, .. } => {
-                            if base == b.id {
-                                BlockSelection::Locked {
-                                    base,
-                                    compare_to: None,
-                                }
-                            } else {
-                                BlockSelection::Locked {
-                                    base,
-                                    compare_to: Some(b.id),
-                                }
-                            }
-                        }
-                        BlockSelection::Unlocked(_) => BlockSelection::Unlocked(b.id),
-                        BlockSelection::NothingSelected => BlockSelection::Unlocked(b.id),
-                    }
-                }
-            } else {
-                // cursor not over any block
+        let block_selection = if let Some(Some(b)) = ctx
+            .canvas
+            .get_cursor_in_map_space()
+            .map(|pt| self.blocks.iter().find(|b| b.shape.contains_pt(pt)))
+        {
+            if app.per_obj.left_click(ctx, "clicked block") {
                 match self.current_block.0 {
-                    BlockSelection::NothingSelected | BlockSelection::Unlocked(_) => {
-                        BlockSelection::NothingSelected
+                    BlockSelection::Locked { base: old_base, .. } => {
+                        if old_base == b.id {
+                            BlockSelection::Unlocked(b.id)
+                        } else {
+                            BlockSelection::Locked {
+                                base: b.id,
+                                compare_to: None,
+                            }
+                        }
                     }
-                    BlockSelection::Locked { base, .. } => BlockSelection::Locked {
-                        base,
+                    _ => BlockSelection::Locked {
+                        base: b.id,
                         compare_to: None,
                     },
                 }
+            } else {
+                // Hovering over block
+                match self.current_block.0 {
+                    BlockSelection::Locked { base, .. } => {
+                        if base == b.id {
+                            BlockSelection::Locked {
+                                base,
+                                compare_to: None,
+                            }
+                        } else {
+                            BlockSelection::Locked {
+                                base,
+                                compare_to: Some(b.id),
+                            }
+                        }
+                    }
+                    BlockSelection::Unlocked(_) => BlockSelection::Unlocked(b.id),
+                    BlockSelection::NothingSelected => BlockSelection::Unlocked(b.id),
+                }
             }
         } else {
-            // cursor not in map space
+            // cursor not over any block
             match self.current_block.0 {
                 BlockSelection::NothingSelected | BlockSelection::Unlocked(_) => {
                     BlockSelection::NothingSelected


### PR DESCRIPTION
In commuter patterns, now that you can click-to-lock onto a particular region, it seems a little strange that nothing changed when you hovered over other blocks. Now, after clicking a block, we show the count of trips to/from the hovered region (based on current filters).

Overview showing first the existing hover behavior without locking, then after locking, the new "hover" behavior:

![output2](https://user-images.githubusercontent.com/217057/88352933-e39f5280-cd18-11ea-9c62-b3160ea09c81.gif)

<img width="1792" alt="Screen Shot 2020-07-23 at 7 14 55 PM" src="https://user-images.githubusercontent.com/217057/88352937-e8fc9d00-cd18-11ea-96d8-7d7af3ee366b.png">

Currently, I'm showing the label for zero counts too - it seems helpful. WDYT?

<img width="1792" alt="Screen Shot 2020-07-23 at 7 14 59 PM" src="https://user-images.githubusercontent.com/217057/88352936-e7cb7000-cd18-11ea-8345-dfb1bc29b6cf.png">

The number is hard to read over blocks with no traffic. I could add some kind of mask to the entire block under hover, but I thought it was useful to keep the original heatmap tone visible.

A couple options:
- We could just not show the label at all for blocks with a zero count, but I personally think it's helpful information.
- I could add some high contrast badge behind the label.
- We could use something other than yellow for 0 counts in the heatmap.

