### PR TITLE
Prototype offset editing

### DIFF
--- a/game/src/edit/traffic_signals/mod.rs
+++ b/game/src/edit/traffic_signals/mod.rs
@@ -12,7 +12,8 @@ use crate::sandbox::GameplayMode;
 use abstutil::Timer;
 use ezgui::{
     hotkey, lctrl, Btn, Color, Composite, Drawable, EventCtx, GeomBatch, GfxCtx,
-    HorizontalAlignment, Key, Line, Outcome, RewriteColor, Text, VerticalAlignment, Widget,
+    HorizontalAlignment, Key, Line, Outcome, RewriteColor, Spinner, Text, TextExt,
+    VerticalAlignment, Widget,
 };
 use geom::{ArrowCap, Bounds, Distance, Duration, Polygon};
 use map_model::{
@@ -239,6 +240,13 @@ impl State for TrafficSignalEditor {
                 if x == "Add new phase" {
                     self.add_new_edit(ctx, app, num_phases, |ts| {
                         ts.phases.push(Phase::new());
+                    });
+                    return Transition::Keep;
+                }
+                if x == "Apply offset" {
+                    let offset = Duration::seconds(self.side_panel.spinner("offset") as f64);
+                    self.add_new_edit(ctx, app, self.current_phase, |ts| {
+                        ts.offset = offset;
                     });
                     return Transition::Keep;
                 }
@@ -556,6 +564,16 @@ fn make_side_panel(
     ];
     if members.len() == 1 {
         col.push(Btn::text_bg2("Edit entire signal").build_def(ctx, hotkey(Key::E)));
+        col.push(Widget::row(vec![
+            "Offset (s):".draw_text(ctx),
+            Spinner::new(
+                ctx,
+                (0, 90),
+                canonical_signal.offset.inner_seconds() as isize,
+            )
+            .named("offset"),
+            Btn::text_bg2("Apply").build(ctx, "Apply offset", None),
+        ]));
     }
 
     for (idx, canonical_phase) in canonical_signal.phases.iter().enumerate() {

--- a/sim/src/mechanics/intersection.rs
+++ b/sim/src/mechanics/intersection.rs
@@ -84,7 +84,9 @@ impl IntersectionSimState {
                 // What phase are we starting with?
                 let mut offset = signal.offset;
                 loop {
-                    let dt = signal.phases[state.current_phase].phase_type.simple_duration();
+                    let dt = signal.phases[state.current_phase]
+                        .phase_type
+                        .simple_duration();
                     if offset >= dt {
                         offset -= dt;
                         state.current_phase += 1;


### PR DESCRIPTION
@michaelkirk: The offset between two traffic signals lets you create "green wave", delaying one signal relative to another. This is a very primitive first attempt at editing offsets:
![Screenshot from 2020-08-14 17-35-04](https://user-images.githubusercontent.com/1664407/90301484-08d53b80-de55-11ea-96c2-9e38dcf96b92.png)
It has many problems, but it's a start. I don't yet have any clear ideas for something better. Ideally there'd be a way to see the best-case time (distance / speed) between any two signals for a certain mode (green wave for pedestrians?!). Offset as shown now is absolute, but really is more meaningful to display relative to other signals. And offset, I think, is directional -- you could turn a light green right as westbound traffic hits an intersection, but then doing the same thing as the eastbound traffic hits the other is... tricky.

Some potential ideas for next steps: https://trafficdean.wordpress.com/2018/03/07/offset-in-traffic-signal-timing/, https://en.wikipedia.org/wiki/Traffic_light_control_and_coordination#Coordinated_control. The time/space diagram is _kind of_ intuitive to me.