### PR TITLE
Do all UI programming in logical pixels - scaling is all in backend

### DIFF
--- a/ezgui/examples/demo.rs
+++ b/ezgui/examples/demo.rs
@@ -213,7 +213,7 @@ fn setup_scrollable_canvas(ctx: &mut EventCtx) -> Drawable {
     );
     // SVG support using lyon and usvg. Map-space means don't scale for high DPI monitors.
     batch.append(
-        GeomBatch::mapspace_svg(&ctx.prerender, "system/assets/pregame/logo.svg")
+        GeomBatch::load_svg(&ctx.prerender, "system/assets/pregame/logo.svg")
             .translate(300.0, 300.0),
     );
     // Text rendering also goes through lyon and usvg.

--- a/ezgui/src/backend_glium.rs
+++ b/ezgui/src/backend_glium.rs
@@ -158,7 +158,7 @@ impl<'a> GfxCtxInnards<'a> {
         });
     }
 
-    pub fn disable_clipping(&mut self, _: &Canvas) {
+    pub fn disable_clipping(&mut self, _scale_factor: f64, _: &Canvas) {
         assert!(self.params.scissor.is_some());
         self.params.scissor = None;
     }
@@ -277,7 +277,7 @@ impl PrerenderInnards {
         }
     }
 
-    pub fn window_resized(&self, _new_size: ScreenDims) {}
+    pub fn window_resized(&self, _new_size: ScreenDims, _scale_factor: f64) {}
 
     pub fn window_size(&self, scale_factor: f64) -> ScreenDims {
         self.display

--- a/ezgui/src/backend_glow.rs
+++ b/ezgui/src/backend_glow.rs
@@ -312,14 +312,15 @@ impl PrerenderInnards {
         }
     }
 
