### PR TITLE
 Commuter Patterns: Larger shapes for border intersections

### DIFF
--- a/game/src/sandbox/dashboards/commuter.rs
+++ b/game/src/sandbox/dashboards/commuter.rs
@@ -211,6 +211,15 @@ impl CommuterPatterns {
 
                 batch.push(Color::BLACK.alpha(0.5), base_block.shape.clone());
 
+                // Draw outline for Locked Selection
+                match block_selection {
+                    BlockSelection::Locked { .. } => {
+                        let outline = base_block.shape.to_outline(Distance::meters(10.0)).unwrap();
+                        batch.push(Color::BLACK, outline);
+                    }
+                    _ => {}
+                };
+
                 {
                     // Indicate direction over current block
                     let (icon_name, icon_scale) = if self.filter.from_block {
@@ -243,15 +252,6 @@ impl CommuterPatterns {
                         other.shape.clone(),
                     );
                 }
-
-                // Draw outline for Locked Selection
-                match block_selection {
-                    BlockSelection::Locked { .. } => {
-                        let outline = base_block.shape.to_outline(Distance::meters(10.0)).unwrap();
-                        batch.push(Color::BLACK, outline);
-                    }
-                    _ => {}
-                };
 
                 // While selection is locked, draw an overlay with compare_to information for the
                 // hovered block

--- a/game/src/sandbox/dashboards/commuter.rs
+++ b/game/src/sandbox/dashboards/commuter.rs
@@ -280,8 +280,10 @@ impl CommuterPatterns {
                             .centered_on(compare_to_block.shape.polylabel());
 
                         let dims = label.get_dims();
-                        let label_bg =  Polygon::rounded_rectangle(dims.width + 70.0, dims.height + 20.0, None);
-                        let bg = GeomBatch::from(vec![(Color::WHITE, label_bg)]).centered_on(compare_to_block.shape.polylabel());
+                        let label_bg =
+                            Polygon::rounded_rectangle(dims.width + 70.0, dims.height + 20.0, None);
+                        let bg = GeomBatch::from(vec![(Color::WHITE, label_bg)])
+                            .centered_on(compare_to_block.shape.polylabel());
                         batch.append(bg);
                         batch.append(label);
                     }
@@ -538,11 +540,7 @@ fn build_shape_for_border(
 ) -> Polygon {
     let start = border.polygon.center();
 
-    let road = match border_type {
-        BorderType::Incoming | BorderType::Both => map.get_parent(border.outgoing_lanes[0]),
-        BorderType::Outgoing => map.get_parent(border.incoming_lanes[0]),
-    };
-
+    let road = map.get_r(*border.roads.iter().next().unwrap());
     let center_line = road.get_current_center(map);
     let angle = if road.src_i == border.id {
         center_line.first_line().angle().opposite()
@@ -555,14 +553,13 @@ fn build_shape_for_border(
     let end = start.project_away(length, angle);
 
     match border_type {
-        BorderType::Incoming => PolyLine::new(vec![end, start])
-            .unwrap()
-            .make_arrow(thickness, geom::ArrowCap::Triangle),
-        BorderType::Outgoing => PolyLine::new(vec![start, end])
-            .unwrap()
-            .make_arrow(thickness, geom::ArrowCap::Triangle),
-        BorderType::Both => PolyLine::new(vec![start, end])
-            .unwrap()
+        BorderType::Incoming => {
+            PolyLine::must_new(vec![end, start]).make_arrow(thickness, geom::ArrowCap::Triangle)
+        }
+        BorderType::Outgoing => {
+            PolyLine::must_new(vec![start, end]).make_arrow(thickness, geom::ArrowCap::Triangle)
+        }
+        BorderType::Both => PolyLine::must_new(vec![start, end])
             .make_double_arrow(thickness, geom::ArrowCap::Triangle),
     }
 }


### PR DESCRIPTION
Fixes #215 

A substantial portion of traffic has an origin/destination off the map.
We were correctly tracking all this data, attributing it to a
"block" the size of the border "intersection"; However, the design
didn't accommodate the small "size" of the border intersections:

**before**

![image](https://user-images.githubusercontent.com/217057/88578439-ce227500-d005-11ea-9799-01804da39b4e.png)

1. it was too small to meaningfully reason about the heatmap visualization
2. it was too small of a "hit" area for clicking and hovering
3. when in the "locked" mode, the hover text overlay was illegible.

**after**

Now we draw a larger arrow, representing the inward/outward/both-ways
direction of traffic which makes it easier to reason about the heatmap
color and accommodates an adequate hit area.

And the hover text is now printed over a white pill to maintain
legibility.

<img width="1792" alt="Screen Shot 2020-07-27 at 12 16 55 PM" src="https://user-images.githubusercontent.com/217057/88578202-69671a80-d005-11ea-810a-f6bdf33d2417.png">

![demo mov](https://user-images.githubusercontent.com/217057/88578227-7257ec00-d005-11ea-87f5-43d0c3b3127f.gif)
