### PR TITLE
preserve whitespace

### DIFF
--- a/game/src/info/intersection.rs
+++ b/game/src/info/intersection.rs
@@ -28,8 +28,7 @@ pub fn info(ctx: &EventCtx, app: &App, details: &mut Details, id: IntersectionID
         );
     }
     for r in road_names {
-        // TODO The spacing is ignored, so use -
-        txt.add(Line(format!("- {}", r)));
+        txt.add(Line(format!("  {}", r)));
     }
     rows.push(txt.draw(ctx));
 

--- a/game/src/info/trip.rs
+++ b/game/src/info/trip.rs
@@ -475,20 +475,20 @@ fn make_timeline(
 
         let mut txt = Text::from(Line(&p.phase_type.describe(map)));
         txt.add(Line(format!(
-            "- Started at {}",
+            "  Started at {}",
             p.start_time.ampm_tostring()
         )));
         let duration = if let Some(t2) = p.end_time {
             let d = t2 - p.start_time;
             txt.add(Line(format!(
-                "- Ended at {} (duration: {})",
+                "  Ended at {} (duration: {})",
                 t2.ampm_tostring(),
                 d
             )));
             d
         } else {
             let d = sim.time() - p.start_time;
-            txt.add(Line(format!("- Ongoing (duration so far: {})", d)));
+            txt.add(Line(format!("  Ongoing (duration so far: {})", d)));
             d
         };
         // TODO Problems when this is really low?
@@ -498,7 +498,7 @@ fn make_timeline(
             duration / total_duration_so_far
         };
         txt.add(Line(format!(
-            "- {}% of trip duration",
+            "  {}% of trip duration",
             (100.0 * percent_duration) as usize
         )));
 

--- a/widgetry/src/text.rs
+++ b/widgetry/src/text.rs
@@ -422,7 +422,7 @@ fn render_line(spans: Vec<TextSpan>, tolerance: f32, assets: &Assets) -> GeomBat
 
     write!(
         &mut svg,
-        r##"<text x="0" y="0" font-size="{}" font-family="{}" {}>"##,
+        r##"<text x="0" y="0" xml:space="preserve" font-size="{}" font-family="{}" {}>"##,
         spans[0].size,
         spans[0].font.family(),
         match spans[0].font {
@@ -515,7 +515,7 @@ impl TextSpan {
             - (Text::from(Line(&self.text)).dims(assets).width * scale) / 2.0;
         write!(
             &mut svg,
-            r##"<text font-size="{}" font-family="{}" {} fill="{}" startOffset="{}">"##,
+            r##"<text xml:space="preserve" font-size="{}" font-family="{}" {} fill="{}" startOffset="{}">"##,
             // This is seemingly the easiest way to do this. We could .scale() the whole batch
             // after, but then we have to re-translate it to the proper spot
             (self.size as f64) * scale,


### PR DESCRIPTION
Before:

<img width="585" alt="Screen Shot 2020-08-28 at 4 03 41 PM" src="https://user-images.githubusercontent.com/217057/91621636-a39b4300-e948-11ea-90ce-451b41146037.png">
<img width="596" alt="Screen Shot 2020-08-28 at 4 01 58 PM" src="https://user-images.githubusercontent.com/217057/91621638-a4cc7000-e948-11ea-9ef7-1601ec6e3958.png">

After:

<img width="415" alt="Screen Shot 2020-08-28 at 4 09 13 PM" src="https://user-images.githubusercontent.com/217057/91621695-d9d8c280-e948-11ea-9fc8-bacf7474e64c.png">
<img width="574" alt="Screen Shot 2020-08-28 at 4 08 29 PM" src="https://user-images.githubusercontent.com/217057/91621696-da715900-e948-11ea-8cb8-61ec75d5cc5c.png">

