### PR TITLE
The JSON format for the map edits changes occasionally. Be backwards

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1810,6 +1810,7 @@ dependencies = [
  "rand_xorshift 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "seattle_traffic_signals 0.1.0 (git+https://github.com/dabreegster/seattle_traffic_signals)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/map_model/Cargo.toml
+++ b/map_model/Cargo.toml
@@ -17,3 +17,4 @@ rand_xorshift = "0.2.0"
 serde = "1.0.110"
 thread_local = "1.0.1"
 seattle_traffic_signals = { git = "https://github.com/dabreegster/seattle_traffic_signals" }
+serde_json = "1.0.40"

--- a/map_model/src/edits/compat.rs
+++ b/map_model/src/edits/compat.rs
@@ -1,0 +1,67 @@
+use crate::PermanentMapEdits;
+use serde_json::Value;
+
+// When the PermanentMapEdits format changes, add a transformation here to automatically convert
+// edits written with the old format.
+//
+// This problem is often solved with something like protocol buffers, but the resulting proto
+// usually winds up with permanent legacy fields, unless the changes are purely additive. For
+// example, protobufs wouldn't have helped with the fix_intersection_ids problem. Explicit
+// transformation is easier!
+pub fn upgrade(mut value: Value) -> Result<PermanentMapEdits, String> {
+    // I don't remember the previous schema change before this. If someone files a bug and has an
+    // older file, can add support for it then.
+    fix_offset(&mut value);
+    fix_intersection_ids(&mut value);
+
+    abstutil::from_json(&value.to_string().into_bytes()).map_err(|x| x.to_string())
+}
+
+// eee179ce8a6c1e6133dc212b73c3f79b11603e82 added an offset_seconds field
+fn fix_offset(value: &mut Value) {
+    match value {
+        Value::Array(list) => {
+            for x in list {
+                fix_offset(x);
+            }
+        }
+        Value::Object(map) => {
+            if map.len() == 1 && map.contains_key("TrafficSignal") {
+                let ts = map
+                    .get_mut("TrafficSignal")
+                    .unwrap()
+                    .as_object_mut()
+                    .unwrap();
+                if ts.get("offset_seconds").is_none() {
+                    ts.insert("offset_seconds".to_string(), Value::Number(0.into()));
+                }
+            } else {
+                for x in map.values_mut() {
+                    fix_offset(x);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+// 11cefb118ab353d2e7fa5dceaab614a9b775e6ec changed { "osm_node_id": 123 } to just 123
+fn fix_intersection_ids(value: &mut Value) {
+    match value {
+        Value::Array(list) => {
+            for x in list {
+                fix_intersection_ids(x);
+            }
+        }
+        Value::Object(map) => {
+            if map.len() == 1 && map.contains_key("osm_node_id") {
+                *value = Value::Number(map["osm_node_id"].as_i64().unwrap().into());
+            } else {
+                for x in map.values_mut() {
+                    fix_intersection_ids(x);
+                }
+            }
+        }
+        _ => {}
+    }
+}

--- a/map_model/src/edits/perma.rs
+++ b/map_model/src/edits/perma.rs
@@ -272,7 +272,12 @@ impl OriginalLane {
         let r = map.get_r(map.find_r_by_osm_id(self.parent)?);
         if r.children_forwards.len() != self.num_fwd || r.children_backwards.len() != self.num_back
         {
-            return Err(format!("number of lanes has changed in {:?}", self));
+            return Err(format!(
+                "number of lanes has changed in {:?} to {} fwd, {} back",
+                self,
+                r.children_forwards.len(),
+                r.children_backwards.len()
+            ));
         }
         Ok(r.children(self.fwd)[self.idx].0)
     }


### PR DESCRIPTION
compatible with old edits, automatically transforming them to match the
new format. Part of #216 and necessary to work on #234.

@michaelkirk 