### PR TITLE
Prototype an idea for unit testing the turn generation code. Hardcode a

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1751,6 +1751,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "map_tests"
+version = "0.1.0"
+dependencies = [
+ "abstutil 0.1.0",
+ "convert_osm 0.1.0",
+ "map_model 0.1.0",
+]
+
+[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
   "kml",
   "map_editor",
   "map_model",
+  "map_tests",
   "sim",
   "updater",
   "widgetry",

--- a/book/src/dev/README.md
+++ b/book/src/dev/README.md
@@ -122,6 +122,7 @@ Constructing the map:
   scratch. pretty abandoned as of June 2020
 - `importer`: tool to run the entire import pipeline
 - `updater`: tool to download/upload large files used in the import pipeline
+- `map_tests`: tests for the map import pipeline
 
 Traffic simulation:
 

--- a/convert_osm/src/lib.rs
+++ b/convert_osm/src/lib.rs
@@ -12,8 +12,14 @@ use geom::{Distance, FindClosest, GPSBounds, LonLat, Pt2D, Ring};
 use map_model::raw::RawMap;
 use map_model::{osm, MapConfig, NamePerLanguage};
 
+pub enum Input {
+    Path(String),
+    Contents(String),
+}
+
 pub struct Options {
-    pub osm_input: String,
+    pub osm_input: Input,
+
     pub city_name: String,
     pub name: String,
 

--- a/importer/src/berlin.rs
+++ b/importer/src/berlin.rs
@@ -58,7 +58,10 @@ pub fn osm_to_raw(name: &str, timer: &mut Timer, config: &ImporterConfiguration)
 
     let map = convert_osm::convert(
         convert_osm::Options {
-            osm_input: abstutil::path(format!("input/berlin/osm/{}.osm", name)),
+            osm_input: convert_osm::Input::Path(abstutil::path(format!(
+                "input/berlin/osm/{}.osm",
+                name
+            ))),
             city_name: "berlin".to_string(),
             name: name.to_string(),
 

--- a/importer/src/krakow.rs
+++ b/importer/src/krakow.rs
@@ -20,7 +20,10 @@ pub fn osm_to_raw(name: &str, timer: &mut abstutil::Timer, config: &ImporterConf
 
     let map = convert_osm::convert(
         convert_osm::Options {
-            osm_input: abstutil::path(format!("input/krakow/osm/{}.osm", name)),
+            osm_input: convert_osm::Input::Path(abstutil::path(format!(
+                "input/krakow/osm/{}.osm",
+                name
+            ))),
             city_name: "krakow".to_string(),
             name: name.to_string(),
 

--- a/importer/src/london.rs
+++ b/importer/src/london.rs
@@ -20,7 +20,10 @@ pub fn osm_to_raw(name: &str, timer: &mut abstutil::Timer, config: &ImporterConf
 
     let map = convert_osm::convert(
         convert_osm::Options {
-            osm_input: abstutil::path(format!("input/london/osm/{}.osm", name)),
+            osm_input: convert_osm::Input::Path(abstutil::path(format!(
+                "input/london/osm/{}.osm",
+                name
+            ))),
             city_name: "london".to_string(),
             name: name.to_string(),
 

--- a/importer/src/main.rs
+++ b/importer/src/main.rs
@@ -203,7 +203,7 @@ fn oneshot(osm_path: String, clip: Option<String>, drive_on_right: bool, build_c
     let name = abstutil::basename(&osm_path);
     let raw = convert_osm::convert(
         convert_osm::Options {
-            osm_input: osm_path,
+            osm_input: convert_osm::Input::Path(osm_path),
             city_name: "oneshot".to_string(),
             name: name.clone(),
 

--- a/importer/src/seattle.rs
+++ b/importer/src/seattle.rs
@@ -67,7 +67,10 @@ pub fn osm_to_raw(name: &str, timer: &mut abstutil::Timer, config: &ImporterConf
 
     let map = convert_osm::convert(
         convert_osm::Options {
-            osm_input: abstutil::path(format!("input/seattle/osm/{}.osm", name)),
+            osm_input: convert_osm::Input::Path(abstutil::path(format!(
+                "input/seattle/osm/{}.osm",
+                name
+            ))),
             city_name: "seattle".to_string(),
             name: name.to_string(),
 

--- a/importer/src/tel_aviv.rs
+++ b/importer/src/tel_aviv.rs
@@ -20,7 +20,10 @@ pub fn osm_to_raw(name: &str, timer: &mut abstutil::Timer, config: &ImporterConf
 
     let map = convert_osm::convert(
         convert_osm::Options {
-            osm_input: abstutil::path(format!("input/tel_aviv/osm/{}.osm", name)),
+            osm_input: convert_osm::Input::Path(abstutil::path(format!(
+                "input/tel_aviv/{}.osm",
+                name
+            ))),
             city_name: "tel_aviv".to_string(),
             name: name.to_string(),
 

--- a/importer/src/xian.rs
+++ b/importer/src/xian.rs
@@ -20,7 +20,7 @@ pub fn osm_to_raw(name: &str, timer: &mut abstutil::Timer, config: &ImporterConf
 
     let map = convert_osm::convert(
         convert_osm::Options {
-            osm_input: abstutil::path(format!("input/xian/osm/{}.osm", name)),
+            osm_input: convert_osm::Input::Path(abstutil::path(format!("input/xian/{}.osm", name))),
             city_name: "xian".to_string(),
             name: name.to_string(),
 

--- a/map_tests/Cargo.toml
+++ b/map_tests/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "map_tests"
+version = "0.1.0"
+authors = ["Dustin Carlino <dabreegster@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+abstutil = { path = "../abstutil" }
+convert_osm = { path = "../convert_osm" }
+map_model = { path = "../map_model" }

--- a/map_tests/src/lib.rs
+++ b/map_tests/src/lib.rs
@@ -1,0 +1,36 @@
+// This crate contains tests for the map importing pipeline. They're closer to integration tests
+// than unit tests, mostly because of how tedious and brittle it would be to specify the full input
+// to individual pieces of the pipeline.
+
+#[cfg(test)]
+mod turns;
+
+// Run the contents of a .osm through the full map importer with default options.
+#[cfg(test)]
+fn import_map(raw_osm: String) -> map_model::Map {
+    let mut timer = abstutil::Timer::new("convert synthetic map");
+    let raw = convert_osm::convert(
+        convert_osm::Options {
+            osm_input: convert_osm::Input::Contents(raw_osm),
+            city_name: "oneshot".to_string(),
+            name: "test_map".to_string(),
+            clip: None,
+            map_config: map_model::MapConfig {
+                driving_side: map_model::DrivingSide::Right,
+                bikes_can_use_bus_lanes: true,
+            },
+            onstreet_parking: convert_osm::OnstreetParking::JustOSM,
+            public_offstreet_parking: convert_osm::PublicOffstreetParking::None,
+            private_offstreet_parking: convert_osm::PrivateOffstreetParking::FixedPerBldg(0),
+            elevation: None,
+            include_railroads: true,
+        },
+        &mut timer,
+    );
+    let map = map_model::Map::create_from_raw(raw, true, &mut timer);
+    // Useful to debug the result
+    if false {
+        map.save();
+    }
+    map
+}

--- a/map_tests/src/turns.rs
+++ b/map_tests/src/turns.rs
@@ -1,0 +1,71 @@
+use crate::import_map;
+use map_model::{LaneID, TurnType};
+
+// If this test gets fully fleshed out, there would be many more of these. This one means the
+// southern road, inbound to the intersection, the left lane of it.
+const S_IN_LEFT: LaneID = LaneID(2);
+
+#[test]
+fn test_left_turn_lane() {
+    let map = import_map(four_way());
+
+    // Assert the hardcoded ID is reasonable
+    assert_eq!("south", map.get_parent(S_IN_LEFT).get_name(None));
+    assert!(map.get_l(S_IN_LEFT).is_driving());
+
+    // TODO This is quite a weak assertion. I want to express that there's only the left turn from
+    // this lane, and S_IN_RIGHT has the two straight turns and the right turn. But it'll be so
+    // verbose.
+    assert_eq!(
+        TurnType::Left,
+        map.get_turns_from_lane(S_IN_LEFT)[0].turn_type
+    );
+}
+
+// A map with 4 roads (north, south, east, west) and one intersection. The north/south roads have 4
+// lanes, the east/west just 2. The south road has a left turn lane.
+fn four_way() -> String {
+    format!(
+        r#"<?xml version='1.0' encoding='UTF-8'?><osm>
+        <bounds minlon="0.0" maxlon="0.01" minlat="0.0" maxlat="0.01"/>
+        <node id="1" lon="0.005" lat="0.005"/>
+        <node id="2" lon="0.005" lat="-1.0"/>
+        <node id="3" lon="0.005" lat="1.0"/>
+        <node id="4" lon="-0.1" lat="0.005"/>
+        <node id="5" lon="1.0" lat="0.005"/>
+        <way id="100">
+            <nd ref="1"/>
+            <nd ref="2"/>
+            <tag k="name" v="south"/>
+            <tag k="highway" v="primary"/>
+            <tag k="lanes" v="4"/>
+            <tag k="sidewalk" v="both"/>
+            <tag k="turn:lanes:backward" v="left|"/>
+        </way>
+        <way id="101">
+            <nd ref="1"/>
+            <nd ref="3"/>
+            <tag k="name" v="north"/>
+            <tag k="highway" v="primary"/>
+            <tag k="lanes" v="4"/>
+            <tag k="sidewalk" v="both"/>
+        </way>
+        <way id="102">
+            <nd ref="1"/>
+            <nd ref="4"/>
+            <tag k="name" v="west"/>
+            <tag k="highway" v="residential"/>
+            <tag k="lanes" v="2"/>
+            <tag k="sidewalk" v="both"/>
+        </way>
+        <way id="103">
+            <nd ref="1"/>
+            <nd ref="5"/>
+            <tag k="name" v="east"/>
+            <tag k="highway" v="residential"/>
+            <tag k="lanes" v="2"/>
+            <tag k="sidewalk" v="both"/>
+        </way>
+    </osm>"#
+    )
+}


### PR DESCRIPTION
simple .osm, turn it into a full Map, and inspect the results.

I'm not really happy with this approach; specifying the .osm input is pretty low-boilerplate, but then asserting all of the expected turns is going to be a mess. Any ideas?

The synthetic map:
![Screenshot from 2020-09-30 14-23-48](https://user-images.githubusercontent.com/1664407/94742125-0b6af200-032a-11eb-81dd-c4dbef07c3b5.png)

@michaelkirk 