### PR TITLE
update panels and their scrollbars when window resizes

### DIFF
--- a/widgetry/examples/demo.rs
+++ b/widgetry/examples/demo.rs
@@ -151,8 +151,10 @@ impl GUI for App {
                     self.elapsed += offset;
                     self.redraw_stopwatch(ctx);
                 }
-                "apply textures" => {
-                    let (bg_texture, fg_texture) = self.controls.dropdown_value("texture dropdown");
+                "apply" => {
+                    let (v_align, h_align) = self.controls.dropdown_value("alignment");
+                    self.controls.align(v_align, h_align);
+                    let (bg_texture, fg_texture) = self.controls.dropdown_value("texture");
                     self.texture_demo = setup_texture_demo(ctx, bg_texture, fg_texture);
                 }
                 _ => unimplemented!("clicked: {:?}", x),
@@ -328,14 +330,38 @@ fn make_controls(ctx: &mut EventCtx) -> Panel {
         Widget::row(vec![
             Widget::dropdown(
                 ctx,
-                "texture dropdown",
+                "alignment",
+                (HorizontalAlignment::Center, VerticalAlignment::Top),
+                vec![
+                    Choice::new("Top", (HorizontalAlignment::Center, VerticalAlignment::Top)),
+                    Choice::new(
+                        "Left",
+                        (HorizontalAlignment::Left, VerticalAlignment::Center),
+                    ),
+                    Choice::new(
+                        "Bottom",
+                        (HorizontalAlignment::Center, VerticalAlignment::Bottom),
+                    ),
+                    Choice::new(
+                        "Right",
+                        (HorizontalAlignment::Right, VerticalAlignment::Center),
+                    ),
+                    Choice::new(
+                        "Center",
+                        (HorizontalAlignment::Center, VerticalAlignment::Center),
+                    ),
+                ],
+            ),
+            Widget::dropdown(
+                ctx,
+                "texture",
                 (Texture::SAND, Texture::CACTUS),
                 vec![
                     Choice::new("Cold", (Texture::SNOW, Texture::SNOW_PERSON)),
                     Choice::new("Hot", (Texture::SAND, Texture::CACTUS)),
                 ],
             ),
-            Btn::text_fg("Apply Textures").build(ctx, "apply textures", None),
+            Btn::text_fg("Apply").build(ctx, "apply", None),
         ])
         .margin_above(30),
     ]))

