### PR TITLE
Revamp the initial support for driving on the left

### DIFF
--- a/convert_osm/src/parking.rs
+++ b/convert_osm/src/parking.rs
@@ -60,17 +60,11 @@ fn use_parking_hints(map: &mut RawMap, path: String, timer: &mut Timer) {
         let center = PolyLine::must_new(r.center_points.clone());
         closest.add(
             (*id, true),
-            map.config
-                .driving_side
-                .must_right_shift(center.clone(), DIRECTED_ROAD_THICKNESS)
-                .points(),
+            center.must_shift_right(DIRECTED_ROAD_THICKNESS).points(),
         );
         closest.add(
             (*id, false),
-            map.config
-                .driving_side
-                .must_left_shift(center, DIRECTED_ROAD_THICKNESS)
-                .points(),
+            center.must_shift_left(DIRECTED_ROAD_THICKNESS).points(),
         );
     }
 

--- a/data/MANIFEST.txt
+++ b/data/MANIFEST.txt
@@ -30,6 +30,7 @@ data/input/screenshots/downtown.zip,21838ff62b31b2d6d4860a7f3d08f921,https://www
 data/input/screenshots/krakow_center.zip,1274855e993e09015c3b00127bf0da97,https://www.dropbox.com/s/azea6v6mnxbe0vc/krakow_center.zip.zip?dl=0
 data/input/screenshots/lakeslice.zip,adedabf6ee4e30f8e386762f860176d8,https://www.dropbox.com/s/06mwgdt6orow3rk/lakeslice.zip.zip?dl=0
 data/input/screenshots/montlake.zip,158ec5f3913f62519fbbeb5a6f47f9cd,https://www.dropbox.com/s/eblgq5zj3gflhwx/montlake.zip.zip?dl=0
+data/input/screenshots/southbank.zip,6abe141b2d2bc5cdb01bff31aaa093ca,https://www.dropbox.com/s/2smj2sw9gq7ajwx/southbank.zip.zip?dl=0
 data/input/screenshots/udistrict.zip,8a98fae6bc9d995f9e1ab4c91d0d7a23,https://www.dropbox.com/s/nlyxnfy11qszk50/udistrict.zip.zip?dl=0
 data/input/seattle/N47W122.hgt,0db4e23e51f7680538b0bbbc72208e07,https://www.dropbox.com/s/mmb4mgutwotijdw/N47W122.hgt.zip?dl=0
 data/input/seattle/blockface.bin,add872bab9040ae911366328a230f8b5,https://www.dropbox.com/s/rxd2care60tbe75/blockface.bin.zip?dl=0
@@ -80,7 +81,7 @@ data/system/maps/krakow_center.bin,7e423da356c1671ea09d2527575fce5c,https://www.
 data/system/maps/lakeslice.bin,c117a20d21a7c68ceae775c6c1daf318,https://www.dropbox.com/s/sss05ts43u8ghb8/lakeslice.bin.zip?dl=0
 data/system/maps/montlake.bin,6ca284783ce83e915282476cf99e04cc,https://www.dropbox.com/s/wyybiw5y7z3gdoc/montlake.bin.zip?dl=0
 data/system/maps/south_seattle.bin,286ce475d0d4a93501d7f9af6fff6418,https://www.dropbox.com/s/y505pnkwxyyrw0f/south_seattle.bin.zip?dl=0
-data/system/maps/southbank.bin,d7a8606a30927a8b73aa935881e526c2,https://www.dropbox.com/s/7k2gxn3jp2h10l0/southbank.bin.zip?dl=0
+data/system/maps/southbank.bin,dc5b1f91ae0e477aea5b4bdcb56e2e2c,https://www.dropbox.com/s/06v1x7enu00pmds/southbank.bin.zip?dl=0
 data/system/maps/tel_aviv.bin,b273e64c3e2ded4134f46bce6d9992cf,https://www.dropbox.com/s/7hndvhud5x8xao5/tel_aviv.bin.zip?dl=0
 data/system/maps/udistrict.bin,d2773d20a171843b7b6c805f350d4cf5,https://www.dropbox.com/s/y03l06emjmtjp32/udistrict.bin.zip?dl=0
 data/system/maps/west_seattle.bin,df580b7566bb9d57a2605cf4affa741d,https://www.dropbox.com/s/a9ws18sar0l5tns/west_seattle.bin.zip?dl=0

