### PR TITLE
Add a layer to color unzoomed agents based on their current delay, to…

### DIFF
--- a/game/src/layer/mod.rs
+++ b/game/src/layer/mod.rs
@@ -134,6 +134,7 @@ impl PickLayer {
                     } else {
                         Widget::nothing()
                     },
+                    btn("delay per agent", Key::F),
                 ]),
                 Widget::col(vec![
                     "Data".draw_text(ctx),
@@ -227,6 +228,9 @@ impl State for PickLayer {
                 }
                 "commuter patterns" => {
                     return Transition::Replace(dashboards::CommuterPatterns::new(ctx, app));
+                }
+                "delay per agent" => {
+                    app.layer = Some(Box::new(traffic::DelayPerAgent::new(ctx, app)));
                 }
                 _ => unreachable!(),
             },

--- a/sim/src/mechanics/car.rs
+++ b/sim/src/mechanics/car.rs
@@ -264,4 +264,13 @@ impl CarState {
             CarState::IdlingAtStop(_, ref time_int) => time_int.end,
         }
     }
+
+    pub fn time_spent_waiting(&self, now: Time) -> Duration {
+        match self {
+            CarState::Queued { blocked_since } | CarState::WaitingToAdvance { blocked_since } => {
+                now - *blocked_since
+            }
+            _ => Duration::ZERO,
+        }
+    }
 }

--- a/sim/src/mechanics/driving.rs
+++ b/sim/src/mechanics/driving.rs
@@ -895,13 +895,7 @@ impl DrivingSimState {
     pub fn agent_properties(&self, id: CarID, now: Time) -> AgentProperties {
         let car = self.cars.get(&id).unwrap();
         let path = car.router.get_path();
-
-        let time_spent_waiting = match car.state {
-            CarState::Queued { blocked_since } | CarState::WaitingToAdvance { blocked_since } => {
-                now - blocked_since
-            }
-            _ => Duration::ZERO,
-        };
+        let time_spent_waiting = car.state.time_spent_waiting(now);
 
         AgentProperties {
             total_time: now - car.started_at,
@@ -1035,5 +1029,16 @@ impl DrivingSimState {
             }
         }
         affected
+    }
+
+    pub fn all_waiting_people(&self, now: Time, delays: &mut BTreeMap<PersonID, Duration>) {
+        for c in self.cars.values() {
+            if let Some((_, person)) = c.trip_and_person {
+                let delay = c.state.time_spent_waiting(now);
+                if delay > Duration::ZERO {
+                    delays.insert(person, delay);
+                }
+            }
+        }
     }
 }

--- a/sim/src/sim/queries.rs
+++ b/sim/src/sim/queries.rs
@@ -371,6 +371,13 @@ impl Sim {
     pub fn infinite_parking(&self) -> bool {
         self.parking.is_infinite()
     }
+
+    pub fn all_waiting_people(&self) -> BTreeMap<PersonID, Duration> {
+        let mut delays = BTreeMap::new();
+        self.walking.all_waiting_people(self.time, &mut delays);
+        self.driving.all_waiting_people(self.time, &mut delays);
+        delays
+    }
 }
 
 pub struct AgentProperties {


### PR DESCRIPTION
… help debug gridlock. Something like this used to exist as a first-class way to change unzoomed color schemes, but until we have more ideas about showing agent intent on the minimap, just implementing this as a separate layer.

![screencast](https://user-images.githubusercontent.com/1664407/94597575-9b357100-0242-11eb-8065-78970b40948f.gif)

@michaelkirk 