### PR TITLE
Clean up "trips" (info/person.rs)

### DIFF
--- a/game/src/info/person.rs
+++ b/game/src/info/person.rs
@@ -1,6 +1,6 @@
 use crate::app::App;
 use crate::info::{building, header_btns, make_table, make_tabs, trip, Details, OpenTrip, Tab};
-use geom::{Duration, Time};
+use geom::{Angle, Duration, Time};
 use map_model::Map;
 use rand::seq::SliceRandom;
 use rand::{Rng, SeedableRng};
@@ -149,7 +149,12 @@ pub fn trips(
                 .batch(),
                 // Without this bottom padding, text is much closer to bottom of pill than top -
                 // seemingly moreso than just text ascender/descender descrepancies - why?
-                Line(trip_status).small().fg(color).batch(ctx).container().padding_bottom(2),
+                Line(trip_status)
+                    .small()
+                    .fg(color)
+                    .batch(ctx)
+                    .container()
+                    .padding_bottom(2),
             ])
             .centered()
             .fully_rounded()
@@ -187,15 +192,23 @@ pub fn trips(
             } else {
                 Widget::nothing()
             },
-            if open_trips.contains_key(t) {
-                "↓"
-            } else {
-                "↑"
-            }
-            .batch_text(ctx)
-            .centered_vert()
-            .align_right(),
+            {
+                let mut icon = GeomBatch::load_svg(
+                    ctx.prerender,
+                    "system/assets/widgetry/arrow_drop_down.svg",
+                )
+                .autocrop()
+                .color(RewriteColor::ChangeAll(Color::WHITE))
+                .scale(1.5);
+
+                if !open_trips.contains_key(t) {
+                    icon = icon.rotate(Angle::new_degs(180.0));
+                }
+
+                icon.batch().container().align_right().margin_right(10)
+            },
         ])
+        .centered()
         .outline(2.0, Color::WHITE)
         .padding(16)
         .bg(app.cs.inner_panel)

--- a/game/src/info/person.rs
+++ b/game/src/info/person.rs
@@ -11,7 +11,8 @@ use sim::{
 };
 use std::collections::BTreeMap;
 use widgetry::{
-    Btn, Color, EventCtx, GeomBatch, Key, Line, RewriteColor, Text, TextExt, TextSpan, Widget,
+    Btn, Color, EdgeInsets, EventCtx, GeomBatch, Key, Line, RewriteColor, Text, TextExt, TextSpan,
+    Widget,
 };
 
 pub fn trips(
@@ -142,16 +143,24 @@ pub fn trips(
                 )
                 // we want the icon to be about the same height as the text
                 .scale(0.75)
+                // discard any padding built into the svg
                 .autocrop()
                 .color(RewriteColor::ChangeAll(color))
                 .batch(),
-                Line(trip_status).small().fg(color).batch(ctx),
+                // Without this bottom padding, text is much closer to bottom of pill than top -
+                // seemingly moreso than just text ascender/descender descrepancies - why?
+                Line(trip_status).small().fg(color).batch(ctx).container().padding_bottom(2),
             ])
             .centered()
             .fully_rounded()
             .outline(1.0, color)
             .bg(color.alpha(0.2))
-            .padding(10)
+            .padding(EdgeInsets {
+                top: 5.0,
+                bottom: 5.0,
+                left: 10.0,
+                right: 10.0,
+            })
             .margin_right(21),
             if trip.modified {
                 Line("modified").batch(ctx).centered_vert().margin_right(15)

--- a/game/src/info/person.rs
+++ b/game/src/info/person.rs
@@ -140,14 +140,14 @@ pub fn trips(
                         TripMode::Transit => "system/assets/meters/bus.svg",
                     },
                 )
+                // we want the icon to be about the same height as the text
+                .scale(0.75)
+                .autocrop()
                 .color(RewriteColor::ChangeAll(color))
                 .batch(),
-                Line(trip_status)
-                    .small()
-                    .fg(color)
-                    .batch(ctx)
-                    .centered_vert(),
+                Line(trip_status).small().fg(color).batch(ctx),
             ])
+            .centered()
             .fully_rounded()
             .outline(1.0, color)
             .bg(color.alpha(0.2))

--- a/widgetry/src/lib.rs
+++ b/widgetry/src/lib.rs
@@ -85,7 +85,7 @@ pub use crate::widgets::scatter_plot::ScatterPlot;
 pub use crate::widgets::slider::{AreaSlider, Slider};
 pub use crate::widgets::spinner::Spinner;
 pub(crate) use crate::widgets::text_box::TextBox;
