### PR TITLE
Refactor the Transition enum, collapsing enum variants that were

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -794,7 +794,7 @@ dependencies = [
  "ttf-parser 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "usvg 0.11.0 (git+https://github.com/RazrFalcon/resvg)",
  "webgl_stdweb 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winit 0.22.2 (git+https://github.com/michaelkirk/winit?branch=mkirk/fix-stdweb-dpi)",
+ "winit 0.22.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3761,37 +3761,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "winit"
 version = "0.22.2"
-source = "git+https://github.com/michaelkirk/winit?branch=mkirk/fix-stdweb-dpi#6b61263293b72a76d46c14ba2abfef92e5a0bd75"
-dependencies = [
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cocoa 0.20.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-foundation 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-graphics 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-video-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "dispatch 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "instant 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio-extras 2.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "ndk 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ndk-glue 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ndk-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "raw-window-handle 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "smithay-client-toolkit 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "stdweb 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-client 0.23.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "x11-dl 2.18.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "winit"
-version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3814,6 +3783,7 @@ dependencies = [
  "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "raw-window-handle 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smithay-client-toolkit 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stdweb 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-client 0.23.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "x11-dl 2.18.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4307,7 +4277,6 @@ dependencies = [
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-util 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "fa515c5163a99cc82bab70fd3bfdd36d827be85de63737b40fcef2ce084a436e"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-"checksum winit 0.22.2 (git+https://github.com/michaelkirk/winit?branch=mkirk/fix-stdweb-dpi)" = "<none>"
 "checksum winit 0.22.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1e4ccbf7ddb6627828eace16cacde80fc6bf4dbb3469f88487262a02cf8e7862"
 "checksum winreg 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"

--- a/ezgui/Cargo.toml
+++ b/ezgui/Cargo.toml
@@ -29,7 +29,9 @@ stretch = "0.3.2"
 ttf-parser = "0.6.1"
 usvg = { git = "https://github.com/RazrFalcon/resvg", default-features=false }
 webgl_stdweb = { version = "0.3", optional = true }
-winit = { version = "0.22.2", git = "https://github.com/michaelkirk/winit", branch = "mkirk/fix-stdweb-dpi" }
+# TODO glium and glutin don't work with winit latest, so temporarily don't include a hidpi wasm fix
+winit = { version = "0.22.2" }
+#winit = { version = "0.22.2", git = "https://github.com/michaelkirk/winit", branch = "mkirk/fix-stdweb-dpi" }
 
 [dev-dependencies]
 rand = "0.7.0"

--- a/game/src/challenges.rs
+++ b/game/src/challenges.rs
@@ -257,12 +257,12 @@ impl State for ChallengesPicker {
                 }
                 "Start!" => {
                     let challenge = self.challenge.take().unwrap();
-                    let sandbox = Box::new(SandboxMode::new(ctx, app, challenge.gameplay.clone()));
+                    let sandbox = SandboxMode::new(ctx, app, challenge.gameplay.clone());
                     if let Some(cutscene) = challenge.cutscene {
-                        Transition::ReplaceThenPush(
-                            sandbox,
-                            cutscene(ctx, app, &challenge.gameplay),
-                        )
+                        Transition::Multi(vec![
+                            Transition::Replace(sandbox),
+                            Transition::Push(cutscene(ctx, app, &challenge.gameplay)),
+                        ])
                     } else {
                         Transition::Replace(sandbox)
                     }

--- a/game/src/cutscene.rs
+++ b/game/src/cutscene.rs
@@ -90,7 +90,7 @@ impl State for CutscenePlayer {
                     // TODO Should SandboxMode use on_destroy for this?
                     app.primary.clear_sim();
                     app.set_prebaked(None);
-                    return Transition::PopTwice;
+                    return Transition::Multi(vec![Transition::Pop, Transition::Pop]);
                 }
                 "back" => {
                     self.idx -= 1;

--- a/game/src/devtools/mapping.rs
+++ b/game/src/devtools/mapping.rs
@@ -353,12 +353,15 @@ impl State for ParkingMapper {
                         ctx,
                         app,
                         Box::new(|ctx, app| {
-                            Transition::PopThenReplace(ParkingMapper::make(
-                                ctx,
-                                app,
-                                Show::TODO,
-                                BTreeMap::new(),
-                            ))
+                            Transition::Multi(vec![
+                                Transition::Pop,
+                                Transition::Replace(ParkingMapper::make(
+                                    ctx,
+                                    app,
+                                    Show::TODO,
+                                    BTreeMap::new(),
+                                )),
+                            ])
                         }),
                     ));
                 }
@@ -479,12 +482,15 @@ impl State for ChangeWay {
                         ))
                     } else {
                         self.data.insert(self.osm_way_id, value);
-                        Transition::PopThenReplace(ParkingMapper::make(
-                            ctx,
-                            app,
-                            self.show,
-                            self.data.clone(),
-                        ))
+                        Transition::Multi(vec![
+                            Transition::Pop,
+                            Transition::Replace(ParkingMapper::make(
+                                ctx,
+                                app,
+                                self.show,
+                                self.data.clone(),
+                            )),
+                        ])
                     }
                 }
             },

