### PR TITLE
Fix glow backend on mac

### DIFF
--- a/ezgui/src/shaders/fragment_140.glsl
+++ b/ezgui/src/shaders/fragment_140.glsl
@@ -1,4 +1,4 @@
-#version 140
+#version 410
 
 // (x offset, y offset, zoom)
 uniform vec3 transform;

--- a/ezgui/src/shaders/vertex_140.glsl
+++ b/ezgui/src/shaders/vertex_140.glsl
@@ -1,12 +1,12 @@
-#version 140
+#version 410
 
 // (x offset, y offset, zoom)
 uniform vec3 transform;
 // (window width, window height, z value)
 uniform vec3 window;
 
-in vec2 position;
-in vec4 style;
+layout (location = 0) in vec2 position;
+layout (location = 1) in vec4 style;
 out vec4 pass_style;
 
 void main() {
@@ -15,7 +15,7 @@ void main() {
     // This is map_to_screen
     float screen_x = (position[0] * transform[2]) - transform[0];
     float screen_y = (position[1] * transform[2]) - transform[1];
-    // Translate that to clip-space or whatever it's called
+    // Translate that to normalized device coordinates (NDC)
     float x = (screen_x / window[0] * 2.0) - 1.0;
     float y = (screen_y / window[1] * 2.0) - 1.0;
 


### PR DESCRIPTION
Without this change, the screen was blank when using the glow backend on macos.

Some debugging traced it down to the shader attribute configuration.
@dabreegster suggested trying to declare a newer version of the shader
language which supports the syntax for explicit attribute layout, which
fixed it.

Tested both glow and glium backends for both the game and the ezgui example on my macos.

@dabreegster can you test on your device before merging?