### PR TITLE
In traffic=none mode, allow recording (most of) the manually specified

### DIFF
--- a/sim/src/sim.rs
+++ b/sim/src/sim.rs
@@ -3,9 +3,9 @@ use crate::{
     AgentID, AgentType, AlertLocation, Analytics, CarID, Command, CreateCar, DrawCarInput,
     DrawPedCrowdInput, DrawPedestrianInput, DrivingSimState, Event, GetDrawAgents,
     IntersectionSimState, OrigPersonID, PandemicModel, ParkedCar, ParkingSimState, ParkingSpot,
-    PedestrianID, Person, PersonID, PersonState, Router, Scheduler, SidewalkPOI, SidewalkSpot,
-    TransitSimState, TripID, TripInfo, TripManager, TripPhaseType, TripResult, TripSpawner,
-    UnzoomedAgent, Vehicle, VehicleSpec, VehicleType, WalkingSimState, BUS_LENGTH,
+    PedestrianID, Person, PersonID, PersonState, Router, Scenario, Scheduler, SidewalkPOI,
+    SidewalkSpot, TransitSimState, TripID, TripInfo, TripManager, TripPhaseType, TripResult,
+    TripSpawner, UnzoomedAgent, Vehicle, VehicleSpec, VehicleType, WalkingSimState, BUS_LENGTH,
     LIGHT_RAIL_LENGTH, MIN_CAR_LENGTH, SPAWN_DIST,
 };
 use abstutil::{prettyprint_usize, serialized_size_bytes, Counter, Parallelism, Timer};
@@ -1191,6 +1191,10 @@ impl Sim {
         at: BusStopID,
     ) -> &Vec<(PedestrianID, BusRouteID, Option<BusStopID>, Time)> {
         self.transit.get_people_waiting_at_stop(at)
+    }
+
+    pub fn generate_scenario(&self, map: &Map, name: String) -> Scenario {
+        self.trips.generate_scenario(map, name)
     }
 }
 


### PR DESCRIPTION
trips as a Scenario to later re-run. This is useful for quickly defining
"test cases" for development, and it's a start to a UI for letting
players specify (and eventually share) traffic patterns they define.

![screencast](https://user-images.githubusercontent.com/1664407/90295053-cdc70e00-de3c-11ea-9081-f2fce8c67203.gif)

@michaelkirk 