--- a/game/src/devtools/mod.rs
+++ b/game/src/devtools/mod.rs
@@ -120,7 +120,10 @@ impl State for DevToolsMode {
                         ctx,
                         app,
                         Box::new(|ctx, app| {
-                            Transition::PopThenReplace(DevToolsMode::new(ctx, app))
+                            Transition::Multi(vec![
+                                Transition::Pop,
+                                Transition::Replace(DevToolsMode::new(ctx, app)),
+                            ])
                         }),
                     ));
                 }

--- a/game/src/edit/lanes.rs
+++ b/game/src/edit/lanes.rs
@@ -22,7 +22,7 @@ pub struct LaneEditor {
 }
 
 impl LaneEditor {
-    pub fn new(ctx: &mut EventCtx, app: &App, l: LaneID, mode: GameplayMode) -> LaneEditor {
+    pub fn new(ctx: &mut EventCtx, app: &App, l: LaneID, mode: GameplayMode) -> Box<dyn State> {
         let mut row = Vec::new();
         let lt = app.primary.map.get_l(l).lane_type;
         for (icon, label, key, active) in vec![
@@ -99,7 +99,7 @@ impl LaneEditor {
             .aligned(HorizontalAlignment::Center, VerticalAlignment::Top)
             .build(ctx);
 
-        LaneEditor { l, mode, composite }
+        Box::new(LaneEditor { l, mode, composite })
     }
 }
 
@@ -125,12 +125,7 @@ impl State for LaneEditor {
         }
         if let Some(ID::Lane(l)) = app.primary.current_selection {
             if app.per_obj.left_click(ctx, "edit this lane") {
-                return Transition::Replace(Box::new(LaneEditor::new(
-                    ctx,
-                    app,
-                    l,
-                    self.mode.clone(),
-                )));
+                return Transition::Replace(LaneEditor::new(ctx, app, l, self.mode.clone()));
             }
         }
         if let Some(ID::Intersection(id)) = app.primary.current_selection {
@@ -186,12 +181,12 @@ impl State for LaneEditor {
                             edits.commands.push(cmd);
                             apply_map_edits(ctx, app, edits);
 
-                            return Transition::Replace(Box::new(LaneEditor::new(
+                            return Transition::Replace(LaneEditor::new(
                                 ctx,
                                 app,
                                 self.l,
                                 self.mode.clone(),
-                            )));
+                            ));
                         }
                         Err(err) => {
                             return Transition::Push(err);
@@ -210,12 +205,7 @@ impl State for LaneEditor {
                     old,
                 });
                 apply_map_edits(ctx, app, edits);
-                return Transition::Replace(Box::new(LaneEditor::new(
-                    ctx,
-                    app,
-                    self.l,
-                    self.mode.clone(),
-                )));
+                return Transition::Replace(LaneEditor::new(ctx, app, self.l, self.mode.clone()));
             }
             _ => {}
         }

--- a/game/src/edit/stop_signs.rs
+++ b/game/src/edit/stop_signs.rs
@@ -33,7 +33,7 @@ impl StopSignEditor {
         app: &mut App,
         id: IntersectionID,
         mode: GameplayMode,
-    ) -> StopSignEditor {
+    ) -> Box<dyn State> {
         app.primary.current_selection = None;
         let geom = app
             .primary
@@ -64,13 +64,13 @@ impl StopSignEditor {
         .aligned(HorizontalAlignment::Center, VerticalAlignment::Top)
         .build(ctx);
 
-        StopSignEditor {
+        Box::new(StopSignEditor {
             composite,
             id,
             mode,
             geom,
             selected_sign: None,
-        }
+        })
     }
 }
 
@@ -107,12 +107,12 @@ impl State for StopSignEditor {
                     new: EditIntersection::StopSign(sign),
                 });
                 apply_map_edits(ctx, app, edits);
-                return Transition::Replace(Box::new(StopSignEditor::new(
+                return Transition::Replace(StopSignEditor::new(
                     ctx,
                     app,
                     self.id,
                     self.mode.clone(),
-                )));
+                ));
             }
         }
 
