### PR TITLE
When a car trip violates a congestion cap, reroute around the problem

### DIFF
--- a/book/src/trafficsim/live_edits.md
+++ b/book/src/trafficsim/live_edits.md
@@ -40,3 +40,9 @@ should just be rescheduling the `StartBus` commands.
 What happens if you modify a parking lane while there are cars on it? For now,
 just delete them. Trips later making use of them will just act as if the car
 never had room to be spawned at all and be aborted or fallback to walking.
+
+A better resolution would be to relocate them to other parking spots. If the
+owner is home, it'd be neat to have them walk outside, move the car, and go back
+in. But this greatly complicates the simulation -- the edited lane is in a
+transition state for a while, it modifies schedules, the person might not be
+around, etc.

--- a/game/src/info/person.rs
+++ b/game/src/info/person.rs
@@ -159,6 +159,11 @@ pub fn trips(
             } else {
                 Widget::nothing()
             },
+            if trip.capped {
+                Line("capped").batch(ctx).centered_vert().margin_right(15)
+            } else {
+                Widget::nothing()
+            },
             if trip_status == "finished" {
                 if let Some(before) = app
                     .has_prebaked()

--- a/map_model/src/map.rs
+++ b/map_model/src/map.rs
@@ -528,6 +528,14 @@ impl Map {
         assert!(!self.pathfinder_dirty);
         self.pathfinder.pathfind(req, self)
     }
+    pub fn pathfind_avoiding_zones(
+        &self,
+        req: PathRequest,
+        avoid: BTreeSet<LaneID>,
+    ) -> Option<Path> {
+        assert!(!self.pathfinder_dirty);
+        self.pathfinder.pathfind_avoiding_zones(req, avoid, self)
+    }
 
     pub fn should_use_transit(
         &self,

--- a/map_model/src/pathfind/mod.rs
+++ b/map_model/src/pathfind/mod.rs
@@ -17,7 +17,7 @@ use abstutil::Timer;
 use enumset::EnumSetType;
 use geom::{Distance, PolyLine, EPSILON_DIST};
 use serde::{Deserialize, Serialize};
-use std::collections::VecDeque;
+use std::collections::{BTreeSet, VecDeque};
 use std::fmt;
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -600,6 +600,14 @@ impl Pathfinder {
             Pathfinder::Dijkstra => dijkstra::pathfind(req, map),
             Pathfinder::CH(ref p) => p.pathfind(req, map),
         }
+    }
+    pub fn pathfind_avoiding_zones(
+        &self,
+        req: PathRequest,
+        avoid: BTreeSet<LaneID>,
+        map: &Map,
+    ) -> Option<Path> {
+        dijkstra::pathfind_avoiding_zones(req, avoid, map)
     }
 
     pub fn should_use_transit(

--- a/sim/src/cap.rs
+++ b/sim/src/cap.rs
@@ -80,11 +80,13 @@ impl CapSimState {
         path: Path,
         now: Time,
         car: CarID,
+        capped: &mut bool,
         map: &Map,
     ) -> Option<Path> {
         if self.allow_trip(now, car, &path) {
             return Some(path);
         }
+        *capped = true;
 
         // TODO Make the responses configurable: abort the trip, reroute, delay an hour, switch
         // modes. Where should this policy be specified? Is it simulation-wide?

--- a/sim/src/mechanics/driving.rs
+++ b/sim/src/mechanics/driving.rs
@@ -335,27 +335,22 @@ impl DrivingSimState {
                 let goto = car.router.next();
                 assert!(from != goto);
 
-                match goto {
-                    Traversable::Turn(t) => {
-                        let mut speed = goto.speed_limit(ctx.map);
-                        if let Some(s) = car.vehicle.max_speed {
-                            speed = speed.min(s);
-                        }
-                        if !ctx.intersections.maybe_start_turn(
-                            AgentID::Car(car.vehicle.id),
-                            t,
-                            speed,
-                            now,
-                            ctx.map,
-                            ctx.scheduler,
-                            Some((&car, &self.cars, &mut self.queues)),
-                        ) {
-                            // Don't schedule a retry here.
-                            return false;
-                        }
+                if let Traversable::Turn(t) = goto {
+                    let mut speed = goto.speed_limit(ctx.map);
+                    if let Some(s) = car.vehicle.max_speed {
+                        speed = speed.min(s);
                     }
-                    Traversable::Lane(l) => {
-                        ctx.cap.car_entering_lane(now, car.vehicle.id, l);
+                    if !ctx.intersections.maybe_start_turn(
+                        AgentID::Car(car.vehicle.id),
+                        t,
+                        speed,
+                        now,
+                        ctx.map,
+                        ctx.scheduler,
+                        Some((&car, &self.cars, &mut self.queues)),
+                    ) {
+                        // Don't schedule a retry here.
+                        return false;
                     }
                 }
 


### PR DESCRIPTION
instead of aborting the trip.

The demo: With a cap on these roads:
![edits](https://user-images.githubusercontent.com/1664407/92851896-f215fc00-f3a2-11ea-81a1-bf00ed9eea5d.png)

Throughput layer now shows higher traffic on the detour, instead of a bunch of aborted trips:
![rerouted](https://user-images.githubusercontent.com/1664407/92851928-00fcae80-f3a3-11ea-8b49-5e485646f917.png)

The edits:
[crazy_cap.json.txt](https://github.com/dabreegster/abstreet/files/5205721/crazy_cap.json.txt)

@michaelkirk 