### PR TITLE
Fix HiDPI screens for wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -794,7 +794,7 @@ dependencies = [
  "ttf-parser 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "usvg 0.11.0 (git+https://github.com/RazrFalcon/resvg)",
  "webgl_stdweb 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winit 0.22.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winit 0.22.2 (git+https://github.com/michaelkirk/winit?branch=mkirk/fix-stdweb-dpi)",
 ]
 
 [[package]]
@@ -3761,7 +3761,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "winit"
 version = "0.22.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/michaelkirk/winit?branch=mkirk/fix-stdweb-dpi#6b61263293b72a76d46c14ba2abfef92e5a0bd75"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cocoa 0.20.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3784,6 +3784,36 @@ dependencies = [
  "raw-window-handle 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smithay-client-toolkit 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "stdweb 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-client 0.23.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "x11-dl 2.18.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winit"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cocoa 0.20.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-video-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dispatch 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "instant 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio-extras 2.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ndk 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ndk-glue 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ndk-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "raw-window-handle 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smithay-client-toolkit 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-client 0.23.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "x11-dl 2.18.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4277,6 +4307,7 @@ dependencies = [
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-util 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "fa515c5163a99cc82bab70fd3bfdd36d827be85de63737b40fcef2ce084a436e"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+"checksum winit 0.22.2 (git+https://github.com/michaelkirk/winit?branch=mkirk/fix-stdweb-dpi)" = "<none>"
 "checksum winit 0.22.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1e4ccbf7ddb6627828eace16cacde80fc6bf4dbb3469f88487262a02cf8e7862"
 "checksum winreg 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"

--- a/ezgui/Cargo.toml
+++ b/ezgui/Cargo.toml
@@ -29,7 +29,7 @@ stretch = "0.3.2"
 ttf-parser = "0.6.1"
 usvg = { git = "https://github.com/RazrFalcon/resvg", default-features=false }
 webgl_stdweb = { version = "0.3", optional = true }
-winit = "0.22.2"
+winit = { version = "0.22.2", git = "https://github.com/michaelkirk/winit", branch = "mkirk/fix-stdweb-dpi" }
 
 [dev-dependencies]
 rand = "0.7.0"


### PR DESCRIPTION
Addresses an upstream winit bug, you can see the fix here: https://github.com/rust-windowing/winit/compare/master...michaelkirk:mkirk/fix-stdweb-dpi?expand=1

@dabreegster - can you do a sanity check to make sure this looks good on your device, then I'll open an upstream PR with winit.

**before**

![before mov](https://user-images.githubusercontent.com/217057/90291578-0f53bb00-de35-11ea-9265-3bead840be38.gif)**

You can see how things look good initially, but then gets wonky because the logical size, which is set in css style, gets clobbered when setting the cursor style.

**after**

![after mov](https://user-images.githubusercontent.com/217057/90291569-0d89f780-de35-11ea-82fe-18607c335839.gif)

Not sure if you'd want to merge this reference to my winit fork or prefer to wait 'til a fix is upstreamed. Note it also includes a few unreleased winit commits from HEAD.