@@ -132,12 +132,12 @@ impl State for StopSignEditor {
                         )),
                     });
                     apply_map_edits(ctx, app, edits);
-                    return Transition::Replace(Box::new(StopSignEditor::new(
+                    return Transition::Replace(StopSignEditor::new(
                         ctx,
                         app,
                         self.id,
                         self.mode.clone(),
-                    )));
+                    ));
                 }
                 "close intersection for construction" => {
                     let cmd = EditCmd::ChangeIntersection {

--- a/game/src/edit/traffic_signals/edits.rs
+++ b/game/src/edit/traffic_signals/edits.rs
@@ -172,7 +172,10 @@ pub fn edit_entire_signal(
                     new: EditIntersection::StopSign(ControlStopSign::new(&app.primary.map, i)),
                 });
                 apply_map_edits(ctx, app, edits);
-                Transition::PopThenReplace(Box::new(StopSignEditor::new(ctx, app, i, mode.clone())))
+                Transition::Multi(vec![
+                    Transition::Pop,
+                    Transition::Replace(StopSignEditor::new(ctx, app, i, mode.clone())),
+                ])
             }
             x if x == close => {
                 original.apply(app);
@@ -189,7 +192,7 @@ pub fn edit_entire_signal(
                     edits.commands.push(cmd);
                     apply_map_edits(ctx, app, edits);
 
-                    Transition::PopTwice
+                    Transition::Multi(vec![Transition::Pop, Transition::Pop])
                 }
             }
             x if x == reset => Transition::PopWithData(Box::new(move |state, ctx, app| {

--- a/game/src/pregame.rs
+++ b/game/src/pregame.rs
@@ -196,11 +196,11 @@ impl State for MainMenu {
                     } else {
                         "home_to_work"
                     };
-                    return Transition::Push(Box::new(SandboxMode::new(
+                    return Transition::Push(SandboxMode::new(
                         ctx,
                         app,
                         GameplayMode::PlayScenario(map_path, scenario.to_string(), Vec::new()),
-                    )));
+                    ));
                 }
                 "Challenges" => {
                     return Transition::Push(ChallengesPicker::new(ctx, app));
@@ -435,7 +435,7 @@ impl State for Proposals {
                         ));
                     } else {
                         app.layer = Some(Box::new(crate::layer::map::Static::edits(ctx, app)));
-                        return Transition::Push(Box::new(SandboxMode::new(
+                        return Transition::Push(SandboxMode::new(
                             ctx,
                             app,
                             GameplayMode::PlayScenario(
@@ -443,7 +443,7 @@ impl State for Proposals {
                                 "weekday".to_string(),
                                 Vec::new(),
                             ),
-                        )));
+                        ));
                     }
                 }
                 "Read detailed write-up" => {

--- a/game/src/sandbox/gameplay/fix_traffic_signals.rs
+++ b/game/src/sandbox/gameplay/fix_traffic_signals.rs
@@ -158,16 +158,16 @@ impl GameplayState for FixTrafficSignals {
                     .aligned(HorizontalAlignment::Center, VerticalAlignment::Top)
                     .build(ctx);
 
-                    return Some(Transition::PushTwice(
-                        final_score(ctx, app, self.mode.clone(), true),
-                        Warping::new(
+                    return Some(Transition::Multi(vec![
+                        Transition::Push(final_score(ctx, app, self.mode.clone(), true)),
+                        Transition::Push(Warping::new(
                             ctx,
                             ID::Intersection(i).canonical_point(&app.primary).unwrap(),
                             Some(10.0),
                             None,
                             &mut app.primary,
-                        ),
-                    ));
+                        )),
+                    ]));
                 }
             } else {
                 self.meter = make_meter(ctx, app, None);
@@ -216,11 +216,11 @@ impl GameplayState for FixTrafficSignals {
                     return Some(Transition::Push(FYI::new(ctx, contents, app.cs.panel_bg)));
                 }
                 "try again" => {
-                    return Some(Transition::Replace(Box::new(SandboxMode::new(
+                    return Some(Transition::Replace(SandboxMode::new(
                         ctx,
                         app,
                         self.mode.clone(),
-                    ))));
+                    )));
                 }
                 _ => unreachable!(),
             },

--- a/game/src/sandbox/gameplay/freeform.rs
+++ b/game/src/sandbox/gameplay/freeform.rs
@@ -49,11 +49,14 @@ impl GameplayState for Freeform {
                         Box::new(|ctx, app| {
                             // The map will be switched before this callback happens.
                             let path = abstutil::path_map(app.primary.map.get_name());
-                            Transition::PopThenReplace(Box::new(SandboxMode::new(
-                                ctx,
-                                app,
-                                GameplayMode::Freeform(path),
-                            )))
+                            Transition::Multi(vec![
+                                Transition::Pop,
+                                Transition::Replace(SandboxMode::new(
+                                    ctx,
+                                    app,
+                                    GameplayMode::Freeform(path),
+                                )),
+                            ])
                         }),
                     )))
                 }