-pub use crate::widgets::{Outcome, Panel, Widget, WidgetImpl, WidgetOutput};
+pub use crate::widgets::{EdgeInsets, Outcome, Panel, Widget, WidgetImpl, WidgetOutput};
 
 pub struct Choice<T> {
     pub label: String,

--- a/widgetry/src/widgets/button.rs
+++ b/widgetry/src/widgets/button.rs
@@ -1,6 +1,6 @@
 use crate::{
-    svg, Color, Drawable, EventCtx, GeomBatch, GfxCtx, Line, MultiKey, Outcome, RewriteColor,
-    ScreenDims, ScreenPt, ScreenRectangle, Text, Widget, WidgetImpl, WidgetOutput,
+    svg, Color, Drawable, EdgeInsets, EventCtx, GeomBatch, GfxCtx, Line, MultiKey, Outcome,
+    RewriteColor, ScreenDims, ScreenPt, ScreenRectangle, Text, Widget, WidgetImpl, WidgetOutput,
 };
 use geom::{Distance, Polygon};
 
@@ -220,10 +220,12 @@ impl Btn {
         let (button_geom, hitbox) = button_geom
             .batch()
             .container()
-            .padding_top(4)
-            .padding_bottom(4)
-            .padding_left(8)
-            .padding_right(8)
+            .padding(EdgeInsets {
+                top: 4.0,
+                bottom: 4.0,
+                left: 8.0,
+                right: 8.0,
+            })
             .to_geom(ctx, None);
 
         let hovered = button_geom.clone().color(RewriteColor::Change(

--- a/widgetry/src/widgets/mod.rs
+++ b/widgetry/src/widgets/mod.rs
@@ -194,13 +194,9 @@ impl Widget {
     }
 
     // TODO Maybe panic if we call this on a non-container
-    pub fn padding(mut self, pixels: usize) -> Widget {
-        self.layout.style.padding = Rect {
-            start: Dimension::Points(pixels as f32),
-            end: Dimension::Points(pixels as f32),
-            top: Dimension::Points(pixels as f32),
-            bottom: Dimension::Points(pixels as f32),
-        };
+    pub fn padding<I: Into<EdgeInsets>>(mut self, insets: I) -> Widget {
+        let insets = insets.into();
+        self.layout.style.padding = Rect::from(insets);
         self
     }
 
@@ -221,6 +217,12 @@ impl Widget {
 
     pub fn padding_right(mut self, pixels: usize) -> Widget {
         self.layout.style.padding.end = Dimension::Points(pixels as f32);
+        self
+    }
+
+    pub fn margin<I: Into<EdgeInsets>>(mut self, insets: I) -> Widget {
+        let insets = insets.into();
+        self.layout.style.margin = Rect::from(insets);
         self
     }
 
@@ -699,5 +701,34 @@ impl Widget {
     }
     pub(crate) fn take_just_draw(self) -> JustDraw {
         *self.widget.downcast::<JustDraw>().ok().unwrap()
+    }
+}
+
+pub struct EdgeInsets {
+    pub top: f32,
+    pub left: f32,
+    pub bottom: f32,
+    pub right: f32,
+}
+
+impl From<usize> for EdgeInsets {
+    fn from(uniform_size: usize) -> EdgeInsets {
+        EdgeInsets {
+            top: uniform_size as f32,
+            left: uniform_size as f32,
+            bottom: uniform_size as f32,
+            right: uniform_size as f32,
+        }
+    }
+}
+
+impl From<EdgeInsets> for Rect<Dimension> {
+    fn from(insets: EdgeInsets) -> Rect<Dimension> {
+        Rect {
+            start: Dimension::Points(insets.left),
+            end: Dimension::Points(insets.right),
+            top: Dimension::Points(insets.top),
+            bottom: Dimension::Points(insets.bottom),
+        }
     }
 }


### PR DESCRIPTION
As well as replacing the ↓/↑ with a triangle glyph, also cleans up the pill rendering.

Before:

<img width="1792" alt="Screen Shot 2020-09-25 at 12 46 32 PM" src="https://user-images.githubusercontent.com/217057/94309579-2655f480-ff2d-11ea-84eb-ce0bb8f058c2.png">

Zooming in you can see:
- car icon is too large (figma shows the icon and text having about the same height)
- car icon is not vertically centered.
- "ongoing" text is a smidge too low, IMO.

<img width="507" alt="Screen Shot 2020-09-25 at 12 45 17 PM" src="https://user-images.githubusercontent.com/217057/94309457-f9a1dd00-ff2c-11ea-9c93-dd4a3a85278b.png">

After:

<img width="1792" alt="Screen Shot 2020-09-25 at 12 42 47 PM" src="https://user-images.githubusercontent.com/217057/94309250-9fa11780-ff2c-11ea-9ab7-4e510f17faba.png">

I've pinged Yuwen to double check about the desired rotation of the disclosure triangle when opened vs. close. 

- Previously we rotated the arrow 180 degrees.
- The mockups show no change in "expanded" vs "closed" states
- Conventionally it's a 90 degree rotation, but typically I only see disclosure controls left aligned, so it's not quite comporable.

For now I've stuck with the previous behavior ("up" while closed, "down" while expanded).