### PR TITLE
fix building overlap for isometric view (mostly)

### DIFF
--- a/game/src/render/building.rs
+++ b/game/src/render/building.rs
@@ -84,7 +84,6 @@ impl DrawBuilding {
                 let map_length = Pt2D::new(0.0, 0.0).dist_to(map_max).inner_meters();
 
                 let distance = |pt: &Pt2D| {
-                    // this is flipped...
                     let projection_origin = match x {
                         CameraAngle::IsometricNE => Pt2D::new(0.0, map_height),
                         CameraAngle::IsometricNW => Pt2D::new(map_width, map_height),
@@ -93,30 +92,15 @@ impl DrawBuilding {
                         CameraAngle::TopDown => unreachable!(),
                     };
 
-                    let ortho_axis = match x {
-                        CameraAngle::IsometricNE => Line::new(
-                            projection_origin.offset(-map_length / 2., -map_length / 2.),
-                            projection_origin.offset(map_length / 2., map_length / 2.),
-                        ),
-                        CameraAngle::IsometricNW => Line::new(
-                            projection_origin.offset(-map_length / 2., map_length / 2.),
-                            projection_origin.offset(map_length / 2., -map_length / 2.),
-                        ),
-                        CameraAngle::IsometricSE => Line::new(
-                            projection_origin.offset(map_length / 2., map_length / 2.),
-                            projection_origin.offset(-map_length / 2., -map_length / 2.),
-                        ),
-                        CameraAngle::IsometricSW => Line::new(
-                            projection_origin.offset(-map_length / 2., map_length / 2.),
-                            projection_origin.offset(map_length / 2., -map_length / 2.),
-                        ),
-                        CameraAngle::TopDown => unreachable!(),
-                    }
-                    .unwrap();
+                    let abs_pt = Pt2D::new(
+                        (pt.x() - projection_origin.x()).abs(),
+                        (pt.y() - projection_origin.y()).abs(),
+                    );
 
-                    // TODO: compute distance to line directly
-                    let nearest_point_on_axis = ortho_axis.project_pt(*pt);
-                    pt.dist_to(nearest_point_on_axis)
+                    let a = f64::hypot(abs_pt.x(), abs_pt.y());
+                    let theta = f64::atan(abs_pt.y() / abs_pt.x());
+                    let distance = a * f64::sin(theta + std::f64::consts::PI / 4.0);
+                    Distance::meters(distance)
                 };
 
                 // Things closer to the isometric projection origin should appear in front of

--- a/game/src/render/building.rs
+++ b/game/src/render/building.rs
@@ -168,7 +168,7 @@ impl DrawBuilding {
                         );
                     }
 
-                    let roof_z = z - height.inner_meters().sqrt() / scale_factor;
+                    let roof_z = z - height.inner_meters() / scale_factor;
                     bldg_batch.push_with_z(bldg_color, roof.clone().to_polygon(), roof_z);
                     bldg_batch.push_with_z(
                         Color::BLACK,

--- a/widgetry/src/backend_glow.rs
+++ b/widgetry/src/backend_glow.rs
@@ -213,10 +213,10 @@ impl PrerenderInnards {
     }
 
     pub fn actually_upload(&self, permanent: bool, batch: GeomBatch) -> Drawable {
-        let mut vertices: Vec<[f32; 7]> = Vec::new();
+        let mut vertices: Vec<[f32; 8]> = Vec::new();
         let mut indices: Vec<u32> = Vec::new();
 
-        for (color, poly) in batch.consume() {
+        for (color, poly, z) in batch.consume() {
             let idx_offset = vertices.len() as u32;
             let (pts, raw_indices) = poly.raw_for_rendering();
             for pt in pts {
@@ -224,6 +224,7 @@ impl PrerenderInnards {
                 vertices.push([
                     pt.x() as f32,
                     pt.y() as f32,
+                    z as f32,
                     style[0],
                     style[1],
                     style[2],
@@ -261,7 +262,7 @@ impl PrerenderInnards {
             );
 
             let vertex_attributes: [i32; 3] = [
-                2, // position is vec2
+                3, // position is vec2
                 4, // color is vec4
                 1, // texture_id is float
             ];

--- a/widgetry/src/drawing.rs
+++ b/widgetry/src/drawing.rs
@@ -7,9 +7,10 @@ use geom::{Bounds, Polygon, Pt2D};
 use std::cell::{Cell, RefCell};
 
 // Lower is more on top
-const MAPSPACE_Z: f32 = 1.0;
-const SCREENSPACE_Z: f32 = 0.5;
-const TOOLTIP_Z: f32 = 0.0;
+pub(crate) const MAPSPACE_Z: f32 = 1.0;
+pub(crate) const SCREENSPACE_Z: f32 = 0.0;
+pub(crate) const MENU_Z: f32 = -1.0;
+pub(crate) const TOOLTIP_Z: f32 = -2.0;
 
 #[derive(Debug)]
 pub struct Uniforms {

--- a/widgetry/src/drawing.rs
+++ b/widgetry/src/drawing.rs
@@ -6,7 +6,11 @@ use crate::{
 use geom::{Bounds, Polygon, Pt2D};
 use std::cell::{Cell, RefCell};
 
-// Lower is more on top
+// We organize major layers of the app with whole number z values, with lower values being more on
+// top.
+//
+// Within each layer, we must only adjust the z-offset of individual polygons within (-1, 0] to
+// avoid traversing layers.
 pub(crate) const MAPSPACE_Z: f32 = 1.0;
 pub(crate) const SCREENSPACE_Z: f32 = 0.0;
 pub(crate) const MENU_Z: f32 = -1.0;

--- a/widgetry/src/geom.rs
+++ b/widgetry/src/geom.rs
@@ -22,7 +22,11 @@ impl GeomBatch {
 
     // Adds a single polygon, painted according to `Fill`
     pub fn push<F: Into<Fill>>(&mut self, fill: F, p: Polygon) {
-        self.list.push((fill.into(), p, 0.0));
+        self.push_with_z(fill, p, 0.0);
+    }
+
+    pub fn push_with_z<F: Into<Fill>>(&mut self, fill: F, p: Polygon, z: f64) {
+        self.list.push((fill.into(), p, z));
     }
 
     /// Applies one Fill to many polygons.

--- a/widgetry/src/geom.rs
+++ b/widgetry/src/geom.rs
@@ -7,7 +7,7 @@ use geom::{Angle, Bounds, Polygon, Pt2D};
 /// A mutable builder for a group of colored polygons.
 #[derive(Clone)]
 pub struct GeomBatch {
-    pub(crate) list: Vec<(Fill, Polygon)>,
+    pub(crate) list: Vec<(Fill, Polygon, f64)>,
     pub autocrop_dims: bool,
 }
 
@@ -22,14 +22,14 @@ impl GeomBatch {
 
     // Adds a single polygon, painted according to `Fill`
     pub fn push<F: Into<Fill>>(&mut self, fill: F, p: Polygon) {
-        self.list.push((fill.into(), p));
+        self.list.push((fill.into(), p, 0.0));
     }
 
     /// Applies one Fill to many polygons.
     pub fn extend<F: Into<Fill>>(&mut self, fill: F, polys: Vec<Polygon>) {
         let fill = fill.into();
         for p in polys {
-            self.list.push((fill.clone(), p));
+            self.list.push((fill.clone(), p, 0.0));
         }
     }
 
@@ -39,7 +39,7 @@ impl GeomBatch {
     }
 
     /// Returns the colored polygons in this batch, destroying the batch.
-    pub fn consume(self) -> Vec<(Fill, Polygon)> {
+    pub fn consume(self) -> Vec<(Fill, Polygon, f64)> {
         self.list
     }
 
@@ -72,7 +72,7 @@ impl GeomBatch {
     /// Compute the bounds of all polygons in this batch.
     pub fn get_bounds(&self) -> Bounds {
         let mut bounds = Bounds::new();
-        for (_, poly) in &self.list {
+        for (_, poly, _) in &self.list {
             bounds.union(poly.get_bounds());
         }
         if !self.autocrop_dims {
@@ -87,7 +87,7 @@ impl GeomBatch {
         if bounds.min_x == 0.0 && bounds.min_y == 0.0 {
             return self;
         }
-        for (_, poly) in &mut self.list {
+        for (_, poly, _) in &mut self.list {
             *poly = poly.translate(-bounds.min_x, -bounds.min_y);
         }
         self
@@ -96,7 +96,7 @@ impl GeomBatch {
     /// Builds a single polygon covering everything in this batch. Use to create a hitbox.
     pub fn unioned_polygon(&self) -> Polygon {
         let mut result = self.list[0].1.clone();
-        for (_, p) in &self.list[1..] {
+        for (_, p, _) in &self.list[1..] {
             result = result.union(p.clone());
         }
         result
@@ -133,7 +133,7 @@ impl GeomBatch {
 
     /// Transforms all colors in a batch.
     pub fn color(mut self, transformation: RewriteColor) -> GeomBatch {
-        for (fancy, _) in &mut self.list {
+        for (fancy, _, _) in &mut self.list {
             if let Fill::Color(ref mut c) = fancy {
                 *c = transformation.apply(*c);
             }
@@ -151,7 +151,7 @@ impl GeomBatch {
 
     /// Translates the batch by some offset.
     pub fn translate(mut self, dx: f64, dy: f64) -> GeomBatch {
-        for (_, poly) in &mut self.list {
+        for (_, poly, _) in &mut self.list {
             *poly = poly.translate(dx, dy);
         }
         self
@@ -159,7 +159,7 @@ impl GeomBatch {
 
     /// Rotates each polygon in the batch relative to the center of that polygon.
     pub fn rotate(mut self, angle: Angle) -> GeomBatch {
-        for (_, poly) in &mut self.list {
+        for (_, poly, _) in &mut self.list {
             *poly = poly.rotate(angle);
         }
         self
@@ -168,7 +168,7 @@ impl GeomBatch {
     /// Rotates each polygon in the batch relative to the center of the entire batch.
     pub fn rotate_around_batch_center(mut self, angle: Angle) -> GeomBatch {
         let center = self.get_bounds().center();
-        for (_, poly) in &mut self.list {
+        for (_, poly, _) in &mut self.list {
             *poly = poly.rotate_around(angle, center);
         }
         self
@@ -179,7 +179,7 @@ impl GeomBatch {
         if factor == 1.0 {
             return self;
         }
-        for (_, poly) in &mut self.list {
+        for (_, poly, _) in &mut self.list {
             // strip_rings first -- sometimes when scaling down, the original rings collapse. Since
             // this polygon is part of a GeomBatch anyway, not calling to_outline on it.
             *poly = poly.strip_rings().scale(factor);
@@ -192,7 +192,7 @@ impl<F: Into<Fill>> From<Vec<(F, Polygon)>> for GeomBatch {
     /// Creates a batch of filled polygons.
     fn from(list: Vec<(F, Polygon)>) -> GeomBatch {
         GeomBatch {
-            list: list.into_iter().map(|(c, p)| (c.into(), p)).collect(),
+            list: list.into_iter().map(|(c, p)| (c.into(), p, 0.0)).collect(),
             autocrop_dims: true,
         }
     }

--- a/widgetry/src/shaders/vertex_140.glsl
+++ b/widgetry/src/shaders/vertex_140.glsl
@@ -25,7 +25,7 @@ void main() {
     // Translate that to normalized device coordinates (NDC)
     float x = (screen_x / window[0] * 2.0) - 1.0;
     float y = (screen_y / window[1] * 2.0) - 1.0;
-    float z = position[2] / 10000.0 + window[2];
+    float z = position[2] + window[2];
 
     // Note the y inversion
     gl_Position = vec4(x, -y, z, 1.0);

--- a/widgetry/src/shaders/vertex_140.glsl
+++ b/widgetry/src/shaders/vertex_140.glsl
@@ -7,7 +7,7 @@ uniform vec3 window;
 // textures grid
 uniform sampler2DArray textures;
 
-layout (location = 0) in vec2 position;
+layout (location = 0) in vec3 position;
 layout (location = 1) in vec4 color;
 layout (location = 2) in float texture_index;
 
@@ -25,9 +25,10 @@ void main() {
     // Translate that to normalized device coordinates (NDC)
     float x = (screen_x / window[0] * 2.0) - 1.0;
     float y = (screen_y / window[1] * 2.0) - 1.0;
+    float z = position[2] / 10000.0 + window[2];
 
     // Note the y inversion
-    gl_Position = vec4(x, -y, window[2], 1.0);
+    gl_Position = vec4(x, -y, z, 1.0);
 
     // An arbitrary factor to scale the textures we're using.
     //

--- a/widgetry/src/widgets/dropdown.rs
+++ b/widgetry/src/widgets/dropdown.rs
@@ -146,8 +146,7 @@ impl<T: 'static + Clone> WidgetImpl for Dropdown<T> {
                 Pt2D::new(0.0, 0.0),
                 ScreenPt::new(m.top_left.x - pad, m.top_left.y - pad),
                 1.0,
-                // Between SCREENSPACE_Z and TOOLTIP_Z
-                Some(0.1),
+                Some(crate::drawing::MENU_Z),
             );
             g.redraw(&draw_bg);
             g.unfork();

--- a/widgetry/src/widgets/menu.rs
+++ b/widgetry/src/widgets/menu.rs
@@ -160,8 +160,12 @@ impl<T: 'static> WidgetImpl for Menu<T> {
         }
 
         let draw = g.upload(self.calculate_txt(g.style()).render_g(g));
-        // In between tooltip and normal screenspace
-        g.fork(Pt2D::new(0.0, 0.0), self.top_left, 1.0, Some(0.1));
+        g.fork(
+            Pt2D::new(0.0, 0.0),
+            self.top_left,
+            1.0,
+            Some(crate::drawing::MENU_Z),
+        );
         g.redraw(&draw);
         g.unfork();
 


### PR DESCRIPTION
**Before**

In the current isometric rendering, there are perspective issues with buildings being rendered on top of eachother in undesirable ways. And note the car parked on the building roof.

<img width="1792" alt="Screen Shot 2020-09-18 at 4 19 54 PM" src="https://user-images.githubusercontent.com/217057/93652694-cad6b480-f9ca-11ea-8a17-dba8230b74b9.png">

Disregard that some of the building's groundfloors juts into the street. As you can see here, it's present in the default rendering, before these changes, and seems to just be bad OSM data:

<img width="564" alt="Screen Shot 2020-09-18 at 4 19 33 PM" src="https://user-images.githubusercontent.com/217057/93652727-f8236280-f9ca-11ea-9936-4f2785b7a846.png">

**After**

Most buildings look good after these changes.

<img width="1792" alt="Screen Shot 2020-09-18 at 4 17 13 PM" src="https://user-images.githubusercontent.com/217057/93652615-821efb80-f9ca-11ea-9f84-af0c530e49be.png">

You can see the z-indexes make sense for agents traveling behind the buildings too, as far as perspective goes. But as discussed previously, this might undesirably obscure details of the simulation. Future work which might address this could be some level of transparency, or rotation, or something else.

![iso_buildings mov](https://user-images.githubusercontent.com/217057/93652610-7c291a80-f9ca-11ea-9c61-4b100c3cacb8.gif)

## math

The thrust of this change is to offset the z-value**, based on it's distance from the orthographic axis. I've attached a drawing which may or may not help clarify:

![ortho_math](https://user-images.githubusercontent.com/217057/93653208-c27f7900-f9cc-11ea-9191-45a3cc8bb569.jpg)

**futzing with z-indices is fraught with peril, but I'm not sure how else to address something like this.  My proposal for enforcing a modicum of sanity is:

We already have some course grained base app layers which have an associated z-index.
1. map
2. menu
3. tooltips
4. etc.

The z-value for these layers should be whole integer values.

Any adjustment to z, like we do for building height, is applied to the base layer, and must not exceed 1.0, so that way we don't inadvertently traverse layers, e.g. we don't want a really tall building to be rendered "above" a tooltip.

Like I said, it's kind of fraught, but it's the best I could come up with. 🤷

I'm not married to this approach if you have other ideas, or just want to hold off on merging for now.