@@ -163,15 +166,18 @@ pub fn make_change_traffic(
         choices,
         Box::new(|scenario_name, ctx, app| {
             let map_path = abstutil::path_map(app.primary.map.get_name());
-            Transition::PopThenReplace(Box::new(SandboxMode::new(
-                ctx,
-                app,
-                if scenario_name == "none" {
-                    GameplayMode::Freeform(map_path)
-                } else {
-                    GameplayMode::PlayScenario(map_path, scenario_name, Vec::new())
-                },
-            )))
+            Transition::Multi(vec![
+                Transition::Pop,
+                Transition::Replace(SandboxMode::new(
+                    ctx,
+                    app,
+                    if scenario_name == "none" {
+                        GameplayMode::Freeform(map_path)
+                    } else {
+                        GameplayMode::PlayScenario(map_path, scenario_name, Vec::new())
+                    },
+                )),
+            ])
         }),
     )
 }

--- a/game/src/sandbox/gameplay/mod.rs
+++ b/game/src/sandbox/gameplay/mod.rs
@@ -355,11 +355,10 @@ impl State for FinalScore {
                     return Transition::Pop;
                 }
                 "Try again" => {
-                    return Transition::PopThenReplace(Box::new(SandboxMode::new(
-                        ctx,
-                        app,
-                        self.retry.clone(),
-                    )));
+                    return Transition::Multi(vec![
+                        Transition::Pop,
+                        Transition::Replace(SandboxMode::new(ctx, app, self.retry.clone())),
+                    ]);
                 }
                 "Next challenge" => {
                     self.chose_next = true;
@@ -406,7 +405,7 @@ impl State for FinalScore {
         if self.chose_next {
             return Transition::Clear(vec![
                 MainMenu::new(ctx, app),
-                Box::new(SandboxMode::new(ctx, app, self.next_mode.clone().unwrap())),
+                SandboxMode::new(ctx, app, self.next_mode.clone().unwrap()),
                 (Challenge::find(self.next_mode.as_ref().unwrap())
                     .0
                     .cutscene

--- a/game/src/sandbox/gameplay/play_scenario.rs
+++ b/game/src/sandbox/gameplay/play_scenario.rs
@@ -65,7 +65,10 @@ impl GameplayState for PlayScenario {
                             } else {
                                 GameplayMode::Freeform(path)
                             };
-                            Transition::PopThenReplace(Box::new(SandboxMode::new(ctx, app, mode)))
+                            Transition::Multi(vec![
+                                Transition::Pop,
+                                Transition::Replace(SandboxMode::new(ctx, app, mode)),
+                            ])
                         }),
                     )))
                 }
