### PR TITLE
revert some switches back to checkboxes

### DIFF
--- a/ezgui/examples/demo.rs
+++ b/ezgui/examples/demo.rs
@@ -259,8 +259,8 @@ fn make_controls(ctx: &mut EventCtx) -> Composite {
             .named("paused"),
             Btn::text_fg("Reset timer").build(ctx, "reset the stopwatch", None),
             Btn::text_fg("New faces").build(ctx, "generate new faces", hotkey(Key::F)),
-            Checkbox::checkbox(ctx, "Draw scrollable canvas", None, true),
-            Checkbox::checkbox(ctx, "Show timeseries", lctrl(Key::T), false),
+            Checkbox::switch(ctx, "Draw scrollable canvas", None, true),
+            Checkbox::switch(ctx, "Show timeseries", lctrl(Key::T), false),
         ])
         .evenly_spaced(),
         "Stopwatch: ...".draw_text(ctx).named("stopwatch"),

--- a/ezgui/examples/demo.rs
+++ b/ezgui/examples/demo.rs
@@ -259,8 +259,8 @@ fn make_controls(ctx: &mut EventCtx) -> Composite {
             .named("paused"),
             Btn::text_fg("Reset timer").build(ctx, "reset the stopwatch", None),
             Btn::text_fg("New faces").build(ctx, "generate new faces", hotkey(Key::F)),
-            Checkbox::text(ctx, "Draw scrollable canvas", None, true),
-            Checkbox::text(ctx, "Show timeseries", lctrl(Key::T), false),
+            Checkbox::checkbox(ctx, "Draw scrollable canvas", None, true),
+            Checkbox::checkbox(ctx, "Show timeseries", lctrl(Key::T), false),
         ])
         .evenly_spaced(),
         "Stopwatch: ...".draw_text(ctx).named("stopwatch"),

--- a/ezgui/src/widgets/checkbox.rs
+++ b/ezgui/src/widgets/checkbox.rs
@@ -28,8 +28,7 @@ impl Checkbox {
         }
     }
 
-    // TODO Probably rename "toggle"
-    pub fn text<I: Into<String>>(
+    pub fn switch<I: Into<String>>(
         ctx: &EventCtx,
         label: I,
         hotkey: Option<MultiKey>,
@@ -71,7 +70,23 @@ impl Checkbox {
         .named(label)
     }
 
-    pub fn custom_text<I: Into<String>>(
+    pub fn checkbox<I: Into<String>>(
+        ctx: &EventCtx,
+        label: I,
+        hotkey: Option<MultiKey>,
+        enabled: bool,
+    ) -> Widget {
+        let label = label.into();
+        Checkbox::new(
+            enabled,
+            Btn::text_fg(format!("[ ] {}", label)).build(ctx, &label, hotkey.clone()),
+            Btn::text_fg(format!("[X] {}", label)).build(ctx, &label, hotkey),
+        )
+        .outline(ctx.style().outline_thickness, ctx.style().outline_color)
+        .named(label)
+    }
+
+     pub fn custom_checkbox<I: Into<String>>(
         ctx: &EventCtx,
         label: I,
         spans: Vec<TextSpan>,

--- a/game/src/common/heatmap.rs
+++ b/game/src/common/heatmap.rs
@@ -52,8 +52,8 @@ impl HeatmapOptions {
                     .named("radius")
                     .align_right(),
             ]),
-            Checkbox::text(ctx, "smoothing", None, self.smoothing),
-            Checkbox::text(ctx, "contours", None, self.contours),
+            Checkbox::switch(ctx, "smoothing", None, self.smoothing),
+            Checkbox::switch(ctx, "contours", None, self.contours),
             Widget::row(vec![
                 "Color scheme".draw_text(ctx).centered_vert(),
                 Widget::dropdown(

--- a/game/src/debug/mod.rs
+++ b/game/src/debug/mod.rs
@@ -43,12 +43,12 @@ impl DebugMode {
                         .align_right(),
                 ]),
                 Text::new().draw(ctx).named("current info"),
-                Checkbox::text(ctx, "show buildings", hotkey(Key::Num1), true),
-                Checkbox::text(ctx, "show intersections", hotkey(Key::Num2), true),
-                Checkbox::text(ctx, "show lanes", hotkey(Key::Num3), true),
-                Checkbox::text(ctx, "show areas", hotkey(Key::Num4), true),
-                Checkbox::text(ctx, "show labels", hotkey(Key::Num5), false),
-                Checkbox::text(ctx, "show route for all agents", hotkey(Key::R), false),
+                Checkbox::switch(ctx, "show buildings", hotkey(Key::Num1), true),
+                Checkbox::switch(ctx, "show intersections", hotkey(Key::Num2), true),
+                Checkbox::switch(ctx, "show lanes", hotkey(Key::Num3), true),
+                Checkbox::switch(ctx, "show areas", hotkey(Key::Num4), true),
+                Checkbox::switch(ctx, "show labels", hotkey(Key::Num5), false),
+                Checkbox::switch(ctx, "show route for all agents", hotkey(Key::R), false),
                 Widget::col(
                     vec![
                         (lctrl(Key::H), "unhide everything"),

--- a/game/src/devtools/destinations.rs
+++ b/game/src/devtools/destinations.rs
@@ -98,7 +98,7 @@ impl PopularDestinations {
                         .build(ctx, "close", hotkey(Key::Escape))
                         .align_right(),
                 ]),
-                Checkbox::text(ctx, "Show heatmap", None, opts.is_some()),
+                Checkbox::switch(ctx, "Show heatmap", None, opts.is_some()),
                 controls,
                 breakdown.draw(ctx),
             ]))

--- a/game/src/devtools/mapping.rs
+++ b/game/src/devtools/mapping.rs
@@ -175,7 +175,7 @@ impl ParkingMapper {
                         },
                     ),
                 ]),
