### PR TITLE
Allow selecting and clicking unzoomed agents. [rebuild]

### DIFF
--- a/game/src/app.rs
+++ b/game/src/app.rs
@@ -8,7 +8,7 @@ use abstutil::Timer;
 use geom::{Bounds, Circle, Distance, Duration, Pt2D, Time};
 use map_model::{IntersectionID, Map, Traversable};
 use sim::{Analytics, Sim, SimCallback, SimFlags};
-use widgetry::{Color, EventCtx, GfxCtx, Prerender};
+use widgetry::{EventCtx, GfxCtx, Prerender};
 
 use crate::challenges::HighScore;
 use crate::colors::ColorScheme;
@@ -197,7 +197,7 @@ impl App {
                     // Usually we show selection with an outline, but no thickness/color is really
                     // visible for these tiny crowded dots.
                     g.draw_polygon(
-                        Color::CYAN,
+                        self.cs.selected,
                         Circle::new(pt, unzoomed_agent_radius(a.to_vehicle_type())).to_polygon(),
                     );
                 }

--- a/game/src/info/mod.rs
+++ b/game/src/info/mod.rs
@@ -412,7 +412,7 @@ impl InfoPanel {
                         app.cs.current_object.alpha(0.5),
                         Circle::new(bounds.center(), radius).to_polygon(),
                     );
