### PR TITLE
macos fix: flip h-scroll to conventional direction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1184,7 +1184,7 @@ dependencies = [
  "parking_lot 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-client 0.23.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winit 0.22.2 (git+https://github.com/michaelkirk/winit?branch=mkirk/fix-stdweb-dpi)",
+ "winit 0.22.2 (git+https://github.com/rust-windowing/winit)",
 ]
 
 [[package]]
@@ -3651,7 +3651,7 @@ dependencies = [
  "ttf-parser 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "usvg 0.11.0 (git+https://github.com/RazrFalcon/resvg)",
  "webgl_stdweb 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winit 0.22.2 (git+https://github.com/michaelkirk/winit?branch=mkirk/fix-stdweb-dpi)",
+ "winit 0.22.2 (git+https://github.com/rust-windowing/winit)",
 ]
 
 [[package]]
@@ -3694,7 +3694,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "winit"
 version = "0.22.2"
-source = "git+https://github.com/michaelkirk/winit?branch=mkirk/fix-stdweb-dpi#a87ae2661263ff241e8868cbf3ce65aab205863a"
+source = "git+https://github.com/rust-windowing/winit#e2cf2a5754f6ee51a37fbe6e1f8b5ff8bd98da49"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cocoa 0.20.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4202,7 +4202,7 @@ dependencies = [
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-util 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "fa515c5163a99cc82bab70fd3bfdd36d827be85de63737b40fcef2ce084a436e"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-"checksum winit 0.22.2 (git+https://github.com/michaelkirk/winit?branch=mkirk/fix-stdweb-dpi)" = "<none>"
+"checksum winit 0.22.2 (git+https://github.com/rust-windowing/winit)" = "<none>"
 "checksum winreg 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 "checksum x11-dl 2.18.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2bf981e3a5b3301209754218f962052d4d9ee97e478f4d26d4a6eced34c1fef8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,4 +23,8 @@ members = [
 opt-level = 3
 
 [patch.crates-io]
-winit = { git = "https://github.com/michaelkirk/winit", branch = "mkirk/fix-stdweb-dpi" }
+# Bug fixes merged since 0.22.2:
+# - web: DPI vs. custom cursor icon: https://github.com/rust-windowing/winit/pull/1652
+# - web: vscroll inverted: https://github.com/rust-windowing/winit/pull/1665
+# - mac: hscroll inverted: https://github.com/rust-windowing/winit/pull/1696
+winit = { git = "https://github.com/rust-windowing/winit" }

--- a/widgetry/src/event.rs
+++ b/widgetry/src/event.rs
@@ -56,8 +56,8 @@ impl Event {
                         None
                     } else {
                         Some(Event::MouseWheelScroll(
-                            scroll_wheel_multiplier() * f64::from(dx),
-                            scroll_wheel_multiplier() * f64::from(dy),
+                            f64::from(dx),
+                            f64::from(dy),
                         ))
                     }
                 }
@@ -82,17 +82,6 @@ impl Event {
             _ => None,
         }
     }
-}
-
-// For some reason, Y is inverted in the browser
-#[cfg(feature = "wasm-backend")]
-fn scroll_wheel_multiplier() -> f64 {
-    -1.0
-}
-
-#[cfg(not(feature = "wasm-backend"))]
-fn scroll_wheel_multiplier() -> f64 {
-    1.0
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]


### PR DESCRIPTION
horizontal scroll in abstreet moves content in the opposite direction vs other apps on macos. 

I'm not sure if the change is really this simple. It fixes things for me on macos, which has ubiquitous [natural scrolling], but maybe it breaks it for others.

Does this break things for you @dabreegster?

[1] Some terms:

> [Reverse Scrolling]: Swipe fingers up on trackpad, magic mouse, scroll-wheel, content goes down, scrollbar goes up.
> [Natural Scrolling]: Swipe fingers up on trackpad, magic mouse, scroll-wheel, content goes up, scrollbar goes down.