### PR TITLE
button height depends on particulars of text content

### DIFF
--- a/ezgui/src/text.rs
+++ b/ezgui/src/text.rs
@@ -333,6 +333,9 @@ impl Text {
             max_width = max_width.max(line_dims.width);
         }
 
+        let spaceholder = Polygon::rectangle(max_width, y);
+        output_batch.push(Color::BLACK.alpha(0.01), spaceholder);
+
         if let Some(c) = self.bg_color {
             output_batch.push(c, Polygon::rectangle(max_width, y));
         }

--- a/ezgui/src/text.rs
+++ b/ezgui/src/text.rs
@@ -257,40 +257,6 @@ impl Text {
         self.render(&ctx.prerender.assets)
     }
 
-    pub fn size(&self, ctx: &EventCtx) -> ScreenDims {
-        let assets = &ctx.prerender.assets;
-        let tolerance = svg::HIGH_QUALITY;
-        let mut master_batch = GeomBatch::new();
-
-        println!("rendering text had lines: {:?}", &self.lines);
-        let mut y = 0.0;
-        let mut max_width = 0.0_f64;
-        for (_, line) in self.lines.clone() {
-            // Assume size doesn't change mid-line. Always use this fixed line height per font
-            // size.
-            let line_height = assets.line_height(line[0].font, line[0].size);
-
-            let line_batch = render_line(line, tolerance, assets);
-            let line_dims = if line_batch.is_empty() {
-                ScreenDims::new(0.0, line_height)
-            } else {
-                // Also lie a little about width to make things look reasonable. TODO Probably
-                // should tune based on font size.
-                ScreenDims::new(line_batch.get_dims().width + 5.0, line_height)
-            };
-
-            y += line_dims.height;
-
-            // Add all of the padding at the bottom of the line.
-            let offset = line_height / SCALE_LINE_HEIGHT * 0.2;
-            master_batch.append(line_batch.translate(0.0, y - offset));
-
-            max_width = max_width.max(line_dims.width);
-        }
-
-        ScreenDims::new(max_width, y)
-    }
-
     pub(crate) fn inner_render(self, assets: &Assets, tolerance: f32) -> GeomBatch {
         let hash_key = self.hash_key();
         if let Some(batch) = assets.get_cached_text(&hash_key) {
@@ -300,7 +266,6 @@ impl Text {
         let mut output_batch = GeomBatch::new();
         let mut master_batch = GeomBatch::new();
 
-        println!("rendering text had lines: {:?}", &self.lines);
         let mut y = 0.0;
         let mut max_width = 0.0_f64;
         for (line_color, line) in self.lines {
@@ -342,7 +307,6 @@ impl Text {
         output_batch.append(master_batch);
         output_batch.autocrop_dims = false;
 
-        println!("rendering text had height: {}", y);
         assets.cache_text(hash_key, output_batch.clone());
         output_batch
     }

--- a/ezgui/src/text.rs
+++ b/ezgui/src/text.rs
@@ -334,7 +334,7 @@ impl Text {
         }
 
         let spaceholder = Polygon::rectangle(max_width, y);
-        output_batch.push(Color::BLACK.alpha(0.01), spaceholder);
+        output_batch.push(Color::BLACK.alpha(0.0), spaceholder);
 
         if let Some(c) = self.bg_color {
             output_batch.push(c, Polygon::rectangle(max_width, y));

--- a/ezgui/src/widgets/button.rs
+++ b/ezgui/src/widgets/button.rs
@@ -386,16 +386,13 @@ impl BtnBuilder {
                 maybe_tooltip,
                 unselected_bg_color,
                 selected_bg_color,
-                label,
                 ..
             } => {
                 const HORIZ_PADDING: f64 = 30.0;
                 const VERT_PADDING: f64 = 10.0;
 
-                // let dims = text.size(ctx);
                 let txt_batch = text.render_ctx(ctx);
                 let dims = txt_batch.get_dims();
-                println!("label: {}, dims: {:?}", label, dims);
                 let geom = Polygon::rounded_rectangle(
                     dims.width + 2.0 * HORIZ_PADDING,
                     dims.height + 2.0 * VERT_PADDING,

--- a/ezgui/src/widgets/button.rs
+++ b/ezgui/src/widgets/button.rs
@@ -386,13 +386,16 @@ impl BtnBuilder {
                 maybe_tooltip,
                 unselected_bg_color,
                 selected_bg_color,
+                label,
                 ..
             } => {
                 const HORIZ_PADDING: f64 = 30.0;
                 const VERT_PADDING: f64 = 10.0;
 
+                let dims = text.size(ctx);
                 let txt_batch = text.render_ctx(ctx);
-                let dims = txt_batch.get_dims();
+                // let dims = txt_batch.get_dims();
+                println!("label: {}, dims: {:?}", label, dims);
                 let geom = Polygon::rounded_rectangle(
                     dims.width + 2.0 * HORIZ_PADDING,
                     dims.height + 2.0 * VERT_PADDING,

--- a/ezgui/src/widgets/button.rs
+++ b/ezgui/src/widgets/button.rs
@@ -392,9 +392,9 @@ impl BtnBuilder {
                 const HORIZ_PADDING: f64 = 30.0;
                 const VERT_PADDING: f64 = 10.0;
 
-                let dims = text.size(ctx);
+                // let dims = text.size(ctx);
                 let txt_batch = text.render_ctx(ctx);
-                // let dims = txt_batch.get_dims();
+                let dims = txt_batch.get_dims();
                 println!("label: {}, dims: {:?}", label, dims);
                 let geom = Polygon::rounded_rectangle(
                     dims.width + 2.0 * HORIZ_PADDING,

--- a/game/src/pregame.rs
+++ b/game/src/pregame.rs
@@ -150,10 +150,17 @@ impl MainMenu {
             .centered(),
             Widget::col(vec![
                 Widget::row(vec![
-                    Btn::text_bg2("About").build_def(ctx, None),
-                    Btn::text_bg2("Feedback").build_def(ctx, None),
+                    Btn::text_bg2("AAA").build_def(ctx, None),
+                    Btn::text_bg2("aaa").build_def(ctx, None),
+                    Btn::text_bg2("yyy").build_def(ctx, None),
+                    Btn::text_bg2("fff").build_def(ctx, None),
                 ]),
-                built_info::time().draw(ctx),
+                //built_info::time().draw(ctx),
+                // MJK
+                Widget::row(vec![
+                            Text::from(Line("aaa")).bg(Color::RED).draw(ctx),
+                            Text::from(Line("yyy")).bg(Color::RED).draw(ctx)
+                ])
             ])
             .centered(),
         ];


### PR DESCRIPTION
I think we want a constant height for buttons with 1 line of text, but because we rely on the dimensions of the rendered polygons, the actual height of the text polygon depended on the particulars of the text.

e.g. "aaa" was shorter than "yyy" which has a hanging tail.

This PR is mostly an attempt to illustrate the problem more than it is a solution. 

**before**
<img width="1792" alt="Screen Shot 2020-07-27 at 4 56 07 PM" src="https://user-images.githubusercontent.com/217057/88600524-ac3be900-d02b-11ea-883f-b82fc500a359.png">

It's admittedly hard to see, it's just a few pixels, but it personally irks me. 
![image](https://user-images.githubusercontent.com/217057/88600727-397f3d80-d02c-11ea-93f4-772a4f1f78ce.png)

**after**
<img width="1792" alt="Screen Shot 2020-07-27 at 5 01 38 PM" src="https://user-images.githubusercontent.com/217057/88600522-aba35280-d02b-11ea-8f47-e1bdd64d4f3e.png">