-                    match Circle::outline(bounds.center(), radius, Distance::meters(0.3)) {
+                    match Circle::new(bounds.center(), radius).to_outline(Distance::meters(0.3)) {
                         Ok(poly) => {
                             details.unzoomed.push(app.cs.current_object, poly.clone());
                             details.zoomed.push(app.cs.current_object, poly.clone());

--- a/game/src/layer/parking.rs
+++ b/game/src/layer/parking.rs
@@ -4,7 +4,6 @@ use abstutil::{prettyprint_usize, Counter, Parallelism};
 use geom::{Circle, Distance, Duration, Pt2D, Time};
 use map_model::{
     BuildingID, Map, OffstreetParking, ParkingLotID, PathConstraints, PathRequest, RoadID,
-    NORMAL_LANE_THICKNESS,
 };
 use sim::{ParkingSpot, Scenario, VehicleType};
 use widgetry::{
@@ -15,6 +14,7 @@ use widgetry::{
 use crate::app::App;
 use crate::common::{ColorLegend, ColorNetwork};
 use crate::layer::{Layer, LayerOutcome};
+use crate::render::unzoomed_agent_radius;
 
 pub struct Occupancy {
     time: Time,
@@ -275,8 +275,11 @@ impl Occupancy {
 
         if looking_for_parking {
             // A bit of copied code from draw_unzoomed_agents
-            let car_circle =
-                Circle::new(Pt2D::new(0.0, 0.0), 4.0 * NORMAL_LANE_THICKNESS).to_polygon();
+            let car_circle = Circle::new(
+                Pt2D::new(0.0, 0.0),
+                unzoomed_agent_radius(Some(VehicleType::Car)),
+            )
+            .to_polygon();
             for a in app.primary.sim.get_unzoomed_agents(&app.primary.map) {
                 if a.parking {
                     colorer.unzoomed.push(

--- a/game/src/layer/traffic.rs
+++ b/game/src/layer/traffic.rs
@@ -4,7 +4,8 @@ use maplit::btreeset;
 
 use abstutil::{prettyprint_usize, Counter};
 use geom::{Circle, Distance, Duration, Polygon, Pt2D, Time};
-use map_model::{IntersectionID, Map, Traversable, NORMAL_LANE_THICKNESS, SIDEWALK_THICKNESS};
+use map_model::{IntersectionID, Map, Traversable};
+use sim::VehicleType;
 use widgetry::{
     Btn, Checkbox, Color, Drawable, EventCtx, GeomBatch, GfxCtx, HorizontalAlignment, Key, Line,
     Outcome, Panel, Text, TextExt, VerticalAlignment, Widget,
@@ -14,6 +15,7 @@ use crate::app::App;
 use crate::common::{ColorLegend, ColorNetwork, DivergingScale};
 use crate::helpers::ID;
 use crate::layer::{Layer, LayerOutcome};
+use crate::render::unzoomed_agent_radius;
 
 pub struct Backpressure {
     time: Time,
@@ -553,8 +555,12 @@ impl Delay {
             app.primary.map.get_boundary_polygon().clone(),
         );
         // A bit of copied code from draw_unzoomed_agents
-        let car_circle = Circle::new(Pt2D::new(0.0, 0.0), 4.0 * NORMAL_LANE_THICKNESS).to_polygon();
-        let ped_circle = Circle::new(Pt2D::new(0.0, 0.0), 4.0 * SIDEWALK_THICKNESS).to_polygon();
+        let car_circle = Circle::new(
+            Pt2D::new(0.0, 0.0),
+            unzoomed_agent_radius(Some(VehicleType::Car)),
+        )
+        .to_polygon();
+        let ped_circle = Circle::new(Pt2D::new(0.0, 0.0), unzoomed_agent_radius(None)).to_polygon();
         for agent in app.primary.sim.get_unzoomed_agents(&app.primary.map) {
             if let Some(delay) = agent.person.and_then(|p| delays.remove(&p)) {
                 let color = app

--- a/game/src/lib.rs
+++ b/game/src/lib.rs
@@ -51,6 +51,9 @@ pub fn main() {
     if args.enabled("--lowzoom") {
         opts.min_zoom_for_detail = 1.0;
     }
+    if args.enabled("--select_unzoomed_agents") {
+        opts.select_unzoomed_agents = true;
+    }
 
     if let Some(x) = args.optional("--color_scheme") {
         let mut ok = false;

--- a/game/src/options.rs
+++ b/game/src/options.rs
@@ -29,6 +29,9 @@ pub struct Options {
     pub min_zoom_for_detail: f64,
     /// Draw buildings in different perspectives
     pub camera_angle: CameraAngle,
+    /// Allow selecting agents when unzoomed. Flagged off by default because the implementation is
+    /// too slow.
+    pub select_unzoomed_agents: bool,
 
     /// How much to advance the sim with one of the speed controls
     pub time_increment: Duration,
@@ -54,6 +57,7 @@ impl Options {
             color_scheme: ColorSchemeChoice::Standard,
             min_zoom_for_detail: 4.0,
             camera_angle: CameraAngle::TopDown,
+            select_unzoomed_agents: false,
 
             time_increment: Duration::minutes(10),
             dont_draw_time_warp: false,

--- a/game/src/render/bus_stop.rs
+++ b/game/src/render/bus_stop.rs
@@ -73,7 +73,9 @@ impl Renderable for DrawBusStop {
     }
 
     fn get_outline(&self, _: &Map) -> Polygon {
-        Circle::outline(self.center, RADIUS, OUTLINE_THICKNESS).expect("constants defined wrong")
+        Circle::new(self.center, RADIUS)
+            .to_outline(OUTLINE_THICKNESS)
+            .expect("constants defined wrong")
     }
 
     fn contains_pt(&self, pt: Pt2D, _: &Map) -> bool {

--- a/game/src/render/mod.rs
+++ b/game/src/render/mod.rs
@@ -1,5 +1,5 @@
 use geom::{Distance, Polygon, Pt2D};
-use map_model::{IntersectionID, Map};
+use map_model::{IntersectionID, Map, NORMAL_LANE_THICKNESS, SIDEWALK_THICKNESS};
 use sim::{DrawCarInput, VehicleType};
 use widgetry::{GfxCtx, Prerender};
 
@@ -82,5 +82,15 @@ impl DrawOptions {
             suppress_traffic_signal_details: Vec::new(),
             label_buildings: false,
         }
+    }
+}
+
+pub fn unzoomed_agent_radius(vt: Option<VehicleType>) -> Distance {
+    // Lane thickness is a little hard to see, so double it. Most of the time, the circles don't
+    // leak out of the road too much.
+    if vt.is_some() {
+        4.0 * NORMAL_LANE_THICKNESS
+    } else {
+        4.0 * SIDEWALK_THICKNESS
     }
 }

--- a/game/src/sandbox/misc_tools.rs
+++ b/game/src/sandbox/misc_tools.rs
@@ -11,7 +11,9 @@ use crate::common::ColorLegend;
 use crate::game::{DrawBaselayer, State, Transition};
 use crate::render::{DrawOptions, BIG_ARROW_THICKNESS};
 
+/// Draws a preview of the path for the agent under the mouse cursor.
 pub struct RoutePreview {
+    // (the agent we're hovering on, the sim time, whether we're zoomed in, the drawn path)
     preview: Option<(AgentID, Time, bool, Drawable)>,
 }
 
@@ -38,6 +40,8 @@ impl RoutePreview {
                 .unwrap_or(true)
             {
                 let mut batch = GeomBatch::new();
+                // Only draw the preview when zoomed in. If we wanted to do this unzoomed, we'd
+                // want a different style; the dashed lines don't show up well.
                 if zoomed {
                     if let Some(trace) = app.primary.sim.trace_route(agent, &app.primary.map, None)
                     {

--- a/game/src/sandbox/mod.rs
+++ b/game/src/sandbox/mod.rs
@@ -132,8 +132,8 @@ impl State for SandboxMode {
             }
         }
 
-        // We need to recalculate unzoomed agent mouseover when the mouse is still and time passes,
-        // or when the mouse moves.
+        // We need to recalculate unzoomed agent mouseover when the mouse is still and time passes
+        // (since something could move beneath the cursor), or when the mouse moves.
         if app.primary.current_selection.is_none()
             && ctx.canvas.cam_zoom < app.opts.min_zoom_for_detail
         {

--- a/game/src/sandbox/mod.rs
+++ b/game/src/sandbox/mod.rs
@@ -730,6 +730,10 @@ fn mouseover_unzoomed_agent_circle(ctx: &mut EventCtx, app: &mut App) {
     // - We could build and cache a quadtree if we're paused
     // - We could always build the quadtree as we loop over unzoomed agents
     // - At least do this while we draw? Don't call twice.
+    if !app.opts.select_unzoomed_agents {
+        return;
+    }
+
     let cursor = if let Some(pt) = ctx.canvas.get_cursor_in_map_space() {
         pt
     } else {

--- a/geom/src/circle.rs
+++ b/geom/src/circle.rs
@@ -71,6 +71,7 @@ impl Circle {
         )
     }
 
+    /// Draws an outline around the circle, strictly contained with the circle's original radius.
     pub fn to_outline(&self, thickness: Distance) -> Result<Polygon, String> {
         if self.radius <= thickness {
             return Err(format!(

--- a/geom/src/circle.rs
+++ b/geom/src/circle.rs
@@ -71,16 +71,16 @@ impl Circle {
         )
     }
 
-    pub fn outline(center: Pt2D, radius: Distance, thickness: Distance) -> Result<Polygon, String> {
-        if radius <= thickness {
+    pub fn to_outline(&self, thickness: Distance) -> Result<Polygon, String> {
+        if self.radius <= thickness {
             return Err(format!(
                 "Can't make Circle outline with radius {} and thickness {}",
-                radius, thickness
+                self.radius, thickness
             ));
         }
 
-        let bigger = Circle::new(center, radius).to_ring();
-        let smaller = Circle::new(center, radius - thickness).to_ring();
+        let bigger = self.to_ring();
+        let smaller = Circle::new(self.center, self.radius - thickness).to_ring();
         Ok(Polygon::with_holes(bigger, vec![smaller]))
     }
 }

--- a/geom/src/polygon.rs
+++ b/geom/src/polygon.rs
@@ -305,8 +305,9 @@ impl Polygon {
         Pt2D::new(pt.x(), pt.y())
     }
 
-    /// Only works for polygons that're formed from rings. Those made from PolyLines won't work, for
-    /// example.
+    /// Creates the outline around the polygon, with the thickness half straddling the polygon and
+    /// half of it just outside. Only works for polygons that're formed from rings. Those made from
+    /// PolyLines won't work, for example.
     pub fn to_outline(&self, thickness: Distance) -> Result<Polygon, String> {
         if let Some(ref rings) = self.rings {
             Ok(Polygon::union_all(

--- a/geom/src/ring.rs
+++ b/geom/src/ring.rs
@@ -43,6 +43,8 @@ impl Ring {
         Ring::new(pts).unwrap()
     }
 
+    /// Draws the ring with some thickness, with half of it straddling the interor of the ring, and
+    /// half on the outside.
     pub fn to_outline(&self, thickness: Distance) -> Polygon {
         // TODO Has a weird corner. Use the polygon offset thing instead?
         PolyLine::unchecked_new(self.pts.clone()).make_polygons(thickness)

--- a/sim/src/lib.rs
+++ b/sim/src/lib.rs
@@ -142,6 +142,14 @@ impl AgentID {
             AgentID::BusPassenger(_, _) => AgentType::TransitRider,
         }
     }
+
+    pub fn to_vehicle_type(self) -> Option<VehicleType> {
+        match self {
+            AgentID::Car(c) => Some(c.1),
+            AgentID::Pedestrian(_) => None,
+            AgentID::BusPassenger(_, _) => None,
+        }
+    }
 }
 
 impl fmt::Display for AgentID {

--- a/sim/src/sim/queries.rs
+++ b/sim/src/sim/queries.rs
@@ -125,6 +125,13 @@ impl Sim {
     pub fn agent_to_person(&self, id: AgentID) -> Option<PersonID> {
         self.agent_to_trip(id).map(|t| self.trip_to_person(t))
     }
+    pub fn person_to_agent(&self, id: PersonID) -> Option<AgentID> {
+        if let PersonState::Trip(t) = self.trips.get_person(id)?.state {
+            self.trip_to_agent(t).ok()
+        } else {
+            None
+        }
+    }
     pub fn get_owner_of_car(&self, id: CarID) -> Option<PersonID> {
         self.driving
             .get_owner_of_car(id)


### PR DESCRIPTION
Several new players during informal UX tests keep trying to click the unzoomed agent circles. Their use case is that they found someone moving, are interested, and want to get more details about what's happening. It's hard for them to zoom in and find them, especially when the sim is running at high speed. The zoomed agents -- especially tiny pedestrians and bikes -- being hard to click doesn't help.

So this PR adds unzoomed agent selection:
![screencast](https://user-images.githubusercontent.com/1664407/95769037-d8572580-0c7c-11eb-9d87-fc1d16f92cb2.gif)

Some caveats:
- won't work for buses (minor, because lots of transit stuff is broken generally right now)
- when you click from this view, it opens the trip panel and centers on them. The automatic centering and snapping feels a bit clunky, especially since it can slightly shift the screen when the agent clicked is already close to center. Should we do the zoom in animation instead?
- I tried a few variations of outlines around the circle, but it's still hard to see the zoom level is very low and the circles are clustered. Is the cyan solid circle too jarring?

And this is a draft, because the performance is unacceptably sad. I think we need to build a quadtree while the main drawing loop iterates over all the unzoomed agents, or plumb the mouseover check inside the loop. Anything to avoid querying all unzoomed agents multiple times.

@michaelkirk Any preliminary feedback?