### PR TITLE
use osm data for actual building height

### DIFF
--- a/game/src/render/building.rs
+++ b/game/src/render/building.rs
@@ -72,9 +72,9 @@ impl DrawBuilding {
                 };
 
                 let bldg_height_per_level = 3.5;
-                // artifically compress height of tall buildings. Subjectively, this makes
-                // downtown areas a little more pleasant to look at.
-                let bldg_rendered_meters = bldg_height_per_level * bldg.levels;
+                // In downtown areas, really tall buildings look kind of ridculous next to
+                // everything else. So we artifically compress the number of levels a bit.
+                let bldg_rendered_meters = bldg_height_per_level * bldg.levels.powf(0.8);
                 let height = Distance::meters(bldg_rendered_meters);
 
                 let map_bounds = map.get_gps_bounds().to_bounds();

--- a/game/src/render/building.rs
+++ b/game/src/render/building.rs
@@ -5,8 +5,6 @@ use crate::options::{CameraAngle, Options};
 use crate::render::{DrawOptions, Renderable, OUTLINE_THICKNESS};
 use geom::{Angle, Distance, Line, Polygon, Pt2D, Ring};
 use map_model::{Building, BuildingID, Map, OffstreetParking, NORMAL_LANE_THICKNESS};
-use rand::{Rng, SeedableRng};
-use rand_xorshift::XorShiftRng;
 use std::cell::RefCell;
 use widgetry::{Color, Drawable, EventCtx, GeomBatch, GfxCtx, Line, Text};
 
@@ -73,10 +71,11 @@ impl DrawBuilding {
                     _ => unreachable!(),
                 };
 
-                // TODO For now, blindly guess the building height
-                let max_height = 15.0;
-                let mut rng = XorShiftRng::seed_from_u64(bldg.id.0 as u64);
-                let height = Distance::meters(rng.gen_range(1.0, max_height));
+                let bldg_height_per_level = 3.5;
+                // artifically compress height of tall buildings. Subjectively, this makes
+                // downtown areas a little more pleasant to look at.
+                let bldg_rendered_meters = bldg_height_per_level * bldg.levels;
+                let height = Distance::meters(bldg_rendered_meters);
 
                 let map_bounds = map.get_gps_bounds().to_bounds();
                 let (map_width, map_height) = (map_bounds.width(), map_bounds.height());
@@ -122,8 +121,8 @@ impl DrawBuilding {
                     .unwrap_or(0.0);
 
                 // smaller z renders above larger
-                let scale_factor = map_length + max_height;
-                let groundfloor_z = (distance_from_projection_axis) / scale_factor - 1.0;
+                let scale_factor = map_length;
+                let groundfloor_z = distance_from_projection_axis / scale_factor - 1.0;
                 let roof_z = groundfloor_z - height.inner_meters() / scale_factor;
 
                 // TODO Some buildings have holes in them

--- a/map_model/src/make/buildings.rs
+++ b/map_model/src/make/buildings.rs
@@ -60,7 +60,8 @@ pub fn make_all_buildings(
 
             let mut rng = XorShiftRng::seed_from_u64(orig_id.inner() as u64);
             // TODO is it worth using height or building:height as an alternative if not tagged?
-            let levels = b.osm_tags
+            let levels = b
+                .osm_tags
                 .get("building:levels")
                 .and_then(|x| x.parse::<f64>().ok())
                 .unwrap_or(1.0);
@@ -74,7 +75,13 @@ pub fn make_all_buildings(
                 orig_id,
                 label_center: b.polygon.polylabel(),
                 amenities: b.amenities.clone(),
-                bldg_type: classify_bldg(&b.osm_tags, &b.amenities, levels, b.polygon.area(), &mut rng),
+                bldg_type: classify_bldg(
+                    &b.osm_tags,
+                    &b.amenities,
+                    levels,
+                    b.polygon.area(),
+                    &mut rng,
+                ),
                 parking: if let Some(n) = b.public_garage_name.clone() {
                     OffstreetParking::PublicGarage(n, b.num_parking_spots)
                 } else {

--- a/map_model/src/make/buildings.rs
+++ b/map_model/src/make/buildings.rs
@@ -57,16 +57,24 @@ pub fn make_all_buildings(
             };
 
             let id = BuildingID(results.len());
+
             let mut rng = XorShiftRng::seed_from_u64(orig_id.inner() as u64);
+            // TODO is it worth using height or building:height as an alternative if not tagged?
+            let levels = b.osm_tags
+                .get("building:levels")
+                .and_then(|x| x.parse::<f64>().ok())
+                .unwrap_or(1.0);
+
             results.push(Building {
                 id,
                 polygon: b.polygon.clone(),
+                levels,
                 address: get_address(&b.osm_tags, sidewalk_pos.lane(), map),
                 name: NamePerLanguage::new(&b.osm_tags),
                 orig_id,
                 label_center: b.polygon.polylabel(),
                 amenities: b.amenities.clone(),
-                bldg_type: classify_bldg(&b.osm_tags, &b.amenities, b.polygon.area(), &mut rng),
+                bldg_type: classify_bldg(&b.osm_tags, &b.amenities, levels, b.polygon.area(), &mut rng),
                 parking: if let Some(n) = b.public_garage_name.clone() {
                     OffstreetParking::PublicGarage(n, b.num_parking_spots)
                 } else {
@@ -117,6 +125,7 @@ fn get_address(tags: &Tags, sidewalk: LaneID, map: &Map) -> String {
 fn classify_bldg(
     tags: &Tags,
     amenities: &BTreeSet<(NamePerLanguage, String)>,
+    levels: f64,
     ground_area_sq_meters: f64,
     rng: &mut XorShiftRng,
 ) -> BuildingType {
@@ -124,11 +133,6 @@ fn classify_bldg(
 
     let mut commercial = false;
 
-    // TODO is it worth using height or building:height as an alternative if not tagged?
-    let levels = tags
-        .get("building:levels")
-        .and_then(|x| x.parse::<f64>().ok())
-        .unwrap_or(1.0);
     let area_sq_meters = levels * ground_area_sq_meters;
 
     // These are (name, amenity type) pairs, produced by get_bldg_amenities in

--- a/map_model/src/objects/building.rs
+++ b/map_model/src/objects/building.rs
@@ -26,6 +26,7 @@ impl fmt::Display for BuildingID {
 pub struct Building {
     pub id: BuildingID,
     pub polygon: Polygon,
+    pub levels: f64,
     pub address: String,
     pub name: Option<NamePerLanguage>,
     pub orig_id: osm::OsmID,


### PR DESCRIPTION
Rather than a random building height, we can often pull real building height from OSM:

<img width="1792" alt="Screen Shot 2020-09-21 at 3 50 08 PM" src="https://user-images.githubusercontent.com/217057/93830093-1b951a00-fc24-11ea-863b-c3dea3da64f4.png">


I found that the reallllly tall buildings looked a little too dominate in downtown areas, so I compressed their height a a bit. 

Here's how it would look without that height compression - WDYT?:

<img width="1792" alt="Screen Shot 2020-09-21 at 3 56 15 PM" src="https://user-images.githubusercontent.com/217057/93830096-1cc64700-fc24-11ea-8649-5b7b7eb10950.png">

Note that because this adds a field to Building, it requires re-importing map data.