### PR TITLE
Infinite parking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -733,6 +733,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum_dispatch"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "enumset"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2816,6 +2827,7 @@ version = "0.1.0"
 dependencies = [
  "abstutil 0.1.0",
  "downcast-rs 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "enum_dispatch 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "geom 0.1.0",
  "instant 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libm 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3880,6 +3892,7 @@ dependencies = [
 "checksum encoding-index-tradchinese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fd0e20d5688ce3cab59eb3ef3a2083a5c77bf496cb798dc6fcdb75f323890c18"
 "checksum encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
 "checksum encoding_rs 0.8.22 (registry+https://github.com/rust-lang/crates.io-index)" = "cd8d03faa7fe0c1431609dfad7bbe827af30f82e1e2ae6f7ee4fca6bd764bc28"
+"checksum enum_dispatch 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9d2984c9b91ef2cd76b29bbc4b6f123b146e73a4bae7dbde490bd5115f6f8f7d"
 "checksum enumset 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3691ce759534316ad900d57dd8e688e2c4263f9750c0f7c1e9b9a4516d4ca241"
 "checksum enumset_derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "74bef436ac71820c5cf768d7af9ba33121246b09a00e09a55d94ef8095a875ac"
 "checksum error-chain 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bd5c82c815138e278b8dcdeffc49f27ea6ffb528403e9dea4194f2e3dd40b143"

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -28,6 +28,7 @@
   - [Gridlock](trafficsim/gridlock.md)
   - [Multi-modal trips](trafficsim/trips.md)
   - [Live edits](trafficsim/live_edits.md)
+  - [Parking](trafficsim/parking.md)
 
 ---
 

--- a/book/src/trafficsim/parking.md
+++ b/book/src/trafficsim/parking.md
@@ -1,0 +1,14 @@
+# Parking
+
+TODO: Fill out the types of parking available, public/private, blackholes, how
+people pick spots, how seeding works, etc.
+
+## Infinite parking
+
+If you pass `--infinite_parking` on the command line, every building gets
+unlimited public spots. This effectively removes the effects of parking from the
+model, since driving trips can always begin or end at their precise building
+(except for blackhole cases). This is useful if a particular map has poor
+parking data and you need to get comparative results about speeding up some
+trips. Often the A/B testing is extremely sensitive, because a parking space
+close to someone's destination is filled up quickly, slowing down the trip.

--- a/game/src/info/building.rs
+++ b/game/src/info/building.rs
@@ -22,7 +22,15 @@ pub fn info(ctx: &mut EventCtx, app: &App, details: &mut Details, id: BuildingID
     }
 
     let num_spots = b.num_parking_spots();
-    if num_spots > 0 {
+    if app.primary.sim.infinite_parking() {
+        kv.push((
+            "Parking",
+            format!(
+                "Unlimited, currently {} cars inside",
+                app.primary.sim.bldg_to_parked_cars(b.id).len()
+            ),
+        ));
+    } else if num_spots > 0 {
         let free = app.primary.sim.get_free_offstreet_spots(b.id).len();
         if let OffstreetParking::PublicGarage(ref n, _) = b.parking {
             kv.push((

--- a/sim/Cargo.toml
+++ b/sim/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 abstutil = { path = "../abstutil" }
 downcast-rs = "1.1.1"
+enum_dispatch = "0.3.3"
 geom = { path = "../geom" }
 instant = "0.1.2"
 libm = "0.2.1"

--- a/sim/src/lib.rs
+++ b/sim/src/lib.rs
@@ -24,7 +24,7 @@ pub use self::make::{
     SpawnOverTime, SpawnTrip, TripSpawner, TripSpec,
 };
 pub(crate) use self::mechanics::{
-    DrivingSimState, IntersectionSimState, ParkingSimState, WalkingSimState,
+    DrivingSimState, IntersectionSimState, ParkingSim, ParkingSimState, WalkingSimState,
 };
 pub(crate) use self::pandemic::PandemicModel;
 pub(crate) use self::router::{ActionAtEnd, Router};

--- a/sim/src/make/load.rs
+++ b/sim/src/make/load.rs
@@ -54,6 +54,7 @@ impl SimFlags {
                     .unwrap_or(AlertHandler::Print),
                 pathfinding_upfront: args.enabled("--pathfinding_upfront"),
                 live_map_edits: args.enabled("--live_map_edits"),
+                infinite_parking: args.enabled("--infinite_parking"),
             },
         }
     }

--- a/sim/src/make/scenario.rs
+++ b/sim/src/make/scenario.rs
@@ -266,6 +266,14 @@ fn seed_parked_cars(
     base_rng: &mut XorShiftRng,
     timer: &mut Timer,
 ) {
+    if sim.infinite_parking() {
+        for (vehicle, b) in parked_cars {
+            let spot = sim.get_free_offstreet_spots(b)[0];
+            sim.seed_parked_car(vehicle, spot);
+        }
+        return;
+    }
+
     let mut open_spots_per_road: BTreeMap<RoadID, Vec<(ParkingSpot, Option<BuildingID>)>> =
         BTreeMap::new();
     for spot in sim.get_all_parking_spots().1 {

--- a/sim/src/make/scenario.rs
+++ b/sim/src/make/scenario.rs
@@ -267,9 +267,19 @@ fn seed_parked_cars(
     timer: &mut Timer,
 ) {
     if sim.infinite_parking() {
+        let mut blackholed = 0;
         for (vehicle, b) in parked_cars {
-            let spot = sim.get_free_offstreet_spots(b)[0];
-            sim.seed_parked_car(vehicle, spot);
+            if let Some(spot) = sim.get_free_offstreet_spots(b).pop() {
+                sim.seed_parked_car(vehicle, spot);
+            } else {
+                blackholed += 1;
+            }
+        }
+        if blackholed > 0 {
+            timer.warn(format!(
+                "{} parked cars weren't seeded, due to blackholed buildings",
+                prettyprint_usize(blackholed)
+            ));
         }
         return;
     }

--- a/sim/src/mechanics/driving.rs
+++ b/sim/src/mechanics/driving.rs
@@ -3,9 +3,9 @@ use crate::mechanics::Queue;
 use crate::sim::Ctx;
 use crate::{
     ActionAtEnd, AgentID, AgentProperties, CarID, Command, CreateCar, DistanceInterval,
-    DrawCarInput, Event, IntersectionSimState, ParkedCar, ParkingSimState, ParkingSpot, PersonID,
-    Scheduler, TimeInterval, TransitSimState, TripID, TripManager, UnzoomedAgent, Vehicle,
-    WalkingSimState, FOLLOWING_DISTANCE,
+    DrawCarInput, Event, IntersectionSimState, ParkedCar, ParkingSim, ParkingSimState, ParkingSpot,
+    PersonID, Scheduler, TimeInterval, TransitSimState, TripID, TripManager, UnzoomedAgent,
+    Vehicle, WalkingSimState, FOLLOWING_DISTANCE,
 };
 use abstutil::{deserialize_btreemap, serialize_btreemap};
 use geom::{Distance, Duration, PolyLine, Time};

--- a/sim/src/mechanics/mod.rs
+++ b/sim/src/mechanics/mod.rs
@@ -7,6 +7,6 @@ mod walking;
 
 pub use self::driving::DrivingSimState;
 pub use self::intersection::IntersectionSimState;
-pub use self::parking::ParkingSimState;
+pub use self::parking::{ParkingSim, ParkingSimState};
 pub use self::queue::Queue;
 pub use self::walking::WalkingSimState;

--- a/sim/src/router.rs
+++ b/sim/src/router.rs
@@ -1,7 +1,7 @@
 use crate::mechanics::Queue;
 use crate::{
-    CarID, Event, ParkingSimState, ParkingSpot, PersonID, SidewalkSpot, TripID, TripPhaseType,
-    Vehicle, VehicleType,
+    CarID, Event, ParkingSim, ParkingSimState, ParkingSpot, PersonID, SidewalkSpot, TripID,
+    TripPhaseType, Vehicle, VehicleType,
 };
 use geom::Distance;
 use map_model::{

--- a/sim/src/sim.rs
+++ b/sim/src/sim.rs
@@ -2,11 +2,11 @@ use crate::analytics::Window;
 use crate::{
     AgentID, AgentType, AlertLocation, Analytics, CapSimState, CarID, Command, CreateCar,
     DrawCarInput, DrawPedCrowdInput, DrawPedestrianInput, DrivingSimState, Event, GetDrawAgents,
-    IntersectionSimState, OrigPersonID, PandemicModel, ParkedCar, ParkingSimState, ParkingSpot,
-    PedestrianID, Person, PersonID, PersonState, Router, Scenario, Scheduler, SidewalkPOI,
-    SidewalkSpot, TransitSimState, TripID, TripInfo, TripManager, TripPhaseType, TripResult,
-    TripSpawner, UnzoomedAgent, Vehicle, VehicleSpec, VehicleType, WalkingSimState, BUS_LENGTH,
-    LIGHT_RAIL_LENGTH, MIN_CAR_LENGTH, SPAWN_DIST,
+    IntersectionSimState, OrigPersonID, PandemicModel, ParkedCar, ParkingSim, ParkingSimState,
+    ParkingSpot, PedestrianID, Person, PersonID, PersonState, Router, Scenario, Scheduler,
+    SidewalkPOI, SidewalkSpot, TransitSimState, TripID, TripInfo, TripManager, TripPhaseType,
+    TripResult, TripSpawner, UnzoomedAgent, Vehicle, VehicleSpec, VehicleType, WalkingSimState,
+    BUS_LENGTH, LIGHT_RAIL_LENGTH, MIN_CAR_LENGTH, SPAWN_DIST,
 };
 use abstutil::{prettyprint_usize, serialized_size_bytes, Counter, Parallelism, Timer};
 use geom::{Distance, Duration, PolyLine, Pt2D, Speed, Time};

--- a/sim/src/trips.rs
+++ b/sim/src/trips.rs
@@ -1,8 +1,8 @@
 use crate::sim::Ctx;
 use crate::{
     AgentID, AgentType, AlertLocation, CarID, Command, CreateCar, CreatePedestrian, DrivingGoal,
-    Event, IndividTrip, OffMapLocation, OrigPersonID, ParkedCar, ParkingSpot, PedestrianID,
-    PersonID, PersonSpec, Scenario, Scheduler, SidewalkPOI, SidewalkSpot, SpawnTrip,
+    Event, IndividTrip, OffMapLocation, OrigPersonID, ParkedCar, ParkingSim, ParkingSpot,
+    PedestrianID, PersonID, PersonSpec, Scenario, Scheduler, SidewalkPOI, SidewalkSpot, SpawnTrip,
     TransitSimState, TripID, TripPhaseType, TripSpec, Vehicle, VehicleSpec, VehicleType,
     WalkingSimState,
 };


### PR DESCRIPTION
This adds an `--infinite_parking` flag that assigns unlimited capacity to all buildings, getting rid of the effects of looking for parking far away.

Unresolved bug, will investigate later: the "parking efficiency" layer should just show 0 seconds between car and owner. But at midnight, there are some long paths. Why?

Implementation-wise, this turned out a little more complicated than I hoped. OOP-style, we split into a trait and two implementations. To avoid plumbing the generic everywhere or passing `Box<dyn ParkingSim>` and having a runtime perf hit, using an enum with `enum_dispatch` to do the delegation boilerplate. Alternative ideas:
- Keep the existing implementation and just fill out lots of offstreet spots for every building. EXTREMELY slow to seed parking, open the parking layer, etc. And it was a hack, assigning 999 spots to every building; theoretically that could even fill up.
- Keep the existing impl, but add an `infinite: bool` and do some branching on a few of the affected methods. This could reduce a little code duplication, but I think the infinite one works differently enough to explicitly think through how each method in the API is affected.
- Keep the existing impl, but **move ParkingSpot::Offstreet generation** to a method that lazily adds "just one more extra spot" for every building. This might be simpler than the current thing, although I still think parking seeding would have to be branched. I didn't implement this idea yet, but bolding it to maybe try later.

@michaelkirk I'm going to ASAP merge this to avoid more local branching, but feel free to review at your leisure. I'm quite open to approaching this differently.