-                Checkbox::text(ctx, "max 3 days parking (default in Seattle)", None, false),
+                Checkbox::checkbox(ctx, "max 3 days parking (default in Seattle)", None, false),
                 Btn::text_fg("Generate OsmChange file").build_def(ctx, None),
                 "Select a road".draw_text(ctx).named("info"),
             ]))

--- a/game/src/info/mod.rs
+++ b/game/src/info/mod.rs
@@ -712,7 +712,7 @@ impl DataOptions {
             return Widget::nothing();
         }
         Widget::row(vec![
-            Checkbox::custom_text(
+            Checkbox::custom_checkbox(
                 ctx,
                 "Show before changes",
                 vec![
@@ -723,7 +723,7 @@ impl DataOptions {
                 self.show_before,
             ),
             if self.show_before {
-                Checkbox::text(ctx, "Show full day", None, self.show_end_of_day)
+                Checkbox::switch(ctx, "Show full day", None, self.show_end_of_day)
             } else {
                 Widget::nothing()
             },

--- a/game/src/layer/pandemic.rs
+++ b/game/src/layer/pandemic.rs
@@ -231,7 +231,6 @@ fn make_controls(
         ]),
     ];
 
-    // MJK: how to show this UI?
     col.push(Checkbox::switch(
         ctx,
         "Show heatmap",

--- a/game/src/layer/pandemic.rs
+++ b/game/src/layer/pandemic.rs
@@ -231,7 +231,8 @@ fn make_controls(
         ]),
     ];
 
-    col.push(Checkbox::text(
+    // MJK: how to show this UI?
+    col.push(Checkbox::switch(
         ctx,
         "Show heatmap",
         None,

--- a/game/src/layer/parking.rs
+++ b/game/src/layer/parking.rs
@@ -208,13 +208,13 @@ impl Occupancy {
             ])
             .draw(ctx),
             Widget::row(vec![
-                Checkbox::text(ctx, "On-street spots", None, onstreet),
-                Checkbox::text(ctx, "Parking lots", None, lots),
+                Checkbox::switch(ctx, "On-street spots", None, onstreet),
+                Checkbox::switch(ctx, "Parking lots", None, lots),
             ])
             .evenly_spaced(),
             Widget::row(vec![
-                Checkbox::text(ctx, "Public garages", None, garages),
-                Checkbox::text(ctx, "Private buildings", None, private_bldgs),
+                Checkbox::switch(ctx, "Public garages", None, garages),
+                Checkbox::switch(ctx, "Private buildings", None, private_bldgs),
             ])
             .evenly_spaced(),
             ColorLegend::gradient(ctx, &app.cs.good_to_bad_red, vec!["0%", "100%"]),

--- a/game/src/layer/population.rs
+++ b/game/src/layer/population.rs
@@ -167,7 +167,7 @@ fn make_controls(
         .centered(),
     ];
 
-    col.push(Checkbox::text(
+    col.push(Checkbox::switch(
         ctx,
         "Show heatmap",
         None,

--- a/game/src/layer/traffic.rs
+++ b/game/src/layer/traffic.rs
@@ -175,7 +175,7 @@ impl Throughput {
                 .wrap_to_pct(ctx, 15)
                 .draw(ctx),
             if app.has_prebaked().is_some() {
-                Checkbox::text(ctx, "Compare before edits", None, false)
+                Checkbox::switch(ctx, "Compare before edits", None, false)
             } else {
                 Widget::nothing()
             },
@@ -266,7 +266,7 @@ impl Throughput {
                     .build(ctx, "close", hotkey(Key::Escape))
                     .align_right(),
             ]),
-            Checkbox::text(ctx, "Compare before edits", None, true),
+            Checkbox::switch(ctx, "Compare before edits", None, true),
             scale.make_legend(ctx, vec!["less traffic", "same", "more"]),
         ]))
         .aligned(HorizontalAlignment::Right, VerticalAlignment::Center)
@@ -378,7 +378,7 @@ impl Delay {
                     .align_right(),
             ]),
             if app.has_prebaked().is_some() {
-                Checkbox::text(ctx, "Compare before edits", None, false)
+                Checkbox::switch(ctx, "Compare before edits", None, false)
             } else {
                 Widget::nothing()
             },
@@ -430,7 +430,7 @@ impl Delay {
                     .build(ctx, "close", hotkey(Key::Escape))
                     .align_right(),
             ]),
-            Checkbox::text(ctx, "Compare before edits", None, true),
+            Checkbox::switch(ctx, "Compare before edits", None, true),
             ColorLegend::gradient(
                 ctx,
                 &ColorScale(vec![green, Color::WHITE, red]),

--- a/game/src/layer/transit.rs
+++ b/game/src/layer/transit.rs
@@ -130,9 +130,9 @@ impl TransitNetwork {
                     .build(ctx, "close", hotkey(Key::Escape))
                     .align_right(),
             ]),
-            Checkbox::text(ctx, "show all routes", None, show_all_routes),
-            Checkbox::text(ctx, "show buses", None, show_buses),
-            Checkbox::text(ctx, "show trains", None, show_trains),
+            Checkbox::switch(ctx, "show all routes", None, show_all_routes),
+            Checkbox::switch(ctx, "show buses", None, show_buses),
+            Checkbox::switch(ctx, "show trains", None, show_trains),
             legend,
         ]))
         .aligned(HorizontalAlignment::Right, VerticalAlignment::Center)

--- a/game/src/options.rs
+++ b/game/src/options.rs
@@ -68,26 +68,26 @@ impl OptionsPanel {
                 ]),
                 "Camera controls".draw_text(ctx),
                 Widget::col(vec![
-                    Checkbox::text(
+                    Checkbox::checkbox(
                         ctx,
                         "Invert direction of vertical scrolling",
                         None,
                         ctx.canvas.invert_scroll,
                     ),
-                    Checkbox::text(
+                    Checkbox::checkbox(
                         ctx,
                         "Pan map when cursor is at edge of screen",
                         None,
                         ctx.canvas.edge_auto_panning,
                     )
                     .named("autopan"),
-                    Checkbox::text(
+                    Checkbox::checkbox(
                         ctx,
                         "Use touchpad to pan and hold Control to zoom",
                         None,
                         ctx.canvas.touchpad_to_move,
                     ),
-                    Checkbox::text(
+                    Checkbox::checkbox(
                         ctx,
                         "Use arrow keys to pan and Q/W to zoom",
                         None,
@@ -103,7 +103,7 @@ impl OptionsPanel {
                 .padding(8),
                 "Appearance".draw_text(ctx),
                 Widget::col(vec![
-                    Checkbox::text(ctx, "Draw road names", None, app.opts.label_roads),
+                    Checkbox::checkbox(ctx, "Draw road names", None, app.opts.label_roads),
                     Widget::row(vec![
                         "Traffic signal rendering:".draw_text(ctx),
                         Widget::dropdown(
@@ -181,7 +181,7 @@ impl OptionsPanel {
                             ],
                         ),
                     ]),
-                    Checkbox::text(
+                    Checkbox::checkbox(
                         ctx,
                         "Draw enlarged unzoomed agents",
                         None,
@@ -192,8 +192,8 @@ impl OptionsPanel {
                 .padding(8),
                 "Debug".draw_text(ctx),
                 Widget::col(vec![
-                    Checkbox::text(ctx, "Enable developer mode", None, app.opts.dev),
-                    Checkbox::text(
+                    Checkbox::checkbox(ctx, "Enable developer mode", None, app.opts.dev),
+                    Checkbox::checkbox(
                         ctx,
                         "Draw all agents to debug geometry (Slow!)",
                         None,

--- a/game/src/sandbox/dashboards/commuter.rs
+++ b/game/src/sandbox/dashboards/commuter.rs
@@ -701,7 +701,7 @@ fn make_panel(ctx: &mut EventCtx, app: &App) -> Composite {
             hotkey(Key::Space),
             true,
         ),
-        Checkbox::text(ctx, "include borders", None, true),
+        Checkbox::switch(ctx, "include borders", None, true),
         Widget::row(vec![
             "Departing from:".draw_text(ctx).margin_right(20),
             AreaSlider::new(ctx, 0.15 * ctx.canvas.window_width, 0.0).named("depart from"),

--- a/game/src/sandbox/dashboards/parking_overhead.rs
+++ b/game/src/sandbox/dashboards/parking_overhead.rs
@@ -299,8 +299,8 @@ fn make(ctx: &mut EventCtx, app: &App, opts: &Options) -> Composite {
         .evenly_spaced(),
     );
     col.push(Widget::row(vec![
-        Checkbox::text(ctx, "starting off-map", None, opts.off_map_starts),
-        Checkbox::text(ctx, "ending off-map", None, opts.off_map_ends),
+        Checkbox::switch(ctx, "starting off-map", None, opts.off_map_starts),
+        Checkbox::switch(ctx, "ending off-map", None, opts.off_map_ends),
     ]));
     col.push(Widget::row(vec![
         if opts.skip > 0 {

--- a/game/src/sandbox/dashboards/trip_table.rs
+++ b/game/src/sandbox/dashboards/trip_table.rs
@@ -357,10 +357,10 @@ fn make(ctx: &mut EventCtx, app: &App, opts: &Options) -> Composite {
     let mut col = vec![DashTab::TripTable.picker(ctx, app)];
     col.push(checkbox_per_mode(ctx, app, &opts.modes));
     col.push(Widget::row(vec![
-        Checkbox::text(ctx, "starting off-map", None, opts.off_map_starts),
-        Checkbox::text(ctx, "ending off-map", None, opts.off_map_ends),
+        Checkbox::switch(ctx, "starting off-map", None, opts.off_map_starts),
+        Checkbox::switch(ctx, "ending off-map", None, opts.off_map_ends),
         if app.primary.has_modified_trips {
-            Checkbox::text(
+            Checkbox::switch(
                 ctx,
                 "trips unmodified by experiment",
                 None,
@@ -370,7 +370,7 @@ fn make(ctx: &mut EventCtx, app: &App, opts: &Options) -> Composite {
             Widget::nothing()
         },
         if app.primary.has_modified_trips {
-            Checkbox::text(
+            Checkbox::switch(
                 ctx,
                 "trips modified by experiment",
                 None,

--- a/game/src/sandbox/speed.rs
+++ b/game/src/sandbox/speed.rs
@@ -398,7 +398,7 @@ impl JumpToTime {
                 Btn::text_bg2("Jump to the next delay over 5 minutes")
                     .build_def(ctx, None)
                     .centered_horiz(),
-                Checkbox::text(
+                Checkbox::checkbox(
                     ctx,
                     "don't draw (for faster simulations)",
                     None,


### PR DESCRIPTION
partial revert of 90bb4ac0

In many ways switches and checkboxes seem interchangeable, but in certain
contexts one may be more appropriate.

For an overview that I mostly agree with:
https://uxplanet.org/checkbox-vs-toggle-switch-7fc6e83f10b8

**before**
<img width="1792" alt="Screen Shot 2020-07-28 at 1 48 47 PM" src="https://user-images.githubusercontent.com/217057/88713986-60e01400-d0d9-11ea-93d7-457f716bb512.png">

**after**
<img width="1792" alt="Screen Shot 2020-07-28 at 1 49 30 PM" src="https://user-images.githubusercontent.com/217057/88713961-56be1580-d0d9-11ea-8d75-2229574ce6f3.png">

Most things continue to use switches - especially those which produce instance feedback without a "submit" step.

<img width="399" alt="Screen Shot 2020-07-28 at 1 50 26 PM" src="https://user-images.githubusercontent.com/217057/88713955-54f45200-d0d9-11ea-9565-7871cd89891d.png">

However, I feel like the switch labels are too large. That didn't change with this PR, but would you be interested in a followup PR which makes the switch text size comparable to what you see on the checkboxes?