--- a/widgetry/src/canvas.rs
+++ b/widgetry/src/canvas.rs
@@ -338,7 +338,7 @@ impl Canvas {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HorizontalAlignment {
     Left,
     Center,
@@ -347,7 +347,7 @@ pub enum HorizontalAlignment {
     Centered(f64),
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum VerticalAlignment {
     Top,
     Center,

--- a/widgetry/src/widgets/mod.rs
+++ b/widgetry/src/widgets/mod.rs
@@ -630,7 +630,7 @@ impl Widget {
                 w.restore(ctx, prev);
             }
         } else if self.widget.can_restore() {
-            if let Some(ref other) = prev.top_level.find(self.id.as_ref().unwrap()) {
+            if let Some(ref other) = prev.maybe_find(self.id.as_ref().unwrap()) {
                 self.widget.restore(ctx, &other.widget);
             }
         }

--- a/widgetry/src/widgets/panel.rs
+++ b/widgetry/src/widgets/panel.rs
@@ -49,10 +49,7 @@ impl Panel {
         self.container_dims = new_container_dims;
     }
 
-    // TODO: this method potentially gets called multiple times in a render pass as an
-    // optimization, we could replace all the current call sites with a "dirty" flag, e.g.
-    // `set_needs_layout()` and then call `layout_if_needed()` once at the last possible moment
-    fn recompute_layout(&mut self, ctx: &EventCtx, recompute_bg: bool) {
+    fn recompute_scrollbar_layout(&mut self, ctx: &EventCtx) {
         let old_scrollable_x = self.scrollable_x;
         let old_scrollable_y = self.scrollable_y;
 
@@ -114,7 +111,13 @@ impl Panel {
         } else {
             None
         };
+    }
 
+    // TODO: this method potentially gets called multiple times in a render pass as an
+    // optimization, we could replace all the current call sites with a "dirty" flag, e.g.
+    // `set_needs_layout()` and then call `layout_if_needed()` once at the last possible moment
+    fn recompute_layout(&mut self, ctx: &EventCtx, recompute_bg: bool) {
+        self.recompute_scrollbar_layout(ctx);
         let mut stretch = Stretch::new();
         let root = stretch
             .new_node(

--- a/widgetry/src/widgets/panel.rs
+++ b/widgetry/src/widgets/panel.rs
@@ -73,10 +73,9 @@ impl Panel {
 
         // Wrap the main widget in scrollable containers if necessary.
         if self.scrollable_x {
-            let mut place_holder = Widget::nothing();
-            std::mem::swap(&mut place_holder, &mut self.top_level);
+            let old_top_level = std::mem::replace(&mut self.top_level, Widget::nothing());
             self.top_level = Widget::custom_col(vec![
-                place_holder,
+                old_top_level,
                 Slider::horizontal(
                     ctx,
                     self.container_dims.width,
@@ -90,10 +89,9 @@ impl Panel {
         }
 
         if self.scrollable_y {
-            let mut place_holder = Widget::nothing();
-            std::mem::swap(&mut place_holder, &mut self.top_level);
+            let old_top_level = std::mem::replace(&mut self.top_level, Widget::nothing());
             self.top_level = Widget::custom_row(vec![
-                place_holder,
+                old_top_level,
                 Slider::vertical(
                     ctx,
                     self.container_dims.height,

--- a/widgetry/src/widgets/panel.rs
+++ b/widgetry/src/widgets/panel.rs
@@ -60,12 +60,12 @@ impl Panel {
         self.scrollable_y = self.contents_dims.height > self.container_dims.height;
 
         // Unwrap the main widget from any scrollable containers if necessary.
-        if old_scrollable_y && !self.scrollable_y {
+        if old_scrollable_y {
             let container = self.top_level.widget.downcast_mut::<Container>().unwrap();
             self.top_level = container.members.remove(0);
         }
 
-        if old_scrollable_x && !self.scrollable_x {
+        if old_scrollable_x {
             let container = self.top_level.widget.downcast_mut::<Container>().unwrap();
             self.top_level = container.members.remove(0);
         }
@@ -75,7 +75,7 @@ impl Panel {
             .align_window(self.container_dims, self.horiz, self.vert);
 
         // Wrap the main widget in scrollable containers if necessary.
-        if self.scrollable_x && !old_scrollable_x {
+        if self.scrollable_x {
             let mut place_holder = Widget::nothing();
             std::mem::swap(&mut place_holder, &mut self.top_level);
             self.top_level = Widget::custom_col(vec![
@@ -92,7 +92,7 @@ impl Panel {
             ]);
         }
 
-        if self.scrollable_y && !old_scrollable_y {
+        if self.scrollable_y {
             let mut place_holder = Widget::nothing();
             std::mem::swap(&mut place_holder, &mut self.top_level);
             self.top_level = Widget::custom_row(vec![

--- a/widgetry/src/widgets/panel.rs
+++ b/widgetry/src/widgets/panel.rs
@@ -404,6 +404,10 @@ impl Panel {
         self.top_level.rect.center()
     }
 
+    pub fn align(&mut self, horiz: HorizontalAlignment, vert: VerticalAlignment) {
+        self.horiz = horiz;
+        self.vert = vert;
+    }
     pub fn align_above(&mut self, ctx: &mut EventCtx, other: &Panel) {
         // Small padding
         self.vert = VerticalAlignment::Above(other.top_level.rect.y1 - 5.0);

--- a/widgetry/src/widgets/panel.rs
+++ b/widgetry/src/widgets/panel.rs
@@ -52,6 +52,7 @@ impl Panel {
     fn recompute_scrollbar_layout(&mut self, ctx: &EventCtx) {
         let old_scrollable_x = self.scrollable_x;
         let old_scrollable_y = self.scrollable_y;
+        let old_scroll_offset = self.scroll_offset();
 
         self.scrollable_x = self.contents_dims.width > self.container_dims.width;
         self.scrollable_y = self.contents_dims.height > self.container_dims.height;
@@ -103,6 +104,8 @@ impl Panel {
                 .abs(top_left.x + self.container_dims.width, top_left.y),
             ]);
         }
+
+        self.update_scroll_sliders(ctx, old_scroll_offset);
 
         self.clip_rect = if self.scrollable_x || self.scrollable_y {
             Some(ScreenRectangle::top_left(top_left, self.container_dims))
@@ -177,7 +180,7 @@ impl Panel {
         (x, y)
     }
 
-    fn set_scroll_offset(&mut self, ctx: &EventCtx, offset: (f64, f64)) {
+    fn update_scroll_sliders(&mut self, ctx: &EventCtx, offset: (f64, f64)) -> bool {
         let mut changed = false;
         if self.scrollable_x {
             changed = true;
@@ -199,7 +202,11 @@ impl Panel {
                     .set_percent(ctx, abstutil::clamp(offset.1, 0.0, max) / max);
             }
         }
-        if changed {
+        changed
+    }
+
+    fn set_scroll_offset(&mut self, ctx: &EventCtx, offset: (f64, f64)) {
+        if self.update_scroll_sliders(ctx, offset) {
             self.recompute_layout(ctx, false);
         }
     }

--- a/widgetry/src/widgets/panel.rs
+++ b/widgetry/src/widgets/panel.rs
@@ -11,7 +11,7 @@ use stretch::number::Number;
 use stretch::style::{Dimension, Style};
 
 pub struct Panel {
-    pub(crate) top_level: Widget,
+    top_level: Widget,
     horiz: HorizontalAlignment,
     vert: VerticalAlignment,
     dims: Dims,
@@ -298,6 +298,10 @@ impl Panel {
 
     pub fn autocomplete_done<T: 'static + Clone>(&self, name: &str) -> Option<Vec<T>> {
         self.find::<Autocomplete<T>>(name).final_value()
+    }
+
+    pub fn maybe_find(&self, name: &str) -> Option<&Widget> {
+        self.top_level.find(name)
     }
 
     pub fn find<T: WidgetImpl>(&self, name: &str) -> &T {

--- a/widgetry/src/widgets/panel.rs
+++ b/widgetry/src/widgets/panel.rs
@@ -180,9 +180,9 @@ impl Panel {
                 Polygon::rectangle(self.container_dims.width, self.container_dims.height)
                     .translate(top_left.x, top_left.y),
             );
+            g.unfork();
         }
 
-        g.unfork();
 
         self.top_level.draw(g);
         if self.scrollable_x || self.scrollable_y {


### PR DESCRIPTION
Panels calculate their container size and whether or not to show scroll bars based on the canvas size. They do this only once when the panel is first built.

But canvas size changes as window size changes. 

Window size can change manually as the user manually adjusts it, or plugs in an external monitor, etc. But one place this is particularly annoying for me personally is upon first launch. Upon launch the window goes through a series of rapid size changes, starting small and growing to full size (this might just be a macos thing, I'm not sure?).

But this means the panels are all drawn WRT to the initial small size. 

**before**

e.g. look how the top center panel looks broken here:

![before-scroll-resize mov](https://user-images.githubusercontent.com/217057/94873395-e9de3900-0403-11eb-8ec1-cf71b0491646.gif)

But even putting the initial launch thing aside, there are a bunch of expected scenarios where the use can change their window size mid-run, and we should try to handle them.

This PR moves the scrollbar manipulation into the Panel, rather than the PanelBuilder, so that it can be recomputed as necessary.

**after**

![after-scroll-resize mov](https://user-images.githubusercontent.com/217057/94873405-ef3b8380-0403-11eb-8ea9-a093de172a4d.gif)
