### PR TITLE
Live map edits

### DIFF
--- a/book/src/trafficsim/live_edits.md
+++ b/book/src/trafficsim/live_edits.md
@@ -34,3 +34,9 @@ figure out rerouting.
 
 And actually, the only other case to handle is `ChangeRouteSchedule`, which
 should just be rescheduling the `StartBus` commands.
+
+## TODO: Parking
+
+What happens if you modify a parking lane while there are cars on it? For now,
+just delete them. Trips later making use of them will just act as if the car
+never had room to be spawned at all and be aborted or fallback to walking.

--- a/game/src/debug/mod.rs
+++ b/game/src/debug/mod.rs
@@ -472,7 +472,7 @@ impl ContextualActions for Actions {
                 }
             }
             ID::Car(_) => {
-                actions.push((Key::Backspace, "forcibly kill this car".to_string()));
+                actions.push((Key::Backspace, "forcibly delete this car".to_string()));
                 actions.push((Key::G, "find front of blockage".to_string()));
             }
             ID::Area(_) => {
@@ -511,8 +511,8 @@ impl ContextualActions for Actions {
                 objects::ObjectDebugger::dump_debug(id, &app.primary.map, &app.primary.sim);
                 Transition::Keep
             }
-            (ID::Car(c), "forcibly kill this car") => {
-                app.primary.sim.kill_stuck_car(c, &app.primary.map);
+            (ID::Car(c), "forcibly delete this car") => {
+                app.primary.sim.delete_car(c, &app.primary.map);
                 app.primary
                     .sim
                     .tiny_step(&app.primary.map, &mut app.primary.sim_cb);

--- a/game/src/edit/mod.rs
+++ b/game/src/edit/mod.rs
@@ -95,8 +95,7 @@ impl EditMode {
             app.primary
                 .sim
                 .handle_live_edited_traffic_signals(&app.primary.map);
-            app.primary.sim.handle_live_edited_lanes(&app.primary.map);
-            app.primary.sim.handle_live_edited_parking(&app.primary.map);
+            app.primary.sim.handle_live_edits(&app.primary.map);
             Transition::Pop
         })
     }

--- a/game/src/edit/mod.rs
+++ b/game/src/edit/mod.rs
@@ -96,6 +96,7 @@ impl EditMode {
                 .sim
                 .handle_live_edited_traffic_signals(&app.primary.map);
             app.primary.sim.handle_live_edited_lanes(&app.primary.map);
+            app.primary.sim.handle_live_edited_parking(&app.primary.map);
             Transition::Pop
         })
     }

--- a/game/src/edit/mod.rs
+++ b/game/src/edit/mod.rs
@@ -95,7 +95,7 @@ impl EditMode {
             app.primary
                 .sim
                 .handle_live_edited_traffic_signals(&app.primary.map);
-            // TODO Some other stuff too
+            app.primary.sim.handle_live_edited_lanes(&app.primary.map);
             Transition::Pop
         })
     }

--- a/game/src/edit/stop_signs.rs
+++ b/game/src/edit/stop_signs.rs
@@ -170,6 +170,9 @@ impl State for StopSignEditor {
                         ),
                     });
                     apply_map_edits(ctx, app, edits);
