### PR TITLE
WIP: avoid jiggle in warp Panel

### DIFF
--- a/game/src/sandbox/speed.rs
+++ b/game/src/sandbox/speed.rs
@@ -528,12 +528,16 @@ impl TimeWarpScreen {
             wall_time_started: Instant::now(),
             sim_time_started: app.primary.sim.time(),
             halt_upon_delay,
-            panel: Panel::new(Widget::col(vec![
-                Text::new().draw(ctx).named("text"),
-                Btn::text_bg2("stop now")
-                    .build_def(ctx, hotkey(Key::Escape))
-                    .centered_horiz(),
-            ]))
+            panel: Panel::new(
+                Widget::col(vec![
+                    Text::new().draw(ctx).named("text"),
+                    Btn::text_bg2("stop now")
+                        .build_def(ctx, hotkey(Key::Escape))
+                        .centered_horiz(),
+                ])
+                // hardcoded width avoids jiggle due to text updates
+                .force_width(700.0),
+            )
             .build(ctx),
         })
     }


### PR DESCRIPTION
There's a couple places in the app which "jiggle", which I'd like to fix.

One of them is the warp screen:
![Screen Recording 2020-08-28 at 2 56 31 PM mov](https://user-images.githubusercontent.com/217057/91619370-bfe7b180-e941-11ea-88d5-de2827f9525e.gif)

A couple tools at our disposal: monospaced fonts and format padding. But a couple of issues that might not make the current proposal a net win, as is:

Firstly, as far as I can tell, it's not possible to have different fonts within a line. 

I'm looking for something like https://developer.apple.com/documentation/foundation/nsattributedstring, which allows you to specify different fonts for different sections of a string. Is there an existing way to achieve something like this in TUIFFKAEZG?

Otherwise, it doesn't look great to just use monospace font for the entire text:
![Screen Recording 2020-08-28 at 3 08 00 PM mov](https://user-images.githubusercontent.com/217057/91619405-cece6400-e941-11ea-9e24-5bb8d87e9c93.gif)

Secondly, until https://github.com/RazrFalcon/resvg/issues/317 is addressed, trailing padding in text is effectively truncated, and does not affect layout. So if we want to reserve layout space, we must use leading padding, which doesn't always look great:

![Screen Recording 2020-08-28 at 3 07 35 PM mov](https://user-images.githubusercontent.com/217057/91619386-c70ebf80-e941-11ea-9b1b-048587046d3e.gif)

I'm inclined to just leave it as is and discard this PR for now, but wondered if you had any thoughts @dabreegster.