-    pub fn window_resized(&self, width: f64, height: f64) {
-        self.windowed_context
-            .resize(winit::dpi::PhysicalSize::new(width as u32, height as u32));
-        unsafe {
-            self.gl.viewport(0, 0, width as i32, height as i32);
-            // I think it's safe to assume there's not a clip right now.
-            self.gl.scissor(0, 0, width as i32, height as i32);
-        }
+    pub fn window_resized(&self, new_size: ScreenDims) {
+        todo!("DPI TODO: support other backends");
+        //self.windowed_context
+        //    .resize(winit::dpi::PhysicalSize::new(width as u32, height as u32));
+        //unsafe {
+        //    self.gl.viewport(0, 0, width as i32, height as i32);
+        //    // I think it's safe to assume there's not a clip right now.
+        //    self.gl.scissor(0, 0, width as i32, height as i32);
+        //}
     }
 
     pub fn get_inner_size(&self) -> (f64, f64) {

--- a/ezgui/src/backend_wasm.rs
+++ b/ezgui/src/backend_wasm.rs
@@ -316,12 +316,13 @@ impl PrerenderInnards {
         }
     }
 
-    pub fn window_resized(&self, width: f64, height: f64) {
-        unsafe {
-            self.gl.viewport(0, 0, width as i32, height as i32);
-            // I think it's safe to assume there's not a clip right now.
-            self.gl.scissor(0, 0, width as i32, height as i32);
-        }
+    pub fn window_resized(&self, new_size: ScreenDims) {
+        todo!("DPI TODO: support other backends");
+        //unsafe {
+        //    self.gl.viewport(0, 0, width as i32, height as i32);
+        //    // I think it's safe to assume there's not a clip right now.
+        //    self.gl.scissor(0, 0, width as i32, height as i32);
+        //}
     }
 
     pub fn get_inner_size(&self) -> (f64, f64) {

--- a/ezgui/src/backend_wasm.rs
+++ b/ezgui/src/backend_wasm.rs
@@ -21,12 +21,10 @@ pub fn setup(window_title: &str) -> (PrerenderInnards, winit::event_loop::EventL
         let win = stdweb::web::window();
         // `inner_width` corresponds to the browser's `self.innerWidth` function, which are in
         // Logical, not Physical, pixels
-        let size = winit::dpi::LogicalSize::new(
+        winit::dpi::LogicalSize::new(
             win.inner_width() - scrollbars,
             win.inner_height() - scrollbars,
-        );
-        stdweb::console!(log, format!("initial size: {:?}, win.inner_width: {:?}", size, win.inner_width()));
-        size
+        )
     };
     let window = winit::window::WindowBuilder::new()
         .with_title(window_title)
@@ -330,10 +328,7 @@ impl PrerenderInnards {
     }
 
     pub fn window_size(&self, scale_factor: f64) -> ScreenDims {
-        let inner_size = self.window.inner_size();
-        let logical_size = inner_size.to_logical(scale_factor);
-        stdweb::console!(log, format!("window.inner_size: {:?}, scale_factor: {}, logical_size: {:?}", inner_size, scale_factor, logical_size));
-        logical_size.into()
+        self.window.inner_size().to_logical(scale_factor).into()
     }
 
     pub fn set_window_icon(&self, icon: winit::window::Icon) {

--- a/ezgui/src/backend_wasm.rs
+++ b/ezgui/src/backend_wasm.rs
@@ -21,10 +21,12 @@ pub fn setup(window_title: &str) -> (PrerenderInnards, winit::event_loop::EventL
         let win = stdweb::web::window();
         // `inner_width` corresponds to the browser's `self.innerWidth` function, which are in
         // Logical, not Physical, pixels
-        winit::dpi::LogicalSize::new(
+        let size = winit::dpi::LogicalSize::new(
             win.inner_width() - scrollbars,
             win.inner_height() - scrollbars,
-        )
+        );
+        stdweb::console!(log, format!("initial size: {:?}, win.inner_width: {:?}", size, win.inner_width()));
+        size
     };
     let window = winit::window::WindowBuilder::new()
         .with_title(window_title)
@@ -328,7 +330,10 @@ impl PrerenderInnards {
     }
 
     pub fn window_size(&self, scale_factor: f64) -> ScreenDims {
-        self.window.inner_size().to_logical(scale_factor).into()
+        let inner_size = self.window.inner_size();
+        let logical_size = inner_size.to_logical(scale_factor);
+        stdweb::console!(log, format!("window.inner_size: {:?}, scale_factor: {}, logical_size: {:?}", inner_size, scale_factor, logical_size));
+        logical_size.into()
     }
 
     pub fn set_window_icon(&self, icon: winit::window::Icon) {

--- a/ezgui/src/canvas.rs
+++ b/ezgui/src/canvas.rs
@@ -49,6 +49,7 @@ pub struct Canvas {
 
 impl Canvas {
     pub(crate) fn new(initial_dims: ScreenDims) -> Canvas {
+        stdweb::console!(log, format!("[Canvas#new] initial_dims: {:?}", initial_dims));
         Canvas {
             cam_x: 0.0,
             cam_y: 0.0,

--- a/ezgui/src/canvas.rs
+++ b/ezgui/src/canvas.rs
@@ -49,7 +49,6 @@ pub struct Canvas {
 
 impl Canvas {
     pub(crate) fn new(initial_dims: ScreenDims) -> Canvas {
-        stdweb::console!(log, format!("[Canvas#new] initial_dims: {:?}", initial_dims));
         Canvas {
             cam_x: 0.0,
             cam_y: 0.0,

--- a/ezgui/src/canvas.rs
+++ b/ezgui/src/canvas.rs
@@ -1,4 +1,3 @@
-use crate::assets::Assets;
 use crate::{Key, ScreenDims, ScreenPt, ScreenRectangle, UpdateType, UserInput};
 use abstutil::Timer;
 use geom::{Bounds, Pt2D};
@@ -49,7 +48,7 @@ pub struct Canvas {
 }
 
 impl Canvas {
-    pub(crate) fn new(initial_width: f64, initial_height: f64) -> Canvas {
+    pub(crate) fn new(initial_dims: ScreenDims) -> Canvas {
         Canvas {
             cam_x: 0.0,
             cam_y: 0.0,
@@ -62,8 +61,8 @@ impl Canvas {
             drag_canvas_from: None,
             drag_just_ended: false,
 
-            window_width: initial_width,
-            window_height: initial_height,
+            window_width: initial_dims.width,
+            window_height: initial_dims.height,
 
             map_dims: (0.0, 0.0),
             invert_scroll: false,
@@ -265,6 +264,10 @@ impl Canvas {
         b
     }
 
+    pub fn get_window_dims(&self) -> ScreenDims {
+        ScreenDims::new(self.window_width, self.window_height)
+    }
+
     fn get_map_bounds(&self) -> Bounds {
         let mut b = Bounds::new();
         b.update(Pt2D::new(0.0, 0.0));
@@ -306,7 +309,6 @@ impl Canvas {
 
     pub(crate) fn align_window(
         &self,
-        assets: &Assets,
         dims: ScreenDims,
         horiz: HorizontalAlignment,
         vert: VerticalAlignment,
@@ -323,9 +325,7 @@ impl Canvas {
             VerticalAlignment::Center => (self.window_height - dims.height) / 2.0,
             VerticalAlignment::Bottom => self.window_height - dims.height,
             // TODO Hack
-            VerticalAlignment::BottomAboveOSD => {
-                self.window_height - dims.height - 60.0 * *assets.scale_factor.borrow()
-            }
+            VerticalAlignment::BottomAboveOSD => self.window_height - dims.height - 60.0,
             VerticalAlignment::Percent(pct) => pct * self.window_height,
             VerticalAlignment::Above(y) => y - dims.height,
             VerticalAlignment::Below(y) => y,

--- a/ezgui/src/drawing.rs
+++ b/ezgui/src/drawing.rs
@@ -229,7 +229,7 @@ pub struct Prerender {
     pub(crate) inner: PrerenderInnards,
     pub(crate) assets: Assets,
     pub(crate) num_uploads: Cell<usize>,
-    pub scale_factor: RefCell<f64>,
+    pub(crate) scale_factor: RefCell<f64>,
 }
 
 impl Prerender {
@@ -255,19 +255,15 @@ impl Prerender {
         self.inner.request_redraw()
     }
 
-    pub fn get_scale_factor(&self) -> f64 {
+    pub(crate) fn get_scale_factor(&self) -> f64 {
         *self.scale_factor.borrow()
     }
 
-    pub fn set_scale_factor(&self, scale_factor: f64) {
-        *self.scale_factor.borrow_mut() = scale_factor;
-    }
-
-    pub fn window_size(&self) -> ScreenDims {
+    pub(crate) fn window_size(&self) -> ScreenDims {
         self.inner.window_size(self.get_scale_factor())
     }
 
-    pub fn window_resized(&self, new_size: ScreenDims) {
+    pub(crate) fn window_resized(&self, new_size: ScreenDims) {
         self.inner.window_resized(new_size, self.get_scale_factor())
     }
 }

--- a/ezgui/src/drawing.rs
+++ b/ezgui/src/drawing.rs
@@ -256,9 +256,7 @@ impl Prerender {
     }
 
     pub fn get_scale_factor(&self) -> f64 {
-        let scale_factor = *self.scale_factor.borrow();
-        //stdweb::console!(log, format!("monitor_scale_factor: {:?}, scale_factor: {:?}", self.inner.monitor_scale_factor(), scale_factor));
-        scale_factor
+        *self.scale_factor.borrow()
     }
 
     pub fn set_scale_factor(&self, scale_factor: f64) {

--- a/ezgui/src/drawing.rs
+++ b/ezgui/src/drawing.rs
@@ -141,7 +141,8 @@ impl<'a> GfxCtx<'a> {
     }
 
     pub fn disable_clipping(&mut self) {
-        self.inner.disable_clipping(self.canvas);
+        let scale_factor = self.prerender.get_scale_factor();
+        self.inner.disable_clipping(scale_factor, self.canvas);
     }
 
     // Canvas stuff.
@@ -264,5 +265,9 @@ impl Prerender {
 
     pub fn window_size(&self) -> ScreenDims {
         self.inner.window_size(self.get_scale_factor())
+    }
+
+    pub fn window_resized(&self, new_size: ScreenDims) {
+        self.inner.window_resized(new_size, self.get_scale_factor())
     }
 }

--- a/ezgui/src/drawing.rs
+++ b/ezgui/src/drawing.rs
@@ -256,7 +256,9 @@ impl Prerender {
     }
 
     pub fn get_scale_factor(&self) -> f64 {
-        *self.scale_factor.borrow()
+        let scale_factor = *self.scale_factor.borrow();
+        //stdweb::console!(log, format!("monitor_scale_factor: {:?}, scale_factor: {:?}", self.inner.monitor_scale_factor(), scale_factor));
+        scale_factor
     }
 
     pub fn set_scale_factor(&self, scale_factor: f64) {

--- a/ezgui/src/drawing.rs
+++ b/ezgui/src/drawing.rs
@@ -4,7 +4,7 @@ use crate::{
     Canvas, Color, Drawable, GeomBatch, ScreenDims, ScreenPt, ScreenRectangle, Style, Text,
 };
 use geom::{Bounds, Polygon, Pt2D};
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 
 // Lower is more on top
 const MAPSPACE_Z: f32 = 1.0;
@@ -136,7 +136,8 @@ impl<'a> GfxCtx<'a> {
 
     // TODO Stateful API :(
     pub fn enable_clipping(&mut self, rect: ScreenRectangle) {
-        self.inner.enable_clipping(rect, self.canvas);
+        let scale_factor = self.prerender.get_scale_factor();
+        self.inner.enable_clipping(rect, scale_factor, self.canvas);
     }
 
     pub fn disable_clipping(&mut self) {
@@ -227,6 +228,7 @@ pub struct Prerender {
     pub(crate) inner: PrerenderInnards,
     pub(crate) assets: Assets,
     pub(crate) num_uploads: Cell<usize>,
+    pub scale_factor: RefCell<f64>,
 }
 
 impl Prerender {
@@ -250,5 +252,17 @@ impl Prerender {
 
     pub(crate) fn request_redraw(&self) {
         self.inner.request_redraw()
+    }
+
+    pub fn get_scale_factor(&self) -> f64 {
+        *self.scale_factor.borrow()
+    }
+
+    pub fn set_scale_factor(&self, scale_factor: f64) {
+        *self.scale_factor.borrow_mut() = scale_factor;
+    }
+
+    pub fn window_size(&self) -> ScreenDims {
+        self.inner.window_size(self.get_scale_factor())
     }
 }

--- a/ezgui/src/event.rs
+++ b/ezgui/src/event.rs
@@ -48,7 +48,11 @@ impl Event {
                 }
             }
             WindowEvent::CursorMoved { position, .. } => Some(Event::MouseMovedTo(
-                position.to_logical(scale_factor).into(),
+                    {
+                        let position = position.to_logical(scale_factor).into();
+                        //stdweb::console!(log, format!("cursor moved: {:?}", position));
+                        position
+                    }
             )),
             WindowEvent::MouseWheel { delta, .. } => match delta {
                 MouseScrollDelta::LineDelta(dx, dy) => {

--- a/ezgui/src/event.rs
+++ b/ezgui/src/event.rs
@@ -1,4 +1,4 @@
-use crate::ScreenPt;
+use crate::{ScreenDims, ScreenPt};
 use geom::Duration;
 use winit::event::{
     ElementState, KeyboardInput, MouseButton, MouseScrollDelta, VirtualKeyCode, WindowEvent,
@@ -23,11 +23,11 @@ pub enum Event {
     WindowLostCursor,
     WindowGainedCursor,
     MouseWheelScroll(f64, f64),
-    WindowResized(f64, f64),
+    WindowResized(ScreenDims),
 }
 
 impl Event {
-    pub fn from_winit_event(ev: WindowEvent) -> Option<Event> {
+    pub fn from_winit_event(ev: WindowEvent, scale_factor: f64) -> Option<Event> {
         match ev {
             WindowEvent::MouseInput { state, button, .. } => match (button, state) {
                 (MouseButton::Left, ElementState::Pressed) => Some(Event::LeftMouseButtonDown),
@@ -47,9 +47,9 @@ impl Event {
                     None
                 }
             }
-            WindowEvent::CursorMoved { position, .. } => {
-                Some(Event::MouseMovedTo(ScreenPt::new(position.x, position.y)))
-            }
+            WindowEvent::CursorMoved { position, .. } => Some(Event::MouseMovedTo(
+                position.to_logical(scale_factor).into(),
+            )),
             WindowEvent::MouseWheel { delta, .. } => match delta {
                 MouseScrollDelta::LineDelta(dx, dy) => {
                     if dx == 0.0 && dy == 0.0 {
@@ -72,7 +72,7 @@ impl Event {
                 }
             },
             WindowEvent::Resized(size) => {
-                Some(Event::WindowResized(size.width.into(), size.height.into()))
+                Some(Event::WindowResized(size.to_logical(scale_factor).into()))
             }
             WindowEvent::Focused(gained) => Some(if gained {
                 Event::WindowGainedCursor

--- a/ezgui/src/event.rs
+++ b/ezgui/src/event.rs
@@ -48,11 +48,7 @@ impl Event {
                 }
             }
             WindowEvent::CursorMoved { position, .. } => Some(Event::MouseMovedTo(
-                    {
-                        let position = position.to_logical(scale_factor).into();
-                        //stdweb::console!(log, format!("cursor moved: {:?}", position));
-                        position
-                    }
+                position.to_logical(scale_factor).into(),
             )),
             WindowEvent::MouseWheel { delta, .. } => match delta {
                 MouseScrollDelta::LineDelta(dx, dy) => {

--- a/ezgui/src/event_ctx.rs
+++ b/ezgui/src/event_ctx.rs
@@ -1,6 +1,6 @@
 use crate::{
-    svg, text, Canvas, Color, Drawable, Event, GeomBatch, GfxCtx, Line, Prerender, ScreenPt, Style,
-    Text, UserInput,
+    svg, text, Canvas, Color, Drawable, Event, GeomBatch, GfxCtx, Line, Prerender, ScreenDims,
+    ScreenPt, Style, Text, UserInput,
 };
 use abstutil::{elapsed_seconds, Timer, TimerSink};
 use geom::Polygon;
@@ -41,8 +41,7 @@ impl<'a> EventCtx<'a> {
             &timer_name,
             Box::new(LoadingScreen::new(
                 self.prerender,
-                self.canvas.window_width,
-                self.canvas.window_height,
+                self.canvas.get_window_dims(),
                 timer_name.clone(),
             )),
         );
@@ -113,18 +112,6 @@ impl<'a> EventCtx<'a> {
         self.prerender.upload(batch)
     }
 
-    pub fn set_scale_factor(&self, scale: f64) {
-        self.prerender.assets.set_scale_factor(scale)
-    }
-
-    pub fn get_scale_factor(&self) -> f64 {
-        *self.prerender.assets.scale_factor.borrow()
-    }
-
-    pub fn monitor_scale_factor(&self) -> f64 {
-        self.prerender.inner.monitor_scale_factor()
-    }
-
     pub(crate) fn cursor_clickable(&mut self) {
         self.prerender
             .inner
@@ -153,13 +140,12 @@ pub struct LoadingScreen<'a> {
 impl<'a> LoadingScreen<'a> {
     pub fn new(
         prerender: &'a Prerender,
-        initial_width: f64,
-        initial_height: f64,
+        initial_size: ScreenDims,
         title: String,
     ) -> LoadingScreen<'a> {
-        let canvas = Canvas::new(initial_width, initial_height);
+        let canvas = Canvas::new(initial_size);
         let max_capacity =
-            (0.8 * initial_height / *prerender.assets.default_line_height.borrow()) as usize;
+            (0.8 * initial_size.height / *prerender.assets.default_line_height.borrow()) as usize;
         LoadingScreen {
             prerender,
             lines: VecDeque::new(),

--- a/ezgui/src/geom.rs
+++ b/ezgui/src/geom.rs
@@ -142,13 +142,8 @@ impl GeomBatch {
     }
 
     /// Returns a batch containing an SVG from a file.
-    pub fn mapspace_svg(prerender: &Prerender, filename: &str) -> GeomBatch {
+    pub fn load_svg(prerender: &Prerender, filename: &str) -> GeomBatch {
         svg::load_svg(prerender, filename).0
-    }
-
-    /// Returns a batch containing an SVG from a file.
-    pub fn screenspace_svg<I: Into<String>>(prerender: &Prerender, filename: I) -> GeomBatch {
-        svg::load_svg(prerender, &filename.into()).0
     }
 
     /// Transforms all colors in a batch.

--- a/ezgui/src/geom.rs
+++ b/ezgui/src/geom.rs
@@ -137,23 +137,18 @@ impl GeomBatch {
     pub fn from_svg_contents(raw: Vec<u8>) -> GeomBatch {
         let mut batch = GeomBatch::new();
         let svg_tree = usvg::Tree::from_data(&raw, &usvg::Options::default()).unwrap();
-        svg::add_svg_inner(&mut batch, svg_tree, svg::HIGH_QUALITY, 1.0).unwrap();
+        svg::add_svg_inner(&mut batch, svg_tree, svg::HIGH_QUALITY).unwrap();
         batch
     }
 
     /// Returns a batch containing an SVG from a file.
     pub fn mapspace_svg(prerender: &Prerender, filename: &str) -> GeomBatch {
-        svg::load_svg(prerender, filename, 1.0).0
+        svg::load_svg(prerender, filename).0
     }
 
-    /// Returns a batch containing an SVG from a file. Uses the current screen's scale factor.
+    /// Returns a batch containing an SVG from a file.
     pub fn screenspace_svg<I: Into<String>>(prerender: &Prerender, filename: I) -> GeomBatch {
-        svg::load_svg(
-            prerender,
-            &filename.into(),
-            *prerender.assets.scale_factor.borrow(),
-        )
-        .0
+        svg::load_svg(prerender, &filename.into()).0
     }
 
     /// Transforms all colors in a batch.

--- a/ezgui/src/input.rs
+++ b/ezgui/src/input.rs
@@ -101,7 +101,7 @@ impl UserInput {
 
     pub fn is_window_resized(&self) -> bool {
         match self.event {
-            Event::WindowResized(_, _) => true,
+            Event::WindowResized(_) => true,
             _ => false,
         }
     }

--- a/ezgui/src/runner.rs
+++ b/ezgui/src/runner.rs
@@ -6,6 +6,7 @@ use image::{GenericImageView, Pixel};
 use instant::Instant;
 use std::cell::{Cell, RefCell};
 use std::panic;
+use stdweb;
 use winit::window::Icon;
 
 const UPDATE_FREQUENCY: std::time::Duration = std::time::Duration::from_millis(1000 / 30);
@@ -61,10 +62,10 @@ impl<G: GUI> State<G> {
         {
             if let Event::WindowResized(new_size) = input.event {
                 let inner_size = prerender.window_size();
-                println!(
-                    "winit event says the window was resized from {}, {} to {:?}. But inner size \
+                stdweb::console!(log, 
+                    format!("winit event says the window was resized from {}, {} to {:?}. But inner size \
                      is {:?}, so using that",
-                    self.canvas.window_width, self.canvas.window_height, new_size, inner_size
+                    self.canvas.window_width, self.canvas.window_height, new_size, inner_size)
                 );
                 prerender.window_resized(new_size);
                 self.canvas.window_width = inner_size.width;
@@ -139,12 +140,12 @@ impl<G: GUI> State<G> {
         let naming_hint = g.naming_hint.take();
 
         if false {
-            println!(
-                "----- {} uploads, {} draw calls, {} forks -----",
+            stdweb::console!(log, 
+                format!("----- {} uploads, {} draw calls, {} forks -----",
                 g.get_num_uploads(),
                 g.num_draw_calls,
                 g.num_forks
-            );
+            ));
         }
 
         g.inner.finish();
@@ -241,7 +242,7 @@ pub fn run<G: 'static + GUI, F: FnOnce(&mut EventCtx) -> G>(settings: Settings, 
     let mut last_update = Instant::now();
     event_loop.run(move |event, _, control_flow| {
         if dump_raw_events {
-            println!("Event: {:?}", event);
+            stdweb::console!(log, format!("Event: {:?}", event));
         }
         let ev = match event {
             winit::event::Event::WindowEvent {

--- a/ezgui/src/runner.rs
+++ b/ezgui/src/runner.rs
@@ -6,7 +6,6 @@ use image::{GenericImageView, Pixel};
 use instant::Instant;
 use std::cell::{Cell, RefCell};
 use std::panic;
-use stdweb;
 use winit::window::Icon;
 
 const UPDATE_FREQUENCY: std::time::Duration = std::time::Duration::from_millis(1000 / 30);
@@ -62,10 +61,10 @@ impl<G: GUI> State<G> {
         {
             if let Event::WindowResized(new_size) = input.event {
                 let inner_size = prerender.window_size();
-                stdweb::console!(log, 
-                    format!("winit event says the window was resized from {}, {} to {:?}. But inner size \
+                println!(
+                    "winit event says the window was resized from {}, {} to {:?}. But inner size \
                      is {:?}, so using that",
-                    self.canvas.window_width, self.canvas.window_height, new_size, inner_size)
+                    self.canvas.window_width, self.canvas.window_height, new_size, inner_size
                 );
                 prerender.window_resized(new_size);
                 self.canvas.window_width = inner_size.width;
@@ -140,12 +139,12 @@ impl<G: GUI> State<G> {
         let naming_hint = g.naming_hint.take();
 
         if false {
-            stdweb::console!(log, 
-                format!("----- {} uploads, {} draw calls, {} forks -----",
+            println!(
+                "----- {} uploads, {} draw calls, {} forks -----",
                 g.get_num_uploads(),
                 g.num_draw_calls,
                 g.num_forks
-            ));
+            );
         }
 
         g.inner.finish();
@@ -242,7 +241,7 @@ pub fn run<G: 'static + GUI, F: FnOnce(&mut EventCtx) -> G>(settings: Settings, 
     let mut last_update = Instant::now();
     event_loop.run(move |event, _, control_flow| {
         if dump_raw_events {
-            stdweb::console!(log, format!("Event: {:?}", event));
+            println!("Event: {:?}", event);
         }
         let ev = match event {
             winit::event::Event::WindowEvent {

--- a/ezgui/src/runner.rs
+++ b/ezgui/src/runner.rs
@@ -66,7 +66,7 @@ impl<G: GUI> State<G> {
                      is {:?}, so using that",
                     self.canvas.window_width, self.canvas.window_height, new_size, inner_size
                 );
-                prerender.inner.window_resized(new_size);
+                prerender.window_resized(new_size);
                 self.canvas.window_width = inner_size.width;
                 self.canvas.window_height = inner_size.height;
             }
@@ -215,13 +215,9 @@ pub fn run<G: 'static + GUI, F: FnOnce(&mut EventCtx) -> G>(settings: Settings, 
     };
     let mut style = Style::standard();
 
-    // DPI TODO: This is going to cause a regression for devs on linux - since not all UI elements
-    // properly resize, e.g. the minimap. However, since only dev's are launching directly to the
-    // simulation, in practice this shouldn't cause much of an issue until we can get the minimap
-    // to resize itself.
     let initial_size = prerender.window_size();
     let mut canvas = Canvas::new(initial_size);
-    prerender.inner.window_resized(initial_size);
+    prerender.window_resized(initial_size);
 
     let gui = make_gui(&mut EventCtx {
         fake_mouseover: true,

--- a/ezgui/src/screen_geom.rs
+++ b/ezgui/src/screen_geom.rs
@@ -2,6 +2,7 @@ use crate::Canvas;
 use geom::{trim_f64, Polygon, Pt2D};
 use serde::{Deserialize, Serialize};
 
+/// ScreenPt is in units of logical pixels, as opposed to physical pixels.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ScreenPt {
     pub x: f64,
@@ -20,6 +21,13 @@ impl ScreenPt {
     }
 }
 
+impl From<winit::dpi::LogicalPosition<f64>> for ScreenPt {
+    fn from(lp: winit::dpi::LogicalPosition<f64>) -> ScreenPt {
+        ScreenPt { x: lp.x, y: lp.y }
+    }
+}
+
+/// ScreenRectangle is in units of logical pixels, as opposed to physical pixels.
 #[derive(Clone, Debug)]
 pub struct ScreenRectangle {
     pub x1: f64,
@@ -87,7 +95,7 @@ impl ScreenRectangle {
     }
 }
 
-// TODO Everything screen-space should probably just be usize, can't have fractional pixels?
+/// ScreenDims is in units of logical pixels, as opposed to physical pixels.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct ScreenDims {
     pub width: f64,
@@ -122,6 +130,15 @@ impl ScreenDims {
                 // corner.y is the bottom corner
                 ScreenPt::new(corner.x - self.width, corner.y - self.height)
             }
+        }
+    }
+}
+
+impl From<winit::dpi::LogicalSize<f64>> for ScreenDims {
+    fn from(lp: winit::dpi::LogicalSize<f64>) -> ScreenDims {
+        ScreenDims {
+            width: lp.width,
+            height: lp.height,
         }
     }
 }

--- a/ezgui/src/screen_geom.rs
+++ b/ezgui/src/screen_geom.rs
@@ -132,13 +132,23 @@ impl ScreenDims {
             }
         }
     }
+
+    pub fn scaled(&self, factor: f64) -> ScreenDims {
+        ScreenDims::new(self.width * factor, self.height * factor)
+    }
 }
 
 impl From<winit::dpi::LogicalSize<f64>> for ScreenDims {
-    fn from(lp: winit::dpi::LogicalSize<f64>) -> ScreenDims {
+    fn from(size: winit::dpi::LogicalSize<f64>) -> ScreenDims {
         ScreenDims {
-            width: lp.width,
-            height: lp.height,
+            width: size.width,
+            height: size.height,
         }
+    }
+}
+
+impl From<ScreenDims> for winit::dpi::LogicalSize<f64> {
+    fn from(dims: ScreenDims) -> winit::dpi::LogicalSize<f64> {
+        winit::dpi::LogicalSize::new(dims.width, dims.height)
     }
 }

--- a/ezgui/src/shaders/vertex_300.glsl
+++ b/ezgui/src/shaders/vertex_300.glsl
@@ -18,8 +18,8 @@ void main() {
     float screen_x = (position[0] * transform[2]) - transform[0];
     float screen_y = (position[1] * transform[2]) - transform[1];
     // Translate that to clip-space or whatever it's called
-    float x = (screen_x / window[0] * 2.0) - 1.0;
-    float y = (screen_y / window[1] * 2.0) - 1.0;
+    float x = (screen_x / window[0]) - 1.0;
+    float y = (screen_y / window[1]) - 1.0;
 
     // Note the y inversion
     gl_Position = vec4(x, -y, window[2], 1.0);

--- a/ezgui/src/shaders/vertex_300.glsl
+++ b/ezgui/src/shaders/vertex_300.glsl
@@ -18,8 +18,8 @@ void main() {
     float screen_x = (position[0] * transform[2]) - transform[0];
     float screen_y = (position[1] * transform[2]) - transform[1];
     // Translate that to clip-space or whatever it's called
-    float x = (screen_x / window[0]) - 1.0;
-    float y = (screen_y / window[1]) - 1.0;
+    float x = (screen_x / window[0] * 2.0) - 1.0;
+    float y = (screen_y / window[1] * 2.0) - 1.0;
 
     // Note the y inversion
     gl_Position = vec4(x, -y, window[2], 1.0);

--- a/ezgui/src/text.rs
+++ b/ezgui/src/text.rs
@@ -454,12 +454,7 @@ fn render_line(spans: Vec<TextSpan>, tolerance: f32, assets: &Assets) -> GeomBat
         Err(err) => panic!("render_line({}): {}", contents, err),
     };
     let mut batch = GeomBatch::new();
-    match crate::svg::add_svg_inner(
-        &mut batch,
-        svg_tree,
-        tolerance,
-        *assets.scale_factor.borrow(),
-    ) {
+    match crate::svg::add_svg_inner(&mut batch, svg_tree, tolerance) {
         Ok(_) => batch,
         Err(err) => panic!("render_line({}): {}", contents, err),
     }

--- a/ezgui/src/widgets/button.rs
+++ b/ezgui/src/widgets/button.rs
@@ -255,11 +255,7 @@ impl BtnBuilder {
                 rewrite_hover,
                 maybe_tooltip,
             } => {
-                let (normal, bounds) = svg::load_svg(
-                    ctx.prerender,
-                    &path,
-                    *ctx.prerender.assets.scale_factor.borrow(),
-                );
+                let (normal, bounds) = svg::load_svg(ctx.prerender, &path);
                 let geom = Polygon::rectangle(bounds.width(), bounds.height());
 
                 let hovered = normal.clone().color(rewrite_hover);

--- a/ezgui/src/widgets/checkbox.rs
+++ b/ezgui/src/widgets/checkbox.rs
@@ -35,14 +35,14 @@ impl Checkbox {
     ) -> Widget {
         let label = label.into();
         let (off, hitbox) = Widget::row(vec![
-            GeomBatch::screenspace_svg(ctx.prerender, "system/assets/tools/toggle_off.svg")
+            GeomBatch::load_svg(ctx.prerender, "system/assets/tools/toggle_off.svg")
                 .batch()
                 .centered_vert(),
             label.clone().batch_text(ctx),
         ])
         .to_geom(ctx, None);
         let (on, _) = Widget::row(vec![
-            GeomBatch::screenspace_svg(ctx.prerender, "system/assets/tools/toggle_on.svg")
+            GeomBatch::load_svg(ctx.prerender, "system/assets/tools/toggle_on.svg")
                 .batch()
                 .centered_vert(),
             label.clone().batch_text(ctx),
@@ -113,7 +113,7 @@ impl Checkbox {
 
     pub fn colored(ctx: &EventCtx, label: &str, color: Color, enabled: bool) -> Widget {
         let (off, hitbox) = Widget::row(vec![
-            GeomBatch::screenspace_svg(ctx.prerender, "system/assets/tools/checkbox.svg")
+            GeomBatch::load_svg(ctx.prerender, "system/assets/tools/checkbox.svg")
                 .color(RewriteColor::ChangeAll(color.alpha(0.3)))
                 .batch()
                 .centered_vert(),
@@ -121,7 +121,7 @@ impl Checkbox {
         ])
         .to_geom(ctx, None);
         let (on, _) = Widget::row(vec![
-            GeomBatch::screenspace_svg(ctx.prerender, "system/assets/tools/checkbox.svg")
+            GeomBatch::load_svg(ctx.prerender, "system/assets/tools/checkbox.svg")
                 .color(RewriteColor::Change(Color::BLACK, color))
                 .batch()
                 .centered_vert(),

--- a/ezgui/src/widgets/just_draw.rs
+++ b/ezgui/src/widgets/just_draw.rs
@@ -22,11 +22,7 @@ impl JustDraw {
     }
 
     pub fn svg(ctx: &EventCtx, filename: String) -> Widget {
-        let (batch, bounds) = svg::load_svg(
-            ctx.prerender,
-            &filename,
-            *ctx.prerender.assets.scale_factor.borrow(),
-        );
+        let (batch, bounds) = svg::load_svg(ctx.prerender, &filename);
         // TODO The dims will be wrong; it'll only look at geometry, not the padding in the image.
         Widget::new(Box::new(JustDraw {
             dims: ScreenDims::new(bounds.width(), bounds.height()),
@@ -35,11 +31,7 @@ impl JustDraw {
         }))
     }
     pub fn svg_transform(ctx: &EventCtx, filename: &str, rewrite: RewriteColor) -> Widget {
-        let (batch, bounds) = svg::load_svg(
-            ctx.prerender,
-            filename,
-            *ctx.prerender.assets.scale_factor.borrow(),
-        );
+        let (batch, bounds) = svg::load_svg(ctx.prerender, filename);
         let batch = batch.color(rewrite);
         // TODO The dims will be wrong; it'll only look at geometry, not the padding in the image.
         Widget::new(Box::new(JustDraw {

--- a/game/Cargo.toml
+++ b/game/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 [features]
 default = ["built", "ezgui/glium-backend", "reqwest", "webbrowser"]
 wasm = ["ezgui/wasm-backend"]
+glow = ["built", "ezgui/glow-backend", "reqwest", "webbrowser"]
 
 [dependencies]
 aabb-quadtree = "0.1.0"

--- a/game/src/common/city_picker.rs
+++ b/game/src/common/city_picker.rs
@@ -36,9 +36,9 @@ impl CityPicker {
             &mut abstutil::Timer::throwaway(),
         ) {
             let bounds = city.boundary.get_bounds();
-            let zoom_no_scale_factor = (0.8 * ctx.canvas.window_width / bounds.width())
+
+            let zoom = (0.8 * ctx.canvas.window_width / bounds.width())
                 .min(0.8 * ctx.canvas.window_height / bounds.height());
-            let zoom = zoom_no_scale_factor / ctx.get_scale_factor();
 
             batch.push(app.cs.map_background, city.boundary);
             for (area_type, polygon) in city.areas {
@@ -56,7 +56,7 @@ impl CityPicker {
                 } else {
                     batch.push(color, polygon.to_outline(Distance::meters(200.0)).unwrap());
                 }
-                regions.push((name, color, polygon.scale(zoom_no_scale_factor)));
+                regions.push((name, color, polygon.scale(zoom)));
             }
             batch = batch.scale(zoom);
         }

--- a/game/src/cutscene.rs
+++ b/game/src/cutscene.rs
@@ -203,12 +203,9 @@ fn make_panel(
                 Layout::PlayerSpeaking => Widget::custom_row(vec![
                     Widget::draw_batch(
                         ctx,
-                        GeomBatch::screenspace_svg(
-                            ctx.prerender,
-                            "system/assets/characters/boss.svg",
-                        )
-                        .scale(0.75)
-                        .autocrop(),
+                        GeomBatch::load_svg(ctx.prerender, "system/assets/characters/boss.svg")
+                            .scale(0.75)
+                            .autocrop(),
                     ),
                     Widget::custom_row(vec![
                         scenes[idx].msg.clone().wrap_to_pct(ctx, 30).draw(ctx),
@@ -219,12 +216,9 @@ fn make_panel(
                 Layout::BossSpeaking => Widget::custom_row(vec![
                     Widget::draw_batch(
                         ctx,
-                        GeomBatch::screenspace_svg(
-                            ctx.prerender,
-                            "system/assets/characters/boss.svg",
-                        )
-                        .scale(0.75)
-                        .autocrop(),
+                        GeomBatch::load_svg(ctx.prerender, "system/assets/characters/boss.svg")
+                            .scale(0.75)
+                            .autocrop(),
                     ),
                     scenes[idx].msg.clone().wrap_to_pct(ctx, 30).draw(ctx),
                     Widget::draw_svg(ctx, "system/assets/characters/player.svg").align_right(),
@@ -232,19 +226,16 @@ fn make_panel(
                 Layout::Extra(name, scale) => Widget::custom_row(vec![
                     Widget::draw_batch(
                         ctx,
-                        GeomBatch::screenspace_svg(
-                            ctx.prerender,
-                            "system/assets/characters/boss.svg",
-                        )
-                        .scale(0.75)
-                        .autocrop(),
+                        GeomBatch::load_svg(ctx.prerender, "system/assets/characters/boss.svg")
+                            .scale(0.75)
+                            .autocrop(),
                     ),
                     Widget::col(vec![
                         Widget::draw_batch(
                             ctx,
-                            GeomBatch::screenspace_svg(
+                            GeomBatch::load_svg(
                                 ctx.prerender,
-                                format!("system/assets/characters/{}.svg", name),
+                                &format!("system/assets/characters/{}.svg", name),
                             )
                             .scale(scale)
                             .autocrop(),

--- a/game/src/devtools/story.rs
+++ b/game/src/devtools/story.rs
@@ -268,12 +268,10 @@ impl State for StoryMapEditor {
         match self.mode {
             Mode::PlacingMarker => {
                 if g.canvas.get_cursor_in_map_space().is_some() {
-                    let batch = GeomBatch::screenspace_svg(
-                        g.prerender,
-                        "system/assets/timeline/goal_pos.svg",
-                    )
-                    .centered_on(g.canvas.get_cursor().to_pt())
-                    .color(RewriteColor::Change(Color::hex("#5B5B5B"), Color::GREEN));
+                    let batch =
+                        GeomBatch::load_svg(g.prerender, "system/assets/timeline/goal_pos.svg")
+                            .centered_on(g.canvas.get_cursor().to_pt())
+                            .color(RewriteColor::Change(Color::hex("#5B5B5B"), Color::GREEN));
                     g.fork_screenspace();
                     batch.draw(g);
                     g.unfork();
@@ -430,7 +428,7 @@ impl Marker {
 
         let hitbox = if pts.len() == 1 {
             batch.append(
-                GeomBatch::screenspace_svg(ctx.prerender, "system/assets/timeline/goal_pos.svg")
+                GeomBatch::load_svg(ctx.prerender, "system/assets/timeline/goal_pos.svg")
                     .scale(2.0)
                     .centered_on(pts[0])
                     .color(RewriteColor::Change(
@@ -474,7 +472,7 @@ impl Marker {
         let mut batch = GeomBatch::new();
         if self.pts.len() == 1 {
             batch.append(
-                GeomBatch::screenspace_svg(g.prerender, "system/assets/timeline/goal_pos.svg")
+                GeomBatch::load_svg(g.prerender, "system/assets/timeline/goal_pos.svg")
                     .scale(2.0)
                     .centered_on(self.pts[0])
                     .color(RewriteColor::Change(Color::hex("#5B5B5B"), app.cs.hovering)),

--- a/game/src/edit/select.rs
+++ b/game/src/edit/select.rs
@@ -296,7 +296,7 @@ impl RoadSelector {
             } {
                 let mut batch = GeomBatch::new();
                 batch.append(
-                    GeomBatch::screenspace_svg(g.prerender, cursor)
+                    GeomBatch::load_svg(g.prerender, cursor)
                         .centered_on(g.canvas.get_cursor().to_pt())
                         .color(RewriteColor::ChangeAll(Color::GREEN)),
                 );

--- a/game/src/edit/traffic_signals.rs
+++ b/game/src/edit/traffic_signals.rs
@@ -932,9 +932,7 @@ fn make_signal_diagram(
                 ctx,
                 GeomBatch::from(vec![(
                     Color::WHITE,
-                    // TODO draw_batch will scale up, but that's inappropriate here, since we're
-                    // depending on window width, which already factors in scale
-                    Polygon::rectangle(0.2 * ctx.canvas.window_width / ctx.get_scale_factor(), 2.0),
+                    Polygon::rectangle(0.2 * ctx.canvas.window_width, 2.0),
                 )]),
             )
             .centered_horiz(),
@@ -1029,7 +1027,7 @@ fn make_signal_diagram(
             ctx,
             GeomBatch::from(vec![(
                 Color::WHITE,
-                Polygon::rectangle(0.2 * ctx.canvas.window_width / ctx.get_scale_factor(), 2.0),
+                Polygon::rectangle(0.2 * ctx.canvas.window_width, 2.0),
             )]),
         )
         .centered_horiz(),

--- a/game/src/info/intersection.rs
+++ b/game/src/info/intersection.rs
@@ -167,7 +167,7 @@ pub fn current_demand(
         txt_batch.append(
             Text::from(Line(prettyprint_usize(demand)).fg(Color::RED))
                 .render_ctx(ctx)
-                .scale(0.15 / ctx.get_scale_factor())
+                .scale(0.15)
                 .centered_on(pl.middle()),
         );
     }

--- a/game/src/info/person.rs
+++ b/game/src/info/person.rs
@@ -132,7 +132,7 @@ pub fn trips(
                 .centered_vert()
                 .margin_right(21),
             Widget::row(vec![
-                GeomBatch::screenspace_svg(
+                GeomBatch::load_svg(
                     ctx.prerender,
                     match trip.mode {
                         TripMode::Walk => "system/assets/meters/pedestrian.svg",
@@ -458,7 +458,7 @@ pub fn parked_car(
                 )
             } else {
                 // TODO Blink
-                GeomBatch::screenspace_svg(ctx.prerender, "system/assets/tools/location.svg")
+                GeomBatch::load_svg(ctx.prerender, "system/assets/tools/location.svg")
                     .color(RewriteColor::ChangeAll(Color::hex("#7FFA4D")))
                     .to_btn(ctx)
                     .build(ctx, "unfollow (pause the simulation)", hotkey(Key::F))
@@ -570,7 +570,7 @@ fn header(
                 )
             } else {
                 // TODO Blink
-                GeomBatch::screenspace_svg(ctx.prerender, "system/assets/tools/location.svg")
+                GeomBatch::load_svg(ctx.prerender, "system/assets/tools/location.svg")
                     .color(RewriteColor::ChangeAll(Color::hex("#7FFA4D")))
                     .to_btn(ctx)
                     .build(ctx, "unfollow (pause the simulation)", hotkey(Key::F))

--- a/game/src/info/trip.rs
+++ b/game/src/info/trip.rs
@@ -385,7 +385,7 @@ fn make_timeline(
         }
 
         details.unzoomed.append(
-            GeomBatch::mapspace_svg(ctx.prerender, "system/assets/timeline/start_pos.svg")
+            GeomBatch::load_svg(ctx.prerender, "system/assets/timeline/start_pos.svg")
                 .scale(3.0)
                 .color(RewriteColor::Change(Color::WHITE, Color::BLACK))
                 .color(RewriteColor::Change(
@@ -395,7 +395,7 @@ fn make_timeline(
                 .centered_on(center),
         );
         details.zoomed.append(
-            GeomBatch::mapspace_svg(ctx.prerender, "system/assets/timeline/start_pos.svg")
+            GeomBatch::load_svg(ctx.prerender, "system/assets/timeline/start_pos.svg")
                 .color(RewriteColor::Change(Color::WHITE, Color::BLACK))
                 .color(RewriteColor::Change(
                     Color::hex("#5B5B5B"),
@@ -430,7 +430,7 @@ fn make_timeline(
         }
 
         details.unzoomed.append(
-            GeomBatch::mapspace_svg(ctx.prerender, "system/assets/timeline/goal_pos.svg")
+            GeomBatch::load_svg(ctx.prerender, "system/assets/timeline/goal_pos.svg")
                 .scale(3.0)
                 .color(RewriteColor::Change(Color::WHITE, Color::BLACK))
                 .color(RewriteColor::Change(
@@ -440,7 +440,7 @@ fn make_timeline(
                 .centered_on(center),
         );
         details.zoomed.append(
-            GeomBatch::mapspace_svg(ctx.prerender, "system/assets/timeline/goal_pos.svg")
+            GeomBatch::load_svg(ctx.prerender, "system/assets/timeline/goal_pos.svg")
                 .color(RewriteColor::Change(Color::WHITE, Color::BLACK))
                 .color(RewriteColor::Change(
                     Color::hex("#5B5B5B"),
@@ -502,16 +502,13 @@ fn make_timeline(
         if idx == num_phases - 1 {
             if let Some(p) = progress_along_path {
                 normal.append(
-                    GeomBatch::screenspace_svg(
-                        ctx.prerender,
-                        "system/assets/timeline/current_pos.svg",
-                    )
-                    .centered_on(Pt2D::new(p * phase_width, 7.5)),
+                    GeomBatch::load_svg(ctx.prerender, "system/assets/timeline/current_pos.svg")
+                        .centered_on(Pt2D::new(p * phase_width, 7.5)),
                 );
             }
         }
         normal.append(
-            GeomBatch::screenspace_svg(
+            GeomBatch::load_svg(
                 ctx.prerender,
                 match p.phase_type {
                     TripPhaseType::Driving => "system/assets/timeline/driving.svg",

--- a/game/src/info/trip.rs
+++ b/game/src/info/trip.rs
@@ -496,12 +496,8 @@ fn make_timeline(
             (100.0 * percent_duration) as usize
         )));
 
-        // TODO We're manually mixing screenspace_svg, our own geometry, and a centered_on(). Be
-        // careful about the scale factor. I'm confused about some of the math here, figured it out
-        // by trial and error.
-        let scale = ctx.get_scale_factor();
         let phase_width = total_width * percent_duration;
-        let rect = Polygon::rectangle(phase_width * scale, 15.0 * scale);
+        let rect = Polygon::rectangle(phase_width, 15.0);
         let mut normal = GeomBatch::from(vec![(color, rect.clone())]);
         if idx == num_phases - 1 {
             if let Some(p) = progress_along_path {
@@ -510,7 +506,7 @@ fn make_timeline(
                         ctx.prerender,
                         "system/assets/timeline/current_pos.svg",
                     )
-                    .centered_on(Pt2D::new(p * phase_width * scale, 7.5 * scale)),
+                    .centered_on(Pt2D::new(p * phase_width, 7.5)),
                 );
             }
         }
@@ -534,7 +530,7 @@ fn make_timeline(
             )
             .centered_on(
                 // TODO Hardcoded layouting...
-                Pt2D::new(0.5 * phase_width * scale, -20.0),
+                Pt2D::new(0.5 * phase_width, -20.0),
             ),
         );
 

--- a/game/src/options.rs
+++ b/game/src/options.rs
@@ -146,26 +146,6 @@ impl OptionsPanel {
                         ),
                     ]),
                     Widget::row(vec![
-                        format!(
-                            "Scale factor for text / UI elements (your monitor is {}):",
-                            ctx.monitor_scale_factor()
-                        )
-                        .draw_text(ctx),
-                        Widget::dropdown(ctx, "Scale factor", ctx.get_scale_factor(), {
-                            let mut choices = vec![
-                                Choice::new("0.5", 0.5),
-                                Choice::new("1.0", 1.0),
-                                Choice::new("1.5", 1.5),
-                                Choice::new("2.0", 2.0),
-                            ];
-                            let native = ctx.monitor_scale_factor();
-                            if !choices.iter().any(|c| c.data == native) {
-                                choices.push(Choice::new(native.to_string(), native));
-                            }
-                            choices
-                        }),
-                    ]),
-                    Widget::row(vec![
                         "Camera zoom to switch to unzoomed view".draw_text(ctx),
                         Widget::dropdown(
                             ctx,
@@ -251,11 +231,6 @@ impl State for OptionsPanel {
                     if app.opts.color_scheme != scheme {
                         app.opts.color_scheme = scheme;
                         app.switch_map(ctx, app.primary.current_flags.sim_flags.load.clone());
-                    }
-
-                    let factor = self.composite.dropdown_value("Scale factor");
-                    if ctx.get_scale_factor() != factor {
-                        ctx.set_scale_factor(factor);
                     }
 
                     app.opts.min_zoom_for_detail = self.composite.dropdown_value("min zoom");

--- a/game/src/render/building.rs
+++ b/game/src/render/building.rs
@@ -46,7 +46,7 @@ impl DrawBuilding {
         if let OffstreetParking::PublicGarage(_, _) = bldg.parking {
             // Might need to scale down more for some buildings, but so far, this works everywhere.
             bldg_batch.append(
-                GeomBatch::mapspace_svg(ctx.prerender, "system/assets/map/parking.svg")
+                GeomBatch::load_svg(ctx.prerender, "system/assets/map/parking.svg")
                     .scale(0.1)
                     .centered_on(bldg.label_center),
             );

--- a/game/src/render/bus_stop.rs
+++ b/game/src/render/bus_stop.rs
@@ -26,7 +26,7 @@ impl DrawBusStop {
 
         let mut icon = GeomBatch::new();
         icon.append(
-            GeomBatch::mapspace_svg(
+            GeomBatch::load_svg(
                 ctx.prerender,
                 if stop.is_train_stop {
                     "system/assets/map/light_rail.svg"

--- a/game/src/render/car.rs
+++ b/game/src/render/car.rs
@@ -76,7 +76,7 @@ impl DrawCar {
         draw_default.push(zoomed_color_car(&input, cs), body_polygon.clone());
         if input.status == CarStatus::Parked {
             draw_default.append(
-                GeomBatch::mapspace_svg(prerender, "system/assets/map/parked_car.svg")
+                GeomBatch::load_svg(prerender, "system/assets/map/parked_car.svg")
                     .scale(0.01)
                     .centered_on(input.body.middle()),
             );

--- a/game/src/render/intersection.rs
+++ b/game/src/render/intersection.rs
@@ -77,12 +77,9 @@ impl DrawIntersection {
             IntersectionType::Construction => {
                 // TODO Centering seems weird
                 default_geom.append(
-                    GeomBatch::mapspace_svg(
-                        g.prerender,
-                        "system/assets/map/under_construction.svg",
-                    )
-                    .scale(0.08)
-                    .centered_on(i.polygon.center()),
+                    GeomBatch::load_svg(g.prerender, "system/assets/map/under_construction.svg")
+                        .scale(0.08)
+                        .centered_on(i.polygon.center()),
                 );
             }
             IntersectionType::TrafficSignal => {}

--- a/game/src/render/lane.rs
+++ b/game/src/render/lane.rs
@@ -131,14 +131,14 @@ impl DrawLane {
                 let (pt, angle) = lane.lane_center_pts.must_dist_along(dist);
                 if lane.is_bus() {
                     draw.append(
-                        GeomBatch::mapspace_svg(g.prerender, "system/assets/map/bus_only.svg")
+                        GeomBatch::load_svg(g.prerender, "system/assets/map/bus_only.svg")
                             .scale(0.06)
                             .centered_on(pt)
                             .rotate(angle.shortest_rotation_towards(Angle::new_degs(-90.0))),
                     );
                 } else if lane.is_biking() {
                     draw.append(
-                        GeomBatch::mapspace_svg(g.prerender, "system/assets/meters/bike.svg")
+                        GeomBatch::load_svg(g.prerender, "system/assets/meters/bike.svg")
                             .scale(0.06)
                             .centered_on(pt)
                             .rotate(angle.shortest_rotation_towards(Angle::new_degs(-90.0))),
@@ -146,7 +146,7 @@ impl DrawLane {
                 } else if lane.lane_type == LaneType::Construction {
                     // TODO Still not quite centered right, but close enough
                     draw.append(
-                        GeomBatch::mapspace_svg(
+                        GeomBatch::load_svg(
                             g.prerender,
                             "system/assets/map/under_construction.svg",
                         )

--- a/game/src/render/parking_lot.rs
+++ b/game/src/render/parking_lot.rs
@@ -28,7 +28,7 @@ impl DrawParkingLot {
             );
         }
         unzoomed_batch.append(
-            GeomBatch::mapspace_svg(ctx.prerender, "system/assets/map/parking.svg")
+            GeomBatch::load_svg(ctx.prerender, "system/assets/map/parking.svg")
                 .scale(0.05)
                 .centered_on(lot.polygon.polylabel()),
         );

--- a/game/src/render/traffic_signal.rs
+++ b/game/src/render/traffic_signal.rs
@@ -69,7 +69,7 @@ pub fn draw_signal_phase(
                 } else {
                     let (center, angle) = crosswalk_icon(&signal.turn_groups[g].geom);
                     batch.append(
-                        GeomBatch::mapspace_svg(prerender, "system/assets/map/walk.svg")
+                        GeomBatch::load_svg(prerender, "system/assets/map/walk.svg")
                             .scale(0.07)
                             .centered_on(center)
                             .rotate(angle)
@@ -81,7 +81,7 @@ pub fn draw_signal_phase(
             for g in dont_walk {
                 let (center, angle) = crosswalk_icon(&signal.turn_groups[g].geom);
                 batch.append(
-                    GeomBatch::mapspace_svg(prerender, "system/assets/map/dont_walk.svg")
+                    GeomBatch::load_svg(prerender, "system/assets/map/dont_walk.svg")
                         .scale(0.07)
                         .centered_on(center)
                         .rotate(angle),
@@ -150,7 +150,7 @@ pub fn draw_signal_phase(
                 } else {
                     let (center, angle) = crosswalk_icon(&signal.turn_groups[g].geom);
                     batch.append(
-                        GeomBatch::mapspace_svg(prerender, "system/assets/map/walk.svg")
+                        GeomBatch::load_svg(prerender, "system/assets/map/walk.svg")
                             .scale(0.07)
                             .centered_on(center)
                             .rotate(angle),
@@ -161,7 +161,7 @@ pub fn draw_signal_phase(
             for g in dont_walk {
                 let (center, angle) = crosswalk_icon(&signal.turn_groups[g].geom);
                 batch.append(
-                    GeomBatch::mapspace_svg(prerender, "system/assets/map/dont_walk.svg")
+                    GeomBatch::load_svg(prerender, "system/assets/map/dont_walk.svg")
                         .scale(0.07)
                         .centered_on(center)
                         .rotate(angle),

--- a/game/src/sandbox/dashboards/commuter.rs
+++ b/game/src/sandbox/dashboards/commuter.rs
@@ -229,7 +229,7 @@ impl CommuterPatterns {
                     };
 
                     let center = base_block.shape.polylabel();
-                    let icon = GeomBatch::mapspace_svg(
+                    let icon = GeomBatch::load_svg(
                         ctx.prerender,
                         &format!("system/assets/tools/{}", icon_name),
                     )

--- a/game/src/sandbox/dashboards/traffic_signals.rs
+++ b/game/src/sandbox/dashboards/traffic_signals.rs
@@ -180,7 +180,7 @@ impl Demand {
                 txt_batch.append(
                     Text::from(Line(prettyprint_usize(demand)).fg(Color::RED))
                         .render_ctx(ctx)
-                        .scale(0.15 / ctx.get_scale_factor())
+                        .scale(0.15)
                         .centered_on(pl.middle()),
                 );
             }

--- a/game/src/sandbox/dashboards/trip_table.rs
+++ b/game/src/sandbox/dashboards/trip_table.rs
@@ -448,12 +448,10 @@ pub fn make_table(
             .enumerate()
             .map(|(idx, w)| {
                 let margin = extra_margin + width_per_col[idx] - w.get_width_for_forcing();
-                // TODO margin_right scales up, so we have to cancel that out. Otherwise here we're
-                // already working in physical pixels. Sigh.
                 if idx == width_per_col.len() - 1 {
-                    w.margin_right(((margin - extra_margin) / ctx.get_scale_factor()) as usize)
+                    w.margin_right((margin - extra_margin) as usize)
                 } else {
-                    w.margin_right((margin / ctx.get_scale_factor()) as usize)
+                    w.margin_right(margin as usize)
                 }
             })
             .collect(),

--- a/game/src/sandbox/dashboards/trip_table.rs
+++ b/game/src/sandbox/dashboards/trip_table.rs
@@ -534,7 +534,7 @@ fn preview_route(g: &mut GfxCtx, app: &App, id: TripID) -> GeomBatch {
 
     let trip = app.primary.sim.trip_info(id);
     batch.append(
-        GeomBatch::mapspace_svg(g.prerender, "system/assets/timeline/start_pos.svg")
+        GeomBatch::load_svg(g.prerender, "system/assets/timeline/start_pos.svg")
             .scale(10.0)
             .color(RewriteColor::Change(Color::WHITE, Color::BLACK))
             .color(RewriteColor::Change(
@@ -547,7 +547,7 @@ fn preview_route(g: &mut GfxCtx, app: &App, id: TripID) -> GeomBatch {
             }),
     );
     batch.append(
-        GeomBatch::mapspace_svg(g.prerender, "system/assets/timeline/goal_pos.svg")
+        GeomBatch::load_svg(g.prerender, "system/assets/timeline/goal_pos.svg")
             .scale(10.0)
             .color(RewriteColor::Change(Color::WHITE, Color::BLACK))
             .color(RewriteColor::Change(

--- a/game/src/sandbox/gameplay/commute.rs
+++ b/game/src/sandbox/gameplay/commute.rs
@@ -248,7 +248,7 @@ fn make_meter(
             ctx,
             GeomBatch::from(vec![(
                 Color::WHITE,
-                Polygon::rectangle(0.2 * ctx.canvas.window_width / ctx.get_scale_factor(), 2.0),
+                Polygon::rectangle(0.2 * ctx.canvas.window_width, 2.0),
             )]),
         )
         .centered_horiz(),

--- a/game/src/sandbox/gameplay/fix_traffic_signals.rs
+++ b/game/src/sandbox/gameplay/fix_traffic_signals.rs
@@ -293,7 +293,7 @@ fn make_meter(
             ctx,
             GeomBatch::from(vec![(
                 Color::WHITE,
-                Polygon::rectangle(0.2 * ctx.canvas.window_width / ctx.get_scale_factor(), 2.0),
+                Polygon::rectangle(0.2 * ctx.canvas.window_width, 2.0),
             )]),
         )
         .centered_horiz(),

--- a/game/src/sandbox/gameplay/mod.rs
+++ b/game/src/sandbox/gameplay/mod.rs
@@ -317,12 +317,9 @@ impl FinalScore {
                 Widget::custom_row(vec![
                     Widget::draw_batch(
                         ctx,
-                        GeomBatch::screenspace_svg(
-                            ctx.prerender,
-                            "system/assets/characters/boss.svg",
-                        )
-                        .scale(0.75)
-                        .autocrop(),
+                        GeomBatch::load_svg(ctx.prerender, "system/assets/characters/boss.svg")
+                            .scale(0.75)
+                            .autocrop(),
                     )
                     .container()
                     .outline(10.0, Color::BLACK)

--- a/game/src/sandbox/mod.rs
+++ b/game/src/sandbox/mod.rs
@@ -330,7 +330,7 @@ impl AgentMeter {
                 ctx,
                 GeomBatch::from(vec![(
                     Color::WHITE,
-                    Polygon::rectangle(0.2 * ctx.canvas.window_width / ctx.get_scale_factor(), 2.0),
+                    Polygon::rectangle(0.2 * ctx.canvas.window_width, 2.0),
                 )]),
             )
             .centered_horiz(),

--- a/game/src/sandbox/speed.rs
+++ b/game/src/sandbox/speed.rs
@@ -70,7 +70,7 @@ impl SpeedControls {
                     txt.extend(Text::tooltip(ctx, hotkey(Key::LeftArrow), "slow down"));
                     txt.extend(Text::tooltip(ctx, hotkey(Key::RightArrow), "speed up"));
 
-                    GeomBatch::screenspace_svg(ctx.prerender, "system/assets/speed/triangle.svg")
+                    GeomBatch::load_svg(ctx.prerender, "system/assets/speed/triangle.svg")
                         .color(if setting >= s {
                             RewriteColor::NoOp
                         } else {


### PR DESCRIPTION
It might be worthwhile examining the commits separately. The bulk of the work needed to get the glium backend was done here: 29bb62c86ac08c81aa126eabe79a0606974cfb48

Could you please check the glium, wasm, and glow builds?

**Glium**: should be working well - though there's the known initial sizing issue. In general this fixes lots of little layout issues on macos (and presumably other scaled displays). In particular things like margin/padding, corner rounding look much better now.

(all screenshots macos, scaling factor 2)

**glium before**
<img width="1792" alt="Screen Shot 2020-08-12 at 2 07 20 PM" src="https://user-images.githubusercontent.com/217057/90068267-3a0f0980-dca5-11ea-8d1d-793a2a4de81e.png">

**glium after**
<img width="1792" alt="Screen Shot 2020-08-12 at 2 08 13 PM" src="https://user-images.githubusercontent.com/217057/90068295-45623500-dca5-11ea-9f12-1ad49d952a95.png">


**Wasm**: there's definitely issues with this, but I don't think there are any *new* issues. Previously the wasm build on macos was not scaled correctly, so at least that much has improved.

**wasm before**
<img width="1792" alt="Screen Shot 2020-08-12 at 2 04 58 PM" src="https://user-images.githubusercontent.com/217057/90068054-e1d80780-dca4-11ea-8ce2-1cf14a196a70.png">

**wasm after**
<img width="1792" alt="Screen Shot 2020-08-12 at 2 03 23 PM" src="https://user-images.githubusercontent.com/217057/90068043-ddabea00-dca4-11ea-8763-1ec9ec318d09.png">

If you encounter any issues with the wasm build, could you un-revert the logging commit (97fa0c04ba65d4a377aac3783e31112616d019e0) re-run and send me the console output along with a screenshot?

**Glow**: I can get things to build, but even on master, I only see a blank screen in the Glow build. If you have instruction on how to get this to build properly, I can take a deeper look.