+                    app.primary
+                        .sim
+                        .handle_live_edited_traffic_signals(&app.primary.map);
                     return Transition::Replace(TrafficSignalEditor::new(
                         ctx,
                         app,

--- a/game/src/layer/map.rs
+++ b/game/src/layer/map.rs
@@ -4,7 +4,7 @@ use crate::helpers::amenity_type;
 use crate::layer::{Layer, LayerOutcome};
 use abstutil::Counter;
 use geom::{Distance, Time};
-use map_model::{EditRoad, LaneType};
+use map_model::LaneType;
 use sim::AgentType;
 use widgetry::{
     hotkey, Btn, Color, Drawable, EventCtx, GfxCtx, HorizontalAlignment, Key, Line, Panel, Text,
@@ -217,22 +217,12 @@ impl Static {
         );
 
         let edits = app.primary.map.get_edits();
-        for r in &edits.changed_roads {
-            let r = app.primary.map.get_r(*r);
-            let orig = EditRoad::get_orig_from_osm(r, app.primary.map.get_config().driving_side);
-            // What exactly changed?
-            if r.speed_limit != orig.speed_limit
-                || r.access_restrictions != orig.access_restrictions
-            {
-                colorer.add_r(r.id, "modified road/intersection");
-            } else {
-                let lanes = r.lanes_ltr();
-                for (idx, (lt, dir)) in orig.lanes_ltr.into_iter().enumerate() {
-                    if lanes[idx].1 != dir || lanes[idx].2 != lt {
-                        colorer.add_l(lanes[idx].0, "modified road/intersection");
-                    }
-                }
-            }
+        let (lanes, roads) = edits.changed_lanes(&app.primary.map);
+        for l in lanes {
+            colorer.add_l(l, "modified road/intersection");
+        }
+        for r in roads {
+            colorer.add_r(r, "modified road/intersection");
         }
         for i in edits.original_intersections.keys() {
             colorer.add_i(*i, "modified road/intersection");

--- a/game/src/options.rs
+++ b/game/src/options.rs
@@ -20,7 +20,6 @@ pub struct Options {
     pub large_unzoomed_agents: bool,
 
     pub time_increment: Duration,
-    pub resume_after_edit: bool,
     pub dont_draw_time_warp: bool,
     pub time_warp_halt_limit: Duration,
 
@@ -40,7 +39,6 @@ impl Options {
             large_unzoomed_agents: false,
 
             time_increment: Duration::minutes(10),
-            resume_after_edit: true,
             dont_draw_time_warp: false,
             time_warp_halt_limit: Duration::minutes(5),
 

--- a/game/src/sandbox/gameplay/mod.rs
+++ b/game/src/sandbox/gameplay/mod.rs
@@ -146,13 +146,6 @@ impl GameplayMode {
         }
     }
 
-    pub fn reset_after_edits(&self) -> bool {
-        match self {
-            GameplayMode::FixTrafficSignals => false,
-            _ => true,
-        }
-    }
-
     pub fn can_jump_to_time(&self) -> bool {
         match self {
             GameplayMode::Freeform(_) => false,

--- a/sim/src/lib.rs
+++ b/sim/src/lib.rs
@@ -380,7 +380,7 @@ pub struct SidewalkSpot {
 }
 
 // Point of interest, that is
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum SidewalkPOI {
     // Note that for offstreet parking, the path will be the same as the building's front path.
     ParkingSpot(ParkingSpot),

--- a/sim/src/make/load.rs
+++ b/sim/src/make/load.rs
@@ -48,6 +48,7 @@ impl SimFlags {
                     })
                     .unwrap_or(AlertHandler::Print),
                 pathfinding_upfront: args.enabled("--pathfinding_upfront"),
+                live_map_edits: args.enabled("--live_map_edits"),
             },
         }
     }

--- a/sim/src/mechanics/intersection.rs
+++ b/sim/src/mechanics/intersection.rs
@@ -208,7 +208,11 @@ impl IntersectionSimState {
                 }
             }
         } else {
-            assert!(map.get_i(i).is_border());
+            // This could either be a border intersection or an intersection that was just closed
+            // in the middle of simulation. In either case, there shouldn't be any other turns at
+            // it.
+            assert!(protected.is_empty());
+            assert!(yielding.is_empty());
         };
 
         for req in protected {

--- a/sim/src/mechanics/parking.rs
+++ b/sim/src/mechanics/parking.rs
@@ -100,7 +100,7 @@ impl ParkingSimState {
     }
 
     // Returns any cars that got very abruptly evicted from existence
-    pub fn handle_map_updates(&mut self, map: &Map, timer: &mut Timer) -> Vec<CarID> {
+    pub fn handle_map_updates(&mut self, map: &Map, timer: &mut Timer) -> Vec<ParkedCar> {
         let (filled_before, _) = self.get_all_parking_spots();
         let new = ParkingSimState::new(map, timer);
         let (_, avail_after) = new.get_all_parking_spots();
@@ -120,8 +120,7 @@ impl ParkingSimState {
         for spot in filled_before {
             if !avail_after.contains(&spot) {
                 let car = self.occupants.remove(&spot).unwrap();
-                assert!(self.parked_cars.remove(&car).is_some());
-                evicted.push(car);
+                evicted.push(self.parked_cars.remove(&car).unwrap());
             }
         }
 

--- a/sim/src/mechanics/parking.rs
+++ b/sim/src/mechanics/parking.rs
@@ -100,7 +100,7 @@ impl ParkingSimState {
     }
 
     // Returns any cars that got very abruptly evicted from existence
-    pub fn handle_map_updates(&mut self, map: &Map, timer: &mut Timer) -> Vec<ParkedCar> {
+    pub fn handle_live_edits(&mut self, map: &Map, timer: &mut Timer) -> Vec<ParkedCar> {
         let (filled_before, _) = self.get_all_parking_spots();
         let new = ParkingSimState::new(map, timer);
         let (_, avail_after) = new.get_all_parking_spots();

--- a/sim/src/mechanics/walking.rs
+++ b/sim/src/mechanics/walking.rs
@@ -298,6 +298,13 @@ impl WalkingSimState {
         };
     }
 
+    pub fn delete_ped(&mut self, id: PedestrianID, scheduler: &mut Scheduler) {
+        let ped = self.peds.remove(&id).unwrap();
+        self.peds_per_traversable
+            .remove(ped.path.current_step().as_traversable(), id);
+        scheduler.cancel(Command::UpdatePed(id));
+    }
+
     pub fn debug_ped(&self, id: PedestrianID) {
         if let Some(ped) = self.peds.get(&id) {
             println!("{}", abstutil::to_json(ped));

--- a/sim/src/mechanics/walking.rs
+++ b/sim/src/mechanics/walking.rs
@@ -489,25 +489,18 @@ impl WalkingSimState {
         std::mem::replace(&mut self.events, Vec::new())
     }
 
-    pub fn handle_live_edited_parking(
-        &mut self,
-        deleted_cars: Vec<ParkedCar>,
-        scheduler: &mut Scheduler,
-    ) {
-        let goals: BTreeSet<SidewalkPOI> = deleted_cars
+    pub fn find_trips_to_parking(&self, evicted_cars: Vec<ParkedCar>) -> Vec<(AgentID, TripID)> {
+        let goals: BTreeSet<SidewalkPOI> = evicted_cars
             .into_iter()
             .map(|p| SidewalkPOI::ParkingSpot(p.spot))
             .collect();
-        let mut delete = Vec::new();
+        let mut affected = Vec::new();
         for ped in self.peds.values() {
             if goals.contains(&ped.goal.connection) {
-                delete.push(ped.id);
+                affected.push((AgentID::Pedestrian(ped.id), ped.trip));
             }
         }
-
-        for id in delete {
-            self.delete_ped(id, scheduler);
-        }
+        affected
     }
 }
 

--- a/sim/src/router.rs
+++ b/sim/src/router.rs
@@ -32,7 +32,6 @@ pub enum ActionAtEnd {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 enum Goal {
     // Spot and cached distance along the last driving lane
-    // TODO Right now, the building is ignored when choosing the best spot.
     ParkNearBuilding {
         target: BuildingID,
         spot: Option<(ParkingSpot, Distance)>,
@@ -427,6 +426,13 @@ impl Router {
                 started_looking, ..
             } => started_looking,
             _ => false,
+        }
+    }
+
+    pub fn get_parking_spot_goal(&self) -> Option<&ParkingSpot> {
+        match self.goal {
+            Goal::ParkNearBuilding { ref spot, .. } => spot.as_ref().map(|(s, _)| s),
+            _ => None,
         }
     }
 }

--- a/sim/src/sim.rs
+++ b/sim/src/sim.rs
@@ -903,9 +903,11 @@ impl Sim {
     }
 
     pub fn handle_live_edited_parking(&mut self, map: &Map) {
-        // TODO Find pedestrians walking to any of the cars mentioned and delete them
-        self.parking
-            .handle_map_updates(map, &mut Timer::throwaway());
+        self.walking.handle_live_edited_parking(
+            self.parking
+                .handle_map_updates(map, &mut Timer::throwaway()),
+            &mut self.scheduler,
+        );
     }
 }
 

--- a/sim/src/sim.rs
+++ b/sim/src/sim.rs
@@ -73,6 +73,7 @@ pub struct SimOptions {
     pub enable_pandemic_model: Option<XorShiftRng>,
     pub alerts: AlertHandler,
     pub pathfinding_upfront: bool,
+    pub live_map_edits: bool,
 }
 
 #[derive(Clone)]
@@ -103,6 +104,7 @@ impl SimOptions {
             enable_pandemic_model: None,
             alerts: AlertHandler::Print,
             pathfinding_upfront: false,
+            live_map_edits: false,
         }
     }
 }

--- a/sim/src/sim.rs
+++ b/sim/src/sim.rs
@@ -845,7 +845,8 @@ impl Sim {
     }
 
     pub fn handle_live_edited_traffic_signals(&mut self, map: &Map) {
-        self.intersections.handle_live_edited_traffic_signals(map)
+        self.intersections
+            .handle_live_edited_traffic_signals(self.time, map, &mut self.scheduler)
     }
 
     pub fn handle_live_edited_lanes(&mut self, map: &Map) {

--- a/sim/src/sim.rs
+++ b/sim/src/sim.rs
@@ -901,6 +901,12 @@ impl Sim {
             }
         }
     }
+
+    pub fn handle_live_edited_parking(&mut self, map: &Map) {
+        // TODO Find pedestrians walking to any of the cars mentioned and delete them
+        self.parking
+            .handle_map_updates(map, &mut Timer::throwaway());
+    }
 }
 
 // Queries of all sorts

--- a/sim/src/trips.rs
+++ b/sim/src/trips.rs
@@ -820,6 +820,9 @@ impl TripManager {
     pub fn get_active_trips(&self) -> Vec<TripID> {
         self.active_trip_mode.values().cloned().collect()
     }
+    pub fn active_agents_and_trips(&self) -> &BTreeMap<AgentID, TripID> {
+        &self.active_trip_mode
+    }
     pub fn num_active_agents(&self) -> usize {
         self.active_trip_mode.len()
     }


### PR DESCRIPTION
The goal is to not reset the simulation to midnight after making map edits. This has been requested by a few of the machine learning groups working through the API, and has been a long-time UX / instant gameplay feedback issue.

V1 of this change finds trips affected by edits and deals with them in the simplest way that doesn't crash the game -- usually just aborting the trip. Even with this, there are lots of crashes left. There are also changes to the tutorial, VIP challenge, and UI (explaining to players how their edits affect the live world) that haven't been thought through yet. So for now, hide everything behind a `--live_map_edits` flag.