### PR TITLE
apply missing pop up button style

### DIFF
--- a/game/src/devtools/story.rs
+++ b/game/src/devtools/story.rs
@@ -311,7 +311,7 @@ fn make_panel(ctx: &mut EventCtx, story: &StoryMap, mode: &Mode, dirty: bool) ->
         Widget::row(vec![
             Line("Story map editor").small_heading().draw(ctx),
             Widget::vert_separator(ctx, 30.0),
-            Btn::text_fg(format!("{} ↓", story.name)).build(ctx, "load", lctrl(Key::L)),
+            Btn::pop_up(ctx, Some(&story.name)).build(ctx, "load", lctrl(Key::L)),
             if dirty {
                 Btn::svg_def("system/assets/tools/save.svg").build(ctx, "save", lctrl(Key::S))
             } else {

--- a/game/src/edit/mod.rs
+++ b/game/src/edit/mod.rs
@@ -746,11 +746,7 @@ fn make_changelist(ctx: &mut EventCtx, app: &App) -> Panel {
     let edits = app.primary.map.get_edits();
     let mut col = vec![
         Widget::row(vec![
-            Btn::plaintext(format!("{} ↓", &edits.edits_name)).build(
-                ctx,
-                "manage proposals",
-                lctrl(Key::P),
-            ),
+            Btn::pop_up(ctx, Some(&edits.edits_name)).build(ctx, "manage proposals", lctrl(Key::P)),
             "autosaved"
                 .draw_text(ctx)
                 .container()

--- a/widgetry/examples/demo.rs
+++ b/widgetry/examples/demo.rs
@@ -123,9 +123,9 @@ impl App {
             ctx,
             "stopwatch",
             format!("Stopwatch: {}", self.elapsed)
-            .draw_text(ctx)
-            .named("stopwatch"),
-            );
+                .draw_text(ctx)
+                .named("stopwatch"),
+        );
     }
 }
 
@@ -141,7 +141,7 @@ impl GUI for App {
                 // typesafe.
                 "reset the stopwatch" => {
                     self.elapsed = Duration::ZERO;
-                    self.redraw_stopwatch(ctx); 
+                    self.redraw_stopwatch(ctx);
                 }
                 "generate new faces" => {
                     self.scrollable_canvas = setup_scrollable_canvas(ctx);
@@ -301,7 +301,10 @@ fn make_controls(ctx: &mut EventCtx) -> Panel {
             Checkbox::switch(ctx, "Draw scrollable canvas", None, true),
             Checkbox::switch(ctx, "Show timeseries", lctrl(Key::T), false),
         ]),
-        "Stopwatch: ...".draw_text(ctx).named("stopwatch").margin_above(30),
+        "Stopwatch: ..."
+            .draw_text(ctx)
+            .named("stopwatch")
+            .margin_above(30),
         Widget::row(vec![
             Checkbox::new(
                 false,
@@ -322,7 +325,6 @@ fn make_controls(ctx: &mut EventCtx) -> Panel {
             Btn::text_fg("Reset Timer").build(ctx, "reset the stopwatch", None),
         ])
         .evenly_spaced(),
-
         Widget::row(vec![
             Widget::dropdown(
                 ctx,
@@ -330,11 +332,12 @@ fn make_controls(ctx: &mut EventCtx) -> Panel {
                 (Texture::SAND, Texture::CACTUS),
                 vec![
                     Choice::new("Cold", (Texture::SNOW, Texture::SNOW_PERSON)),
-                    Choice::new("Hot", (Texture::SAND, Texture::CACTUS))
+                    Choice::new("Hot", (Texture::SAND, Texture::CACTUS)),
                 ],
             ),
             Btn::text_fg("Apply Textures").build(ctx, "apply textures", None),
-        ]).margin_above(30),
+        ])
+        .margin_above(30),
     ]))
     .aligned(HorizontalAlignment::Center, VerticalAlignment::Top)
     .build(ctx)

--- a/widgetry/src/widgets/button.rs
+++ b/widgetry/src/widgets/button.rs
@@ -226,9 +226,10 @@ impl Btn {
             .padding_right(8)
             .to_geom(ctx, None);
 
-        let hovered = button_geom
-            .clone()
-            .color(RewriteColor::Change(ctx.style().outline_color, ctx.style().hovering_color));
+        let hovered = button_geom.clone().color(RewriteColor::Change(
+            ctx.style().outline_color,
+            ctx.style().hovering_color,
+        ));
 
         let outline = (ctx.style().outline_thickness, ctx.style().outline_color);
         BtnBuilder::Custom {


### PR DESCRIPTION
>  I spot a few more uses of ↑ and ↓ that could be migrated. Either of us could tackle that in a followup

Follow up to https://github.com/dabreegster/abstreet/pull/344, to replace the remaining drop down ↓ with ▾ - sorry that I missed these on the first pass!

Note that though this completes the replacement for drop-down handles, there are still a couple places I intentionally left in the ↑/↓ - controls that are explicitly about direction:

e.g. the increment decrement operations:

<img width="356" alt="Screen Shot 2020-09-24 at 10 33 23 PM" src="https://user-images.githubusercontent.com/217057/94230054-f6b7d580-feb5-11ea-9121-78bea63374aa.png">

e.g. the signal re-ordering

<img width="495" alt="Screen Shot 2020-09-24 at 10 33 46 PM" src="https://user-images.githubusercontent.com/217057/94230075-03d4c480-feb6-11ea-8fb4-04ee8474d041.png">

What do you think about keeping these as arrows @dabreegster?