### PR TITLE
Represent edits to a road in a more robust way

### DIFF
--- a/game/src/edit/bulk.rs
+++ b/game/src/edit/bulk.rs
@@ -172,11 +172,10 @@ impl State for BulkEdit {
                     let speed = self.composite.dropdown_value("speed limit");
                     let mut edits = app.primary.map.get_edits().clone();
                     for r in &self.roads {
-                        edits.commands.push(EditCmd::ChangeSpeedLimit {
-                            id: *r,
-                            new: speed,
-                            old: app.primary.map.get_r(*r).speed_limit,
-                        });
+                        let old = app.primary.map.get_r_edit(*r);
+                        let mut new = old.clone();
+                        new.speed_limit = speed;
+                        edits.commands.push(EditCmd::ChangeRoad { r: *r, old, new });
                     }
                     apply_map_edits(ctx, app, edits);
                     return Transition::Keep;

--- a/game/src/edit/lanes.rs
+++ b/game/src/edit/lanes.rs
@@ -87,9 +87,8 @@ impl LaneEditor {
             Widget::custom_row(vec![
                 Btn::text_fg("Finish").build_def(ctx, hotkey(Key::Escape)),
                 // TODO Handle reverting speed limit too...
-                if app.primary.map.get_edits().original_lts.contains_key(&l)
-                    || app.primary.map.get_edits().reversed_lanes.contains(&l)
-                {
+                // TODO Woops, we need an easy way to figure this out
+                if false {
                     Btn::text_fg("Revert").build_def(ctx, hotkey(Key::R))
                 } else {
                     Btn::text_fg("Revert").inactive(ctx)
@@ -153,12 +152,7 @@ impl State for LaneEditor {
                     let map = &mut app.primary.map;
                     let result = match x {
                         "Revert" => {
-                            // TODO It's hard to revert both changes at once.
-                            if let Some(lt) = map.get_edits().original_lts.get(&self.l).cloned() {
-                                try_change_lt(ctx, map, self.l, lt)
-                            } else {
-                                try_reverse(ctx, map, self.l)
-                            }
+                            panic!("need to implement this again");
                         }
                         "reverse lane direction" => try_reverse(ctx, map, self.l),
                         "convert to a driving lane" => {

--- a/game/src/edit/lanes.rs
+++ b/game/src/edit/lanes.rs
@@ -198,15 +198,12 @@ impl State for LaneEditor {
                 }
             },
             Outcome::Changed => {
-                let parent = app.primary.map.get_parent(self.l);
-                let new = self.composite.dropdown_value("speed limit");
-                let old = parent.speed_limit;
+                let r = app.primary.map.get_l(self.l).parent;
+                let old = app.primary.map.get_r_edit(r);
+                let mut new = old.clone();
+                new.speed_limit = self.composite.dropdown_value("speed limit");
                 let mut edits = app.primary.map.get_edits().clone();
-                edits.commands.push(EditCmd::ChangeSpeedLimit {
-                    id: parent.id,
-                    new,
-                    old,
-                });
+                edits.commands.push(EditCmd::ChangeRoad { r, new, old });
                 apply_map_edits(ctx, app, edits);
                 return Transition::Replace(LaneEditor::new(ctx, app, self.l, self.mode.clone()));
             }

--- a/game/src/edit/lanes.rs
+++ b/game/src/edit/lanes.rs
@@ -84,17 +84,7 @@ impl LaneEditor {
             Widget::custom_row(row).centered(),
             change_speed_limit(ctx, parent.speed_limit),
             Btn::text_fg("Change access restrictions").build_def(ctx, hotkey(Key::A)),
-            Widget::custom_row(vec![
-                Btn::text_fg("Finish").build_def(ctx, hotkey(Key::Escape)),
-                // TODO Handle reverting speed limit too...
-                // TODO Woops, we need an easy way to figure this out
-                if false {
-                    Btn::text_fg("Revert").build_def(ctx, hotkey(Key::R))
-                } else {
-                    Btn::text_fg("Revert").inactive(ctx)
-                },
-            ])
-            .centered(),
+            Btn::text_bg2("Finish").build_def(ctx, hotkey(Key::Escape)),
         ];
 
         let composite = Composite::new(Widget::col(col))
@@ -151,9 +141,6 @@ impl State for LaneEditor {
                 x => {
                     let map = &mut app.primary.map;
                     let result = match x {
-                        "Revert" => {
-                            panic!("need to implement this again");
-                        }
                         "reverse lane direction" => try_reverse(ctx, map, self.l),
                         "convert to a driving lane" => {
                             try_change_lt(ctx, map, self.l, LaneType::Driving)

--- a/game/src/edit/mod.rs
+++ b/game/src/edit/mod.rs
@@ -712,7 +712,7 @@ fn make_changelist(ctx: &mut EventCtx, app: &App) -> Composite {
             Btn::text_fg("Autosaved!").inactive(ctx)
         },
         Text::from_multiline(vec![
-            Line(format!("{} roads changed", edits.original_roads.len())),
+            Line(format!("{} roads changed", edits.changed_roads.len())),
             Line(format!(
                 "{} intersections changed",
                 edits.original_intersections.len()

--- a/game/src/edit/mod.rs
+++ b/game/src/edit/mod.rs
@@ -722,6 +722,7 @@ fn make_changelist(ctx: &mut EventCtx, app: &App) -> Composite {
                 "{} access restrictions changed",
                 edits.changed_access_restrictions.len()
             )),
+            Line(format!("{} roads changed", edits.original_roads.len())),
             Line(format!(
                 "{} intersections changed",
                 edits.original_intersections.len()

--- a/game/src/edit/mod.rs
+++ b/game/src/edit/mod.rs
@@ -712,16 +712,6 @@ fn make_changelist(ctx: &mut EventCtx, app: &App) -> Composite {
             Btn::text_fg("Autosaved!").inactive(ctx)
         },
         Text::from_multiline(vec![
-            Line(format!("{} lane types changed", edits.original_lts.len())),
-            Line(format!("{} lanes reversed", edits.reversed_lanes.len())),
-            Line(format!(
-                "{} speed limits changed",
-                edits.changed_speed_limits.len()
-            )),
-            Line(format!(
-                "{} access restrictions changed",
-                edits.changed_access_restrictions.len()
-            )),
             Line(format!("{} roads changed", edits.original_roads.len())),
             Line(format!(
                 "{} intersections changed",
@@ -752,12 +742,8 @@ fn make_changelist(ctx: &mut EventCtx, app: &App) -> Composite {
 // TODO Ideally a Tab.
 fn cmd_to_id(cmd: &EditCmd) -> Option<ID> {
     match cmd {
-        EditCmd::ChangeLaneType { id, .. } => Some(ID::Lane(*id)),
-        EditCmd::ReverseLane { l, .. } => Some(ID::Lane(*l)),
-        EditCmd::ChangeSpeedLimit { id, .. } => Some(ID::Road(*id)),
         EditCmd::ChangeRoad { r, .. } => Some(ID::Road(*r)),
         EditCmd::ChangeIntersection { i, .. } => Some(ID::Intersection(*i)),
-        EditCmd::ChangeAccessRestrictions { id, .. } => Some(ID::Road(*id)),
         EditCmd::ChangeRouteSchedule { .. } => None,
     }
 }

--- a/game/src/edit/mod.rs
+++ b/game/src/edit/mod.rs
@@ -480,17 +480,24 @@ impl State for LoadEdits {
                             }
                             // TODO Hack. Have to replace ourselves, because the Menu might be
                             // invalidated now that something was chosen.
-                            Err(err) => Transition::Multi(vec![
-                                Transition::Replace(LoadEdits::new(ctx, app, self.mode.clone())),
-                                // TODO Menu draws at a weird Z-order to deal with tooltips, so now
-                                // the menu underneath bleeds
-                                // through
-                                Transition::Push(PopupMsg::new(
-                                    ctx,
-                                    "Error",
-                                    vec![format!("Can't load {}", path), err.clone()],
-                                )),
-                            ]),
+                            Err(err) => {
+                                println!("Can't load {}: {}", path, err);
+                                Transition::Multi(vec![
+                                    Transition::Replace(LoadEdits::new(
+                                        ctx,
+                                        app,
+                                        self.mode.clone(),
+                                    )),
+                                    // TODO Menu draws at a weird Z-order to deal with tooltips, so
+                                    // now the menu underneath
+                                    // bleeds through
+                                    Transition::Push(PopupMsg::new(
+                                        ctx,
+                                        "Error",
+                                        vec![format!("Can't load {}", path), err.clone()],
+                                    )),
+                                ])
+                            }
                         }
                     }
                 }
@@ -747,6 +754,7 @@ fn cmd_to_id(cmd: &EditCmd) -> Option<ID> {
         EditCmd::ChangeLaneType { id, .. } => Some(ID::Lane(*id)),
         EditCmd::ReverseLane { l, .. } => Some(ID::Lane(*l)),
         EditCmd::ChangeSpeedLimit { id, .. } => Some(ID::Road(*id)),
+        EditCmd::ChangeRoad { r, .. } => Some(ID::Road(*r)),
         EditCmd::ChangeIntersection { i, .. } => Some(ID::Intersection(*i)),
         EditCmd::ChangeAccessRestrictions { id, .. } => Some(ID::Road(*id)),
         EditCmd::ChangeRouteSchedule { .. } => None,

--- a/game/src/layer/map.rs
+++ b/game/src/layer/map.rs
@@ -224,7 +224,7 @@ impl Static {
         let edits = app.primary.map.get_edits();
         // TODO Actually this loses tons of information; we really should highlight just the
         // changed lanes
-        for r in edits.original_roads.keys() {
+        for r in &edits.changed_roads {
             colorer.add_r(*r, "modified road/intersection");
         }
         for i in edits.original_intersections.keys() {
@@ -237,7 +237,7 @@ impl Static {
             "map edits",
             format!("Map edits ({})", edits.edits_name),
             Text::from_multiline(vec![
-                Line(format!("{} roads changed", edits.original_roads.len())),
+                Line(format!("{} roads changed", edits.changed_roads.len())),
                 Line(format!(
                     "{} intersections changed",
                     edits.original_intersections.len()

--- a/game/src/layer/map.rs
+++ b/game/src/layer/map.rs
@@ -251,6 +251,7 @@ impl Static {
                     "{} access restrictions changed",
                     edits.changed_access_restrictions.len()
                 )),
+                Line(format!("{} roads changed", edits.original_roads.len())),
                 Line(format!(
                     "{} intersections changed",
                     edits.original_intersections.len()

--- a/game/src/layer/map.rs
+++ b/game/src/layer/map.rs
@@ -218,21 +218,17 @@ impl Static {
     pub fn edits(ctx: &mut EventCtx, app: &App) -> Static {
         let mut colorer = ColorDiscrete::new(
             app,
-            vec![("modified lane/intersection", app.cs.edits_layer)],
+            vec![("modified road/intersection", app.cs.edits_layer)],
         );
 
         let edits = app.primary.map.get_edits();
-        for l in edits.original_lts.keys().chain(&edits.reversed_lanes) {
-            colorer.add_l(*l, "modified lane/intersection");
+        // TODO Actually this loses tons of information; we really should highlight just the
+        // changed lanes
+        for r in edits.original_roads.keys() {
+            colorer.add_r(*r, "modified road/intersection");
         }
         for i in edits.original_intersections.keys() {
             colorer.add_i(*i, "modified lane/intersection");
-        }
-        for r in &edits.changed_speed_limits {
-            colorer.add_r(*r, "modified lane/intersection");
-        }
-        for r in &edits.changed_access_restrictions {
-            colorer.add_r(*r, "modified lane/intersection");
         }
 
         Static::new(
@@ -241,16 +237,6 @@ impl Static {
             "map edits",
             format!("Map edits ({})", edits.edits_name),
             Text::from_multiline(vec![
-                Line(format!("{} lane types changed", edits.original_lts.len())),
-                Line(format!("{} lanes reversed", edits.reversed_lanes.len())),
-                Line(format!(
-                    "{} speed limits changed",
-                    edits.changed_speed_limits.len()
-                )),
-                Line(format!(
-                    "{} access restrictions changed",
-                    edits.changed_access_restrictions.len()
-                )),
                 Line(format!("{} roads changed", edits.original_roads.len())),
                 Line(format!(
                     "{} intersections changed",

--- a/game/src/sandbox/gameplay/mod.rs
+++ b/game/src/sandbox/gameplay/mod.rs
@@ -164,14 +164,6 @@ impl GameplayMode {
     pub fn allows(&self, edits: &MapEdits) -> bool {
         for cmd in &edits.commands {
             match cmd {
-                EditCmd::ChangeLaneType { .. }
-                | EditCmd::ReverseLane { .. }
-                | EditCmd::ChangeSpeedLimit { .. }
-                | EditCmd::ChangeAccessRestrictions { .. } => {
-                    if !self.can_edit_lanes() {
-                        return false;
-                    }
-                }
                 EditCmd::ChangeRoad { .. } => {
                     if !self.can_edit_lanes() {
                         return false;

--- a/game/src/sandbox/gameplay/mod.rs
+++ b/game/src/sandbox/gameplay/mod.rs
@@ -172,6 +172,11 @@ impl GameplayMode {
                         return false;
                     }
                 }
+                EditCmd::ChangeRoad { .. } => {
+                    if !self.can_edit_lanes() {
+                        return false;
+                    }
+                }
                 EditCmd::ChangeIntersection { ref new, .. } => match new {
                     // TODO Conflating construction
                     EditIntersection::StopSign(_) | EditIntersection::Closed => {

--- a/game/src/sandbox/gameplay/tutorial.rs
+++ b/game/src/sandbox/gameplay/tutorial.rs
@@ -16,7 +16,7 @@ use ezgui::{
 };
 use geom::{ArrowCap, Distance, Duration, PolyLine, Pt2D, Time};
 use map_model::raw::OriginalRoad;
-use map_model::{osm, BuildingID, DirectedRoadID, Direction, Map, OriginalLane, Position};
+use map_model::{osm, BuildingID, DirectedRoadID, Direction, Map, Position};
 use sim::{
     AgentID, Analytics, BorderSpawnOverTime, CarID, DrivingGoal, IndividTrip, OriginDestination,
     PersonID, PersonSpec, Scenario, ScenarioGenerator, SpawnOverTime, SpawnTrip, VehicleType,
@@ -1037,24 +1037,25 @@ impl TutorialState {
                     // parking to force the target to park on-street.
                     let map = &app.primary.map;
                     let goal_bldg = map.find_b_by_osm_id(bldg(217701875)).unwrap();
-                    let start_lane = OriginalLane {
-                        parent: OriginalRoad::new(158782224, (1709145066, 53128052)),
-                        num_fwd: 3,
-                        num_back: 3,
-                        dir: Direction::Back,
-                        idx: 0,
-                    }
-                    .from_permanent(map)
-                    .unwrap();
-                    let lane_near_bldg = OriginalLane {
-                        parent: OriginalRoad::new(6484869, (53163501, 53069236)),
-                        num_fwd: 3,
-                        num_back: 3,
-                        dir: Direction::Fwd,
-                        idx: 0,
-                    }
-                    .from_permanent(map)
-                    .unwrap();
+                    let start_lane = {
+                        let r = map.get_r(
+                            map.find_r_by_osm_id(OriginalRoad::new(
+                                158782224,
+                                (1709145066, 53128052),
+                            ))
+                            .unwrap(),
+                        );
+                        assert_eq!(r.lanes_ltr().len(), 6);
+                        r.lanes_ltr()[2].0
+                    };
+                    let lane_near_bldg = {
+                        let r = map.get_r(
+                            map.find_r_by_osm_id(OriginalRoad::new(6484869, (53163501, 53069236)))
+                                .unwrap(),
+                        );
+                        assert_eq!(r.lanes_ltr().len(), 6);
+                        r.lanes_ltr()[3].0
+                    };
 
                     let mut scenario = Scenario::empty(map, "prank");
                     scenario.people.push(PersonSpec {

--- a/map_model/src/edits/mod.rs
+++ b/map_model/src/edits/mod.rs
@@ -45,9 +45,9 @@ pub enum EditIntersection {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct EditRoad {
-    lanes_ltr: Vec<(LaneType, Direction)>,
-    speed_limit: Speed,
-    access_restrictions: AccessRestrictions,
+    pub lanes_ltr: Vec<(LaneType, Direction)>,
+    pub speed_limit: Speed,
+    pub access_restrictions: AccessRestrictions,
 }
 
 impl EditRoad {

--- a/map_model/src/edits/mod.rs
+++ b/map_model/src/edits/mod.rs
@@ -46,7 +46,7 @@ pub struct EditRoad {
 }
 
 impl EditRoad {
-    fn get_orig_from_osm(r: &Road) -> EditRoad {
+    pub fn get_orig_from_osm(r: &Road) -> EditRoad {
         EditRoad {
             lanes_ltr: get_lane_specs_ltr(&r.osm_tags)
                 .into_iter()

--- a/map_model/src/edits/perma.rs
+++ b/map_model/src/edits/perma.rs
@@ -137,7 +137,7 @@ impl PermanentMapEdits {
                 })
                 .collect::<Result<Vec<EditCmd>, String>>()?,
 
-            original_roads: BTreeMap::new(),
+            changed_roads: BTreeSet::new(),
             original_intersections: BTreeMap::new(),
             changed_routes: BTreeSet::new(),
         };

--- a/map_model/src/lib.rs
+++ b/map_model/src/lib.rs
@@ -10,7 +10,9 @@ pub mod raw;
 mod traversable;
 
 pub use crate::city::City;
-pub use crate::edits::{EditCmd, EditEffects, EditIntersection, MapEdits, PermanentMapEdits};
+pub use crate::edits::{
+    EditCmd, EditEffects, EditIntersection, EditRoad, MapEdits, PermanentMapEdits,
+};
 pub use crate::map::MapConfig;
 pub use crate::objects::area::{Area, AreaID, AreaType};
 pub use crate::objects::building::{

--- a/map_model/src/lib.rs
+++ b/map_model/src/lib.rs
@@ -10,9 +10,7 @@ pub mod raw;
 mod traversable;
 
 pub use crate::city::City;
-pub use crate::edits::{
-    EditCmd, EditEffects, EditIntersection, MapEdits, OriginalLane, PermanentMapEdits,
-};
+pub use crate::edits::{EditCmd, EditEffects, EditIntersection, MapEdits, PermanentMapEdits};
 pub use crate::map::MapConfig;
 pub use crate::objects::area::{Area, AreaID, AreaType};
 pub use crate::objects::building::{

--- a/map_model/src/make/initial/lane_specs.rs
+++ b/map_model/src/make/initial/lane_specs.rs
@@ -363,8 +363,8 @@ mod tests {
                 "sbbdps",
                 "vv^^^^",
             ),
-            // TODO I have a fix for this, but somehow the fallout gridlocked lakeslice, so holding
-            // off...
+            /* TODO I have a fix for this, but somehow the fallout gridlocked lakeslice, so
+             * holding off... */
             /*(
                 "https://www.openstreetmap.org/way/534549104",
                 vec![

--- a/map_model/src/objects/intersection.rs
+++ b/map_model/src/objects/intersection.rs
@@ -41,6 +41,8 @@ pub struct Intersection {
 
     // Note that a lane may belong to both incoming_lanes and outgoing_lanes.
     // TODO narrow down when and why. is it just sidewalks in weird cases?
+    // TODO Change to BTreeSet, or otherwise emphasize to callers that the order of these isn't
+    // meaningful
     pub incoming_lanes: Vec<LaneID>,
     pub outgoing_lanes: Vec<LaneID>,
 


### PR DESCRIPTION
#113 and #234 are both partly caused by a tension between two things:

1) The edit commands apply to an individual lane -- some lane's type is changed, another is reversed
2) When we serialize edits, we "compress" all of the commands, so that a bunch of changes to one lane aren't all captured. This compression fiddles with the order of commands.

Upon loading the saved edits with the compressed commands, it crashes. This PR takes a very different strategy -- just capture the entire state of a road in an edit command. It's actually pretty simple, and the original state can even be determined purely from the OSM tags -- lane types, lane directions, speed limit, and access restrictions.

I've tested various edit->save->load scenarios and believe this works.

The big TODO, for a followup PR, is to write the compatibility layer to transform the old individual commands into the new consolidated one. I _think_ it'll work, but there's a possibility some situations are impossible to automatically fix. In that case, this will be a breaking change for those old edits. I think this PR is still worth it if so, because this is so much more robust / simple going forward.

@michaelkirk 