### PR TITLE
Record throughput through a traffic signal by direction, expose through

### DIFF
--- a/book/src/api.md
+++ b/book/src/api.md
@@ -34,6 +34,9 @@ are missing, etc. A summary of the commands available so far:
   - **GET /traffic-signals/get-delays?id=42&t1=03:00:00&t2=03:30:00**: Returns
     the delay experienced by every agent passing through intersection #42 from
     3am to 3:30, grouped by direction of travel.
+  - **GET /traffic-signals/get-cumulative-thruput?id=42**: Returns the number of
+    agents passing through intersection #42 since midnight, grouped by direction
+    of travel.
 - **/data**
   - **GET /data/get-finished-trips**: Returns a JSON list of all finished trips.
     Each tuple is (time the trip finished in seconds after midnight, trip ID,

--- a/data/MANIFEST.txt
+++ b/data/MANIFEST.txt
@@ -73,9 +73,9 @@ data/system/maps/south_seattle.bin,87815aaddcc294c0cd30f0b7db97d0d4,https://www.
 data/system/maps/udistrict.bin,ae9163526dcd1b4f15d4cee2b3a2f91f,https://www.dropbox.com/s/hb6yxpvkums7mtt/udistrict.bin.zip?dl=0
 data/system/maps/west_seattle.bin,d91214290adac1f8d8db63f6d680f2d1,https://www.dropbox.com/s/qk0kxreqjpoghwh/west_seattle.bin.zip?dl=0
 data/system/maps/xian.bin,dcb681858c2f4723a4c09b0ebafcc38f,https://www.dropbox.com/s/qxtwswze0o93w3p/xian.bin.zip?dl=0
-data/system/prebaked_results/lakeslice/weekday.bin,364abba838c51f1ecc94738878c6ec9c,https://www.dropbox.com/s/jwy9gnak0g81qoz/weekday.bin.zip?dl=0
-data/system/prebaked_results/montlake/car vs bike contention.bin,faa041af70a41bb8fcacd3dfd7a7d467,https://www.dropbox.com/s/jefg0ikjy9dsrdd/car%20vs%20bike%20contention.bin.zip?dl=0
-data/system/prebaked_results/montlake/weekday.bin,3d2e502d13b995ebd3de4682ae41207a,https://www.dropbox.com/s/wxi268ft3iuhco4/weekday.bin.zip?dl=0
+data/system/prebaked_results/lakeslice/weekday.bin,6f5a5b9076fb4f47c3e2d9870c020167,https://www.dropbox.com/s/tzzxxu4575wnapl/weekday.bin.zip?dl=0
+data/system/prebaked_results/montlake/car vs bike contention.bin,8002ad9207bda6a2fc20594f413a8c2e,https://www.dropbox.com/s/jefg0ikjy9dsrdd/car%20vs%20bike%20contention.bin.zip?dl=0
+data/system/prebaked_results/montlake/weekday.bin,c483c6734087c76630cdf652882dc440,https://www.dropbox.com/s/rvhek1pbwnf7t2e/weekday.bin.zip?dl=0
 data/system/scenarios/ballard/weekday.bin,8fba0bf4e623552d75c27e9c210ce469,https://www.dropbox.com/s/62pwtz3pn098v84/weekday.bin.zip?dl=0
 data/system/scenarios/downtown/weekday.bin,d789b5b7fe2a536f65ae330abb575823,https://www.dropbox.com/s/2ia9ssy9gza86sw/weekday.bin.zip?dl=0
 data/system/scenarios/huge_seattle/weekday.bin,9892f03c2998b3661384f086dbc6c4bb,https://www.dropbox.com/s/hk3sr90owfr3hzc/weekday.bin.zip?dl=0

--- a/game/src/app.rs
+++ b/game/src/app.rs
@@ -106,6 +106,10 @@ impl App {
                     prettyprint_usize(serialized_size_bytes(&a.intersection_thruput))
                 );
                 println!(
+                    "- traffic_signal_thruput: {} bytes",
+                    prettyprint_usize(serialized_size_bytes(&a.traffic_signal_thruput))
+                );
+                println!(
                     "- demand : {} bytes",
                     prettyprint_usize(serialized_size_bytes(&a.demand))
                 );


### PR DESCRIPTION
the API (#288), and beef up the Python example.

Impact to prebaked file size is tiny -- for lakeslice, the original
intersection_thruput is 2MB and the new traffic_signal_thruput is 435KB.

@michaelkirk 