@@ -222,15 +225,18 @@ impl State for EditScenarioModifiers {
                     return Transition::Pop;
                 }
                 "Apply" => {
-                    return Transition::PopThenReplace(Box::new(SandboxMode::new(
-                        ctx,
-                        app,
-                        GameplayMode::PlayScenario(
-                            abstutil::path_map(&app.primary.map.get_name()),
-                            self.scenario_name.clone(),
-                            self.modifiers.clone(),
-                        ),
-                    )));
+                    return Transition::Multi(vec![
+                        Transition::Pop,
+                        Transition::Replace(SandboxMode::new(
+                            ctx,
+                            app,
+                            GameplayMode::PlayScenario(
+                                abstutil::path_map(&app.primary.map.get_name()),
+                                self.scenario_name.clone(),
+                                self.modifiers.clone(),
+                            ),
+                        )),
+                    ]);
                 }
                 "Change trip mode" => {
                     return Transition::Push(ChangeMode::new(
@@ -387,11 +393,14 @@ impl State for ChangeMode {
                         departure_filter,
                         from_modes,
                     });
-                    Transition::PopThenReplace(EditScenarioModifiers::new(
-                        ctx,
-                        self.scenario_name.clone(),
-                        mods,
-                    ))
+                    Transition::Multi(vec![
+                        Transition::Pop,
+                        Transition::Replace(EditScenarioModifiers::new(
+                            ctx,
+                            self.scenario_name.clone(),
+                            mods,
+                        )),
+                    ])
                 }
                 _ => unreachable!(),
             },

--- a/game/src/sandbox/gameplay/tutorial.rs
+++ b/game/src/sandbox/gameplay/tutorial.rs
@@ -49,8 +49,8 @@ impl TutorialPointer {
 
 impl Tutorial {
     pub fn start(ctx: &mut EventCtx, app: &mut App) -> Transition {
-        Transition::PushTwice(
-            Box::new(SandboxMode::new(
+        Transition::Multi(vec![
+            Transition::Push(SandboxMode::new(
                 ctx,
                 app,
                 GameplayMode::Tutorial(
@@ -61,8 +61,8 @@ impl Tutorial {
                         .unwrap_or(TutorialPointer::new(0, 0)),
                 ),
             )),
-            intro_story(ctx, app),
-        )
+            Transition::Push(intro_story(ctx, app)),
+        ])
     }
 
     pub fn new(
@@ -656,7 +656,7 @@ fn make_bike_lane_scenario(map: &Map) -> ScenarioGenerator {
 fn transition(ctx: &mut EventCtx, app: &mut App, tut: &mut TutorialState) -> Transition {
     tut.reset_state();
     let mode = GameplayMode::Tutorial(tut.current);
-    Transition::Replace(Box::new(SandboxMode::new(ctx, app, mode)))
+    Transition::Replace(SandboxMode::new(ctx, app, mode))
 }
 
 impl TutorialState {

--- a/game/src/sandbox/speed.rs
+++ b/game/src/sandbox/speed.rs
@@ -175,11 +175,11 @@ impl SpeedControls {
                 }
                 "reset to midnight" => {
                     if let Some(mode) = maybe_mode {
-                        return Some(Transition::Replace(Box::new(SandboxMode::new(
+                        return Some(Transition::Replace(SandboxMode::new(
                             ctx,
                             app,
                             mode.clone(),
-                        ))));
+                        )));
                     } else {
                         return Some(Transition::Push(PopupMsg::new(
                             ctx,
@@ -307,16 +307,16 @@ impl SpeedControls {
             self.pause(ctx, app);
             if let Some(id) = maybe_id {
                 // Just go to the first one, but print all messages
-                return Some(Transition::PushTwice(
-                    popup,
-                    Warping::new(
+                return Some(Transition::Multi(vec![
+                    Transition::Push(popup),
+                    Transition::Push(Warping::new(
                         ctx,
                         id.canonical_point(&app.primary).unwrap(),
                         Some(10.0),
                         None,
                         &mut app.primary,
-                    ),
-                ));
+                    )),
+                ]));
             } else {
                 return Some(Transition::Push(popup));
             }
@@ -425,10 +425,10 @@ impl State for JumpToTime {
                 "jump to time" => {
                     if self.target < app.primary.sim.time() {
                         if let Some(mode) = self.maybe_mode.take() {
-                            return Transition::ReplaceThenPush(
-                                Box::new(SandboxMode::new(ctx, app, mode)),
-                                TimeWarpScreen::new(ctx, app, self.target, false),
-                            );
+                            return Transition::Multi(vec![
+                                Transition::Replace(SandboxMode::new(ctx, app, mode)),
+                                Transition::Push(TimeWarpScreen::new(ctx, app, self.target, false)),
+                            ]);
                         } else {
                             return Transition::Replace(PopupMsg::new(
                                 ctx,


### PR DESCRIPTION
combining primitive transitions into sequences.

Brief context on the state/transition system: The game crate is
organized as a stack of states, with the topmost one being active.
Transitions manipulate this stack. For example, the stack might look
like: [main menu, sandbox mode, edit mode, traffic signal editor, signal
picker]

@michaelkirk 