### PR TITLE
Add a tool to see where people blocked on a traffic signal are trying…

### DIFF
--- a/game/src/debug/mod.rs
+++ b/game/src/debug/mod.rs
@@ -1,5 +1,6 @@
 mod floodfill;
 mod objects;
+pub mod path_counter;
 mod polygons;
 pub mod shared_row;
 

--- a/game/src/debug/path_counter.rs
+++ b/game/src/debug/path_counter.rs
@@ -1,0 +1,141 @@
+// A state to count the number of trips that will cross different roads.
+
+use crate::app::{App, ShowEverything};
+use crate::common::{ColorLegend, ColorNetwork, CommonState};
+use crate::game::{State, Transition};
+use crate::helpers::ID;
+use abstutil::Counter;
+use map_model::{IntersectionID, PathStep, RoadID, Traversable};
+use sim::DontDrawAgents;
+use widgetry::{
+    Btn, Color, Drawable, EventCtx, GfxCtx, HorizontalAlignment, Key, Line, Outcome, Panel, Text,
+    VerticalAlignment, Widget,
+};
+
+pub struct PathCounter {
+    panel: Panel,
+    unzoomed: Drawable,
+    zoomed: Drawable,
+    cnt: Counter<RoadID>,
+    tooltip: Option<Text>,
+}
+
+impl PathCounter {
+    pub fn demand_across_intersection(
+        ctx: &mut EventCtx,
+        app: &App,
+        i: IntersectionID,
+    ) -> Box<dyn State> {
+        let map = &app.primary.map;
+        let sim = &app.primary.sim;
+        let mut cnt = Counter::new();
+        // Find all active agents whose path crosses this intersection
+        for agent in sim.active_agents() {
+            if let Some(path) = sim.get_path(agent) {
+                if path.get_steps().iter().any(|step| match step {
+                    PathStep::Turn(t) => t.parent == i,
+                    _ => false,
+                }) {
+                    // Count what lanes they'll cross
+                    for step in path.get_steps() {
+                        if let Traversable::Lane(l) = step.as_traversable() {
+                            cnt.inc(map.get_l(l).parent);
+                        }
+                    }
+                }
+            }
+        }
+
+        let mut colorer = ColorNetwork::new(app);
+        // Highlight the intersection
+        colorer
+            .unzoomed
+            .push(Color::CYAN, map.get_i(i).polygon.clone());
+        colorer
+            .zoomed
+            .push(Color::CYAN.alpha(0.5), map.get_i(i).polygon.clone());
+
+        colorer.ranked_roads(cnt.clone(), &app.cs.good_to_bad_red);
+        let (unzoomed, zoomed) = colorer.build(ctx);
+
+        Box::new(PathCounter {
+            unzoomed,
+            zoomed,
+            tooltip: None,
+            cnt,
+            panel: Panel::new(Widget::col(vec![
+                Widget::row(vec![
+                    Line(format!("Paths across {}", i))
+                        .small_heading()
+                        .draw(ctx),
+                    Btn::text_fg("X")
+                        .build(ctx, "close", Key::Escape)
+                        .align_right(),
+                ]),
+                ColorLegend::gradient(
+                    ctx,
+                    &app.cs.good_to_bad_red,
+                    vec!["lowest count", "highest"],
+                ),
+            ]))
+            .aligned(HorizontalAlignment::Center, VerticalAlignment::Top)
+            .build(ctx),
+        })
+    }
+}
+
+impl State for PathCounter {
+    fn event(&mut self, ctx: &mut EventCtx, app: &mut App) -> Transition {
+        ctx.canvas_movement();
+        if ctx.redo_mouseover() {
+            app.primary.current_selection = app.calculate_current_selection(
+                ctx,
+                &DontDrawAgents {},
+                &ShowEverything::new(),
+                false,
+                true,
+                false,
+            );
+            self.tooltip = None;
+            if let Some(r) = match app.primary.current_selection {
+                Some(ID::Lane(l)) => Some(app.primary.map.get_l(l).parent),
+                Some(ID::Road(r)) => Some(r),
+                _ => None,
+            } {
+                let n = self.cnt.get(r);
+                if n > 0 {
+                    self.tooltip = Some(Text::from(Line(abstutil::prettyprint_usize(n))));
+                }
+            } else {
+                app.primary.current_selection = None;
+            }
+        }
+
+        match self.panel.event(ctx) {
+            Outcome::Clicked(x) => match x.as_ref() {
+                "close" => {
+                    return Transition::Pop;
+                }
+                _ => unreachable!(),
+            },
+            _ => {}
+        }
+
+        Transition::Keep
+    }
+
+    fn draw(&self, g: &mut GfxCtx, app: &App) {
+        self.panel.draw(g);
+        CommonState::draw_osd(g, app);
+
+        if g.canvas.cam_zoom < app.opts.min_zoom_for_detail {
+            g.redraw(&self.unzoomed);
+        } else {
+            g.redraw(&self.zoomed);
+        }
+
+        if let Some(ref txt) = self.tooltip {
+            g.draw_mouse_tooltip(txt.clone());
+        }
+    }
+}

--- a/game/src/info/intersection.rs
+++ b/game/src/info/intersection.rs
@@ -209,6 +209,13 @@ pub fn current_demand(
         .outline(2.0, Color::WHITE),
     );
     rows.push(Btn::text_fg("Explore demand across all traffic signals").build_def(ctx, None));
+    if app.opts.dev {
+        rows.push(Btn::text_fg("Where are these agents headed?").build(
+            ctx,
+            format!("routes across {}", id),
+            None,
+        ));
+    }
 
     rows
 }

--- a/game/src/info/mod.rs
+++ b/game/src/info/mod.rs
@@ -9,6 +9,7 @@ mod trip;
 
 use crate::app::App;
 use crate::common::Warping;
+use crate::debug::path_counter::PathCounter;
 use crate::edit::{EditMode, RouteEditor};
 use crate::game::Transition;
 use crate::helpers::{color_for_agent_type, hotkey_btn, open_browser, ID};
@@ -569,6 +570,15 @@ impl InfoPanel {
                         false,
                         Some(Transition::Push(dashboards::TrafficSignalDemand::new(
                             ctx, app,
+                        ))),
+                    )
+                } else if let Some(x) = action.strip_prefix("routes across Intersection #") {
+                    (
+                        false,
+                        Some(Transition::Push(PathCounter::demand_across_intersection(
+                            ctx,
+                            app,
+                            IntersectionID(x.parse::<usize>().unwrap()),
                         ))),
                     )
                 } else {


### PR DESCRIPTION
… to go

Motivation: You're debugging gridlock and see lots of people waiting at a light. The demand panel shows which directions through the light are most needed, but what're the downstream dependencies where people will be blocked next?

![screencast](https://user-images.githubusercontent.com/1664407/94602243-755f9a80-0249-11eb-9e6b-68f27abd7bd8.gif)

@michaelkirk 