### PR TITLE
Remove the purple parking agents from the unzoomed view. Instead, add…

### DIFF
--- a/game/src/common/minimap.rs
+++ b/game/src/common/minimap.rs
@@ -437,8 +437,7 @@ fn make_tool_panel(ctx: &mut EventCtx, app: &App) -> Widget {
 fn make_horiz_viz_panel(ctx: &mut EventCtx, app: &App) -> Widget {
     let a = &app.unzoomed_agents;
     Widget::custom_row(vec![
-        Checkbox::colored(ctx, "Car", a.car_color, a.cars).margin_right(8),
-        Widget::draw_svg(ctx, "system/assets/timeline/parking.svg").margin_right(24),
+        Checkbox::colored(ctx, "Car", a.car_color, a.cars).margin_right(24),
         Checkbox::colored(ctx, "Bike", a.bike_color, a.bikes).margin_right(24),
         Checkbox::colored(ctx, "Bus", a.bus_color, a.buses_and_trains).margin_right(24),
         Checkbox::colored(ctx, "Pedestrian", a.ped_color, a.peds).margin_right(8),
@@ -448,10 +447,7 @@ fn make_horiz_viz_panel(ctx: &mut EventCtx, app: &App) -> Widget {
 fn make_vert_viz_panel(ctx: &mut EventCtx, app: &App) -> Widget {
     let a = &app.unzoomed_agents;
     Widget::col(vec![
-        Widget::custom_row(vec![
-            Checkbox::colored(ctx, "Car", a.car_color, a.cars).margin_right(8),
-            Widget::draw_svg(ctx, "system/assets/timeline/parking.svg"),
-        ]),
+        Checkbox::colored(ctx, "Car", a.car_color, a.cars),
         Checkbox::colored(ctx, "Bike", a.bike_color, a.bikes),
         Checkbox::colored(ctx, "Bus", a.bus_color, a.buses_and_trains),
         Checkbox::colored(ctx, "Pedestrian", a.ped_color, a.peds),

--- a/game/src/layer/mod.rs
+++ b/game/src/layer/mod.rs
@@ -182,7 +182,7 @@ impl State for PickLayer {
                 }
                 "parking occupancy" => {
                     app.layer = Some(Box::new(parking::Occupancy::new(
-                        ctx, app, true, true, true, false,
+                        ctx, app, true, true, true, false, true,
                     )));
                 }
                 "population map" => {

--- a/game/src/render/map.rs
+++ b/game/src/render/map.rs
@@ -461,7 +461,6 @@ pub struct UnzoomedAgents {
     pub peds: bool,
 
     pub car_color: Color,
-    pub parking_color: Color,
     pub bike_color: Color,
     pub bus_color: Color,
     pub ped_color: Color,
@@ -476,7 +475,6 @@ impl UnzoomedAgents {
             peds: true,
 
             car_color: cs.unzoomed_car.alpha(0.8),
-            parking_color: cs.parking_trip.alpha(0.8),
             bike_color: cs.unzoomed_bike.alpha(0.8),
             bus_color: cs.unzoomed_bus.alpha(0.8),
             ped_color: cs.unzoomed_pedestrian.alpha(0.8),
@@ -487,11 +485,7 @@ impl UnzoomedAgents {
         match agent.vehicle_type {
             Some(VehicleType::Car) => {
                 if self.cars {
-                    if agent.parking {
-                        Some(self.parking_color)
-                    } else {
-                        Some(self.car_color)
-                    }
+                    Some(self.car_color)
                 } else {
                     None
                 }


### PR DESCRIPTION
… them to the parking layer, so supply and demand can be seen in the same place.

Before:
![before](https://user-images.githubusercontent.com/1664407/92824868-c6374e00-f383-11ea-956b-60b76a9089de.gif)

After:
![after](https://user-images.githubusercontent.com/1664407/92824883-c9cad500-f383-11ea-9802-378827d835c6.gif)

The trade-offs:
- The old minimap was inconsistent; most of the checkboxes are normal categories, but there was an extra subcategory represented.
- But seeing the purple dots previously was helpful as an "alert" that parking might be scarce somewhere.
- The new approach shows supply and demand of parking in one place, which should be more clear.

Yuwen and I also discussed resurrecting an old UI for changing the agent color scheme from the minimap. Once upon a time, there was a way to color all of the unzoomed dots by how long an agent was waiting at a particular spot, or by the total trip distance. If there are more ideas for usefully coloring unzoomed agents, we could bring this back in some form.

@michaelkirk, @muzlee1113