### PR TITLE
fix doctest errors 😅 

### DIFF
--- a/widgetry/src/backend_glow_native.rs
+++ b/widgetry/src/backend_glow_native.rs
@@ -104,13 +104,13 @@ impl WindowAdapter {
 /// Once uploaded, textures are addressed by their id, starting from 1, from left to right, top to
 /// bottom, like so:
 ///
-///     ┌─┬─┬─┐
-///     │1│2│3│
-///     ├─┼─┼─┤
-///     │4│5│6│
-///     ├─┼─┼─┤
-///     │7│8│9│
-///     └─┴─┴─┘
+///   ┌─┬─┬─┐
+///   │1│2│3│
+///   ├─┼─┼─┤
+///   │4│5│6│
+///   ├─┼─┼─┤
+///   │7│8│9│
+///   └─┴─┴─┘
 ///
 /// Texture(0) is reserved for a pure white (no-op) texture.
 ///

--- a/widgetry/src/color.rs
+++ b/widgetry/src/color.rs
@@ -28,13 +28,13 @@ pub enum Fill {
     /// Once uploaded, textures are addressed by their id, starting from 1, from left to right, top
     /// to bottom, like so:
     ///
-    ///     ┌─┬─┬─┐
-    ///     │1│2│3│
-    ///     ├─┼─┼─┤
-    ///     │4│5│6│
-    ///     ├─┼─┼─┤
-    ///     │7│8│9│
-    ///     └─┴─┴─┘
+    ///   ┌─┬─┬─┐
+    ///   │1│2│3│
+    ///   ├─┼─┼─┤
+    ///   │4│5│6│
+    ///   ├─┼─┼─┤
+    ///   │7│8│9│
+    ///   └─┴─┴─┘
     ///
     /// Texture(0) is reserved for a pure white (no-op) texture.
     Texture(Texture),


### PR DESCRIPTION
because I significantly indented the unicode diagram, doctest tried to
execute them, and exploded when parsing non-ascii "rust code"