--- a/game/src/debug/mod.rs
+++ b/game/src/debug/mod.rs
@@ -236,6 +236,7 @@ impl State for DebugMode {
                             "krakow_center",
                             "lakeslice",
                             "montlake",
+                            "southbank",
                             "udistrict",
                         ],
                     }));

--- a/game/src/devtools/mapping.rs
+++ b/game/src/devtools/mapping.rs
@@ -417,12 +417,14 @@ impl ChangeWay {
             let r = map.get_r(*id);
             batch.push(
                 Color::GREEN,
-                map.must_right_shift(r.center_pts.clone(), r.get_half_width(map))
+                r.center_pts
+                    .must_shift_right(r.get_half_width(map))
                     .make_polygons(thickness),
             );
             batch.push(
                 Color::BLUE,
-                map.must_left_shift(r.center_pts.clone(), r.get_half_width(map))
+                r.center_pts
+                    .must_shift_left(r.get_half_width(map))
                     .make_polygons(thickness),
             );
         }

--- a/game/src/layer/map.rs
+++ b/game/src/layer/map.rs
@@ -219,7 +219,7 @@ impl Static {
         let edits = app.primary.map.get_edits();
         for r in &edits.changed_roads {
             let r = app.primary.map.get_r(*r);
-            let orig = EditRoad::get_orig_from_osm(r);
+            let orig = EditRoad::get_orig_from_osm(r, app.primary.map.get_config().driving_side);
             // What exactly changed?
             if r.speed_limit != orig.speed_limit
                 || r.access_restrictions != orig.access_restrictions

--- a/game/src/render/pedestrian.rs
+++ b/game/src/render/pedestrian.rs
@@ -206,9 +206,9 @@ impl DrawPedCrowd {
             PedCrowdLocation::Sidewalk(on, contraflow) => {
                 let pl_slice = on.exact_slice(input.low, input.high, map);
                 if contraflow {
-                    map.left_shift(pl_slice, SIDEWALK_THICKNESS / 4.0)
+                    pl_slice.shift_left(SIDEWALK_THICKNESS / 4.0)
                 } else {
-                    map.right_shift(pl_slice, SIDEWALK_THICKNESS / 4.0)
+                    pl_slice.shift_right(SIDEWALK_THICKNESS / 4.0)
                 }
                 .unwrap_or_else(|_| on.exact_slice(input.low, input.high, map))
             }

--- a/map_model/src/make/initial/mod.rs
+++ b/map_model/src/make/initial/mod.rs
@@ -2,7 +2,7 @@ mod geometry;
 pub mod lane_specs;
 
 pub use self::geometry::intersection_polygon;
-use crate::raw::{OriginalRoad, RawMap, RawRoad};
+use crate::raw::{DrivingSide, OriginalRoad, RawMap, RawRoad};
 use crate::{osm, IntersectionType};
 use abstutil::{Tags, Timer};
 use geom::{Bounds, Circle, Distance, PolyLine, Polygon, Pt2D};
@@ -29,9 +29,9 @@ pub struct Road {
 }
 
 impl Road {
-    pub fn new(id: OriginalRoad, r: &RawRoad) -> Road {
-        let lane_specs_ltr = lane_specs::get_lane_specs_ltr(&r.osm_tags);
-        let (trimmed_center_pts, total_width) = r.get_geometry(id);
+    pub fn new(id: OriginalRoad, r: &RawRoad, driving_side: DrivingSide) -> Road {
+        let lane_specs_ltr = lane_specs::get_lane_specs_ltr(&r.osm_tags, driving_side);
+        let (trimmed_center_pts, total_width) = r.get_geometry(id, driving_side);
 
         Road {
             id,
@@ -89,7 +89,8 @@ impl InitialMap {
             m.intersections.get_mut(&id.i1).unwrap().roads.insert(*id);
             m.intersections.get_mut(&id.i2).unwrap().roads.insert(*id);
 
-            m.roads.insert(*id, Road::new(*id, r));
+            m.roads
+                .insert(*id, Road::new(*id, r, raw.config.driving_side));
         }
 
         timer.start_iter("find each intersection polygon", m.intersections.len());

--- a/map_model/src/make/initial/mod.rs
+++ b/map_model/src/make/initial/mod.rs
@@ -2,7 +2,7 @@ mod geometry;
 pub mod lane_specs;
 
 pub use self::geometry::intersection_polygon;
-use crate::raw::{DrivingSide, OriginalRoad, RawMap, RawRoad};
+use crate::raw::{OriginalRoad, RawMap, RawRoad};
 use crate::{osm, IntersectionType};
 use abstutil::{Tags, Timer};
 use geom::{Bounds, Circle, Distance, PolyLine, Polygon, Pt2D};
@@ -29,9 +29,9 @@ pub struct Road {
 }
 
 impl Road {
-    pub fn new(id: OriginalRoad, r: &RawRoad, driving_side: DrivingSide) -> Road {
+    pub fn new(id: OriginalRoad, r: &RawRoad) -> Road {
         let lane_specs_ltr = lane_specs::get_lane_specs_ltr(&r.osm_tags);
-        let (trimmed_center_pts, total_width) = r.get_geometry(id, driving_side);
+        let (trimmed_center_pts, total_width) = r.get_geometry(id);
 
         Road {
             id,
@@ -89,14 +89,13 @@ impl InitialMap {
             m.intersections.get_mut(&id.i1).unwrap().roads.insert(*id);
             m.intersections.get_mut(&id.i2).unwrap().roads.insert(*id);
 
-            m.roads
-                .insert(*id, Road::new(*id, r, raw.config.driving_side));
+            m.roads.insert(*id, Road::new(*id, r));
         }
 
         timer.start_iter("find each intersection polygon", m.intersections.len());
         for i in m.intersections.values_mut() {
             timer.next();
-            match intersection_polygon(raw.config.driving_side, i, &mut m.roads, timer) {
+            match intersection_polygon(i, &mut m.roads, timer) {
                 Ok((poly, _)) => {
                     i.polygon = poly;
                 }
@@ -142,9 +141,7 @@ impl InitialMap {
                     .extend_to_length(min_len)
                     .reversed();
             }
-            i.polygon = intersection_polygon(raw.config.driving_side, i, &mut m.roads, timer)
-                .unwrap()
-                .0;
+            i.polygon = intersection_polygon(i, &mut m.roads, timer).unwrap().0;
             timer.note(format!(
                 "Shifted border {} out a bit to make the road a reasonable length",
                 i.id

--- a/map_model/src/make/mod.rs
+++ b/map_model/src/make/mod.rs
@@ -138,8 +138,9 @@ impl Map {
             }
             // TODO Maybe easier to use the road's "yellow center line" and shift left/right from
             // there.
-            let road_left_pts = map
-                .left_shift(road.center_pts.clone(), r.half_width)
+            let road_left_pts = road
+                .center_pts
+                .shift_left(r.half_width)
                 .unwrap_or_else(|_| road.center_pts.clone());
 
             let mut width_so_far = Distance::ZERO;
@@ -156,14 +157,13 @@ impl Map {
 
                 road.lanes_ltr.push((id, lane.dir, lane.lt));
 
-                let pl = if let Ok(pl) =
-                    map.right_shift(road_left_pts.clone(), width_so_far + (lane.width / 2.0))
-                {
-                    pl
-                } else {
-                    timer.error(format!("{} geometry broken; lane not shifted!", id));
-                    road_left_pts.clone()
-                };
+                let pl =
+                    if let Ok(pl) = road_left_pts.shift_right(width_so_far + (lane.width / 2.0)) {
+                        pl
+                    } else {
+                        timer.error(format!("{} geometry broken; lane not shifted!", id));
+                        road_left_pts.clone()
+                    };
                 let lane_center_pts = if lane.dir == Direction::Fwd {
                     pl
                 } else {

--- a/map_model/src/make/walking_turns.rs
+++ b/map_model/src/make/walking_turns.rs
@@ -359,12 +359,8 @@ fn make_shared_sidewalk_corner(
 
     // Find all of the points on the intersection polygon between the two sidewalks. Assumes
     // sidewalks are the same length.
-    let corner1 = driving_side
-        .right_shift_line(l1.last_line(), l1.width / 2.0)
-        .pt2();
-    let corner2 = driving_side
-        .right_shift_line(l2.first_line(), l2.width / 2.0)
-        .pt1();
+    let corner1 = l1.last_line().shift_right(l1.width / 2.0).pt2();
+    let corner2 = l2.first_line().shift_right(l2.width / 2.0).pt1();
 
     // TODO Something like this will be MUCH simpler and avoid going around the long way sometimes.
     if false {
@@ -393,8 +389,8 @@ fn make_shared_sidewalk_corner(
             }
 
             pts_between.extend(
-                driving_side
-                    .must_right_shift(PolyLine::must_new(deduped), l1.width.min(l2.width) / 2.0)
+                PolyLine::must_new(deduped)
+                    .must_shift_right(l1.width.min(l2.width) / 2.0)
                     .points(),
             );
         }

--- a/map_model/src/map.rs
+++ b/map_model/src/map.rs
@@ -629,4 +629,8 @@ impl Map {
         }
         languages
     }
+
+    pub fn get_config(&self) -> &MapConfig {
+        &self.config
+    }
 }

--- a/map_model/src/map.rs
+++ b/map_model/src/map.rs
@@ -6,7 +6,7 @@ use crate::{
     PathConstraints, PathRequest, Pathfinder, Position, Road, RoadID, Turn, TurnID, TurnType, Zone,
 };
 use abstutil::Timer;
-use geom::{Angle, Bounds, Distance, GPSBounds, Line, PolyLine, Polygon, Pt2D, Ring, Time};
+use geom::{Bounds, GPSBounds, Polygon, Pt2D, Ring, Time};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet, HashSet, VecDeque};
 
@@ -583,32 +583,6 @@ impl Map {
             }
         }
         None
-    }
-
-    pub fn right_shift(&self, pl: PolyLine, width: Distance) -> Result<PolyLine, String> {
-        self.config.driving_side.right_shift(pl, width)
-    }
-    pub fn must_right_shift(&self, pl: PolyLine, width: Distance) -> PolyLine {
-        self.right_shift(pl, width).unwrap()
-    }
-    pub fn left_shift(&self, pl: PolyLine, width: Distance) -> Result<PolyLine, String> {
-        self.config.driving_side.left_shift(pl, width)
-    }
-    pub fn must_left_shift(&self, pl: PolyLine, width: Distance) -> PolyLine {
-        self.left_shift(pl, width).unwrap()
-    }
-    pub fn right_shift_line(&self, line: Line, width: Distance) -> Line {
-        self.config.driving_side.right_shift_line(line, width)
-    }
-    pub fn left_shift_line(&self, line: Line, width: Distance) -> Line {
-        self.config.driving_side.left_shift_line(line, width)
-    }
-    pub fn driving_side_angle(&self, a: Angle) -> Angle {
-        self.config.driving_side.angle_offset(a)
-    }
-    // Last resort
-    pub fn get_driving_side(&self) -> DrivingSide {
-        self.config.driving_side
     }
 
     // TODO Sort of a temporary hack

--- a/map_model/src/objects/turn.rs
+++ b/map_model/src/objects/turn.rs
@@ -297,7 +297,9 @@ impl Movement {
             left = right;
         }
 
-        let mut pl = map.must_right_shift(r.get_left_side(map), (leftmost + rightmost) / 2.0);
+        let mut pl = r
+            .get_left_side(map)
+            .must_shift_right((leftmost + rightmost) / 2.0);
         if self.id.from.dir == Direction::Back {
             pl = pl.reversed();
         }

--- a/map_model/src/pathfind/uber_turns.rs
+++ b/map_model/src/pathfind/uber_turns.rs
@@ -313,7 +313,9 @@ impl UberTurnGroup {
             left = right;
         }
 
-        let mut pl = map.must_right_shift(r.get_left_side(map), (leftmost + rightmost) / 2.0);
+        let mut pl = r
+            .get_left_side(map)
+            .must_shift_right((leftmost + rightmost) / 2.0);
         // Point towards the intersection
         if self.from.dir == Direction::Back {
             pl = pl.reversed();

--- a/map_model/src/raw.rs
+++ b/map_model/src/raw.rs
@@ -153,7 +153,10 @@ impl RawMap {
         };
         let mut roads = BTreeMap::new();
         for r in &i.roads {
-            roads.insert(*r, initial::Road::new(*r, &self.roads[r]));
+            roads.insert(
+                *r,
+                initial::Road::new(*r, &self.roads[r], self.config.driving_side),
+            );
         }
 
         let (poly, debug) = initial::intersection_polygon(&i, &mut roads, timer).unwrap();
@@ -242,8 +245,12 @@ pub struct RawRoad {
 
 impl RawRoad {
     // Returns the corrected center and half width
-    pub fn get_geometry(&self, id: OriginalRoad) -> (PolyLine, Distance) {
-        let lane_specs = get_lane_specs_ltr(&self.osm_tags);
+    pub fn get_geometry(
+        &self,
+        id: OriginalRoad,
+        driving_side: DrivingSide,
+    ) -> (PolyLine, Distance) {
+        let lane_specs = get_lane_specs_ltr(&self.osm_tags, driving_side);
         let mut total_width = Distance::ZERO;
         let mut sidewalk_right = None;
         let mut sidewalk_left = None;

--- a/sim/src/mechanics/walking.rs
+++ b/sim/src/mechanics/walking.rs
@@ -548,10 +548,7 @@ impl Pedestrian {
                     orig_angle.opposite()
                 };
                 (
-                    pos.project_away(
-                        SIDEWALK_THICKNESS / 4.0,
-                        map.driving_side_angle(facing.rotate_degs(90.0)),
-                    ),
+                    pos.project_away(SIDEWALK_THICKNESS / 4.0, facing.rotate_degs(90.0)),
                     facing,
                 )
             }
@@ -563,10 +560,7 @@ impl Pedestrian {
                     orig_angle
                 };
                 (
-                    pos.project_away(
-                        SIDEWALK_THICKNESS / 4.0,
-                        map.driving_side_angle(facing.rotate_degs(90.0)),
-                    ),
+                    pos.project_away(SIDEWALK_THICKNESS / 4.0, facing.rotate_degs(90.0)),
                     facing,
                 )
             }
@@ -620,11 +614,8 @@ impl Pedestrian {
                 let (pt, angle) = self.goal.sidewalk_pos.pt_and_angle(map);
                 // Stand on the far side of the sidewalk (by the bus stop), facing the road
                 (
-                    pt.project_away(
-                        SIDEWALK_THICKNESS / 4.0,
-                        map.driving_side_angle(angle.rotate_degs(90.0)),
-                    ),
-                    map.driving_side_angle(angle.rotate_degs(-90.0)),
+                    pt.project_away(SIDEWALK_THICKNESS / 4.0, angle.rotate_degs(90.0)),
+                    angle.rotate_degs(-90.0),
                 )
             }
         };


### PR DESCRIPTION
My first attempt at handling left-hand driving was to take all of the code that shifts a road center line left/right and just sort of invert it. That actually did work, but it was extremely confusing and was an API change that percolated everywhere. Now that we have `lanes_ltr` and not `children_fwd/back`, rip out the old hack and handle things in just one smaller, unit tested place.

@michaelkirk 