### PR TITLE
perf: only allocate vector for `inner_get_car_positions` when necessary

### DIFF
--- a/sim/src/mechanics/driving.rs
+++ b/sim/src/mechanics/driving.rs
@@ -700,18 +700,18 @@ impl DrivingSimState {
 
     pub fn update_laggy_head(&mut self, id: CarID, now: Time, ctx: &mut Ctx) {
         let currently_on = self.cars[&id].router.head();
-        let current_dists =
-            self.queues[&currently_on].get_car_positions(now, &self.cars, &self.queues);
         // This car must be the tail.
         let dist_along_last = {
-            let (last_id, dist) = current_dists.last().unwrap();
-            if id != *last_id {
+            let (last_id, dist) = self.queues[&currently_on]
+                .get_last_car_position(now, &self.cars, &self.queues)
+                .unwrap();
+            if id != last_id {
                 panic!(
                     "At {} on {:?}, laggy head {} isn't the last on the lane; it's {}",
                     now, currently_on, id, last_id
                 );
             }
-            *dist
+            dist
         };
 
         // Trim off as many of the oldest last_steps as we've made distance.

--- a/sim/src/mechanics/queue.rs
+++ b/sim/src/mechanics/queue.rs
@@ -45,7 +45,25 @@ impl Queue {
         cars: &FixedMap<CarID, Car>,
         queues: &BTreeMap<Traversable, Queue>,
     ) -> Option<(CarID, Distance)> {
-        self.inner_get_last_car_position(now, cars, queues, &mut BTreeSet::new())
+        self.inner_get_last_car_position(now, cars, queues, &mut BTreeSet::new(), None)
+    }
+
+    /// Farthest along (greatest distance) is first.
+    pub fn get_car_positions(
+        &self,
+        now: Time,
+        cars: &FixedMap<CarID, Car>,
+        queues: &BTreeMap<Traversable, Queue>,
+    ) -> Vec<(CarID, Distance)> {
+        let mut all_cars = vec![];
+        self.inner_get_last_car_position(
+            now,
+            cars,
+            queues,
+            &mut BTreeSet::new(),
+            Some(&mut all_cars),
+        );
+        all_cars
     }
 
     fn inner_get_last_car_position(
@@ -54,6 +72,7 @@ impl Queue {
         cars: &FixedMap<CarID, Car>,
         queues: &BTreeMap<Traversable, Queue>,
         recursed_queues: &mut BTreeSet<Traversable>,
+        mut intermediate_results: Option<&mut Vec<(CarID, Distance)>>,
     ) -> Option<(CarID, Distance)> {
         if self.cars.is_empty() {
             return None;
@@ -61,9 +80,9 @@ impl Queue {
 
         let mut previous: Option<(CarID, Distance)> = None;
         for id in &self.cars {
-            let bound = match previous.as_ref() {
+            let bound = match previous {
                 Some((leader, last_dist)) => {
-                    *last_dist - cars[leader].vehicle.length - FOLLOWING_DISTANCE
+                    last_dist - cars[&leader].vehicle.length - FOLLOWING_DISTANCE
                 }
                 None => match self.laggy_head {
                     Some(id) => {
@@ -95,7 +114,13 @@ impl Queue {
                             recursed_queues.insert(recurse_to);
 
                             let (head, head_dist) = queues[&leader.router.head()]
-                                .inner_get_last_car_position(now, cars, queues, recursed_queues)
+                                .inner_get_last_car_position(
+                                    now,
+                                    cars,
+                                    queues,
+                                    recursed_queues,
+                                    None,
+                                )
                                 .unwrap();
                             assert_eq!(head, id);
 
@@ -125,7 +150,9 @@ impl Queue {
 
             // There's spillover and a car shouldn't have been able to enter yet.
             if bound < Distance::ZERO {
-                // dump_cars(&result, cars, self.id, now);
+                if let Some(intermediate_results) = intermediate_results {
+                    dump_cars(intermediate_results, cars, self.id, now);
+                }
                 panic!(
                     "Queue has spillover on {} at {} -- can't draw {}, bound is {}. Laggy head is \
                      {:?}. This is usually a geometry bug; check for duplicate roads going \
@@ -157,144 +184,18 @@ impl Queue {
                 CarState::IdlingAtStop(front, _) => front,
             };
 
+            if let Some(ref mut intermediate_results) = intermediate_results {
+                intermediate_results.push((*id, front));
+            }
             previous = Some((*id, front));
         }
         // Enable to detect possible bugs, but save time otherwise
-        //if false {
-        //    validate_positions(&result, cars, now, self.id)
-        //}
-
-        previous
-    }
-
-    /// Farthest along (greatest distance) is first.
-    pub fn get_car_positions(
-        &self,
-        now: Time,
-        cars: &FixedMap<CarID, Car>,
-        queues: &BTreeMap<Traversable, Queue>,
-    ) -> Vec<(CarID, Distance)> {
-        self.inner_get_car_positions(now, cars, queues, &mut BTreeSet::new())
-    }
-
-    fn inner_get_car_positions(
-        &self,
-        now: Time,
-        cars: &FixedMap<CarID, Car>,
-        queues: &BTreeMap<Traversable, Queue>,
-        recursed_queues: &mut BTreeSet<Traversable>,
-    ) -> Vec<(CarID, Distance)> {
-        if self.cars.is_empty() {
-            return Vec::new();
-        }
-
-        let mut result: Vec<(CarID, Distance)> = Vec::new();
-
-        for id in &self.cars {
-            let bound = match result.last() {
-                Some((leader, last_dist)) => {
-                    *last_dist - cars[leader].vehicle.length - FOLLOWING_DISTANCE
-                }
-                None => match self.laggy_head {
-                    Some(id) => {
-                        // The simple but broken version:
-                        //self.geom_len - cars[&id].vehicle.length - FOLLOWING_DISTANCE
-
-                        // The expensive case. We need to figure out exactly where the laggy head
-                        // is on their queue.
-                        let leader = &cars[&id];
-
-                        // But don't create a cycle!
-                        let recurse_to = leader.router.head();
-                        if recursed_queues.contains(&recurse_to) {
-                            // See the picture in
-                            // https://github.com/dabreegster/abstreet/issues/30. We have two
-                            // extremes to break the cycle.
-                            //
-                            // 1) Hope that the last person in this queue isn't bounded by the
-                            //    agent in front of them yet. geom_len
-                            // 2) Assume the leader has advanced minimally into the next lane.
-                            //    geom_len - laggy head's length - FOLLOWING_DISTANCE.
-                            //
-                            // For now, optimistically assume 1. If we're wrong, consequences could
-                            // be queue spillover (we're too optimistic about the number of
-                            // vehicles that can fit on a lane) or cars jumping positions slightly
-                            // while the cycle occurs.
-                            self.geom_len
-                        } else {
-                            recursed_queues.insert(recurse_to);
-
-                            let (head, head_dist) = *queues[&leader.router.head()]
-                                .inner_get_car_positions(now, cars, queues, recursed_queues)
-                                .last()
-                                .unwrap();
-                            assert_eq!(head, id);
-
-                            let mut dist_away_from_this_queue = head_dist;
-                            for on in &leader.last_steps {
-                                if *on == self.id {
-                                    break;
-                                }
-                                dist_away_from_this_queue += queues[on].geom_len;
-                            }
-                            // They might actually be out of the way, but laggy_head hasn't been
-                            // updated yet.
-                            if dist_away_from_this_queue
-                                < leader.vehicle.length + FOLLOWING_DISTANCE
-                            {
-                                self.geom_len
-                                    - (cars[&id].vehicle.length - dist_away_from_this_queue)
-                                    - FOLLOWING_DISTANCE
-                            } else {
-                                self.geom_len
-                            }
-                        }
-                    }
-                    None => self.geom_len,
-                },
-            };
-
-            // There's spillover and a car shouldn't have been able to enter yet.
-            if bound < Distance::ZERO {
-                dump_cars(&result, cars, self.id, now);
-                panic!(
-                    "Queue has spillover on {} at {} -- can't draw {}, bound is {}. Laggy head is \
-                     {:?}. This is usually a geometry bug; check for duplicate roads going \
-                     between the same intersections.",
-                    self.id, now, id, bound, self.laggy_head
-                );
-            }
-
-            let car = &cars[id];
-            let front = match car.state {
-                CarState::Queued { .. } => {
-                    if car.router.last_step() {
-                        car.router.get_end_dist().min(bound)
-                    } else {
-                        bound
-                    }
-                }
-                CarState::WaitingToAdvance { .. } => {
-                    assert_eq!(bound, self.geom_len);
-                    self.geom_len
-                }
-                CarState::Crossing(ref time_int, ref dist_int) => {
-                    // TODO Why percent_clamp_end? We process car updates in any order, so we might
-                    // calculate this before moving this car from Crossing to another state.
-                    dist_int.lerp(time_int.percent_clamp_end(now)).min(bound)
-                }
-                CarState::Unparking(front, _, _) => front,
-                CarState::Parking(front, _, _) => front,
-                CarState::IdlingAtStop(front, _) => front,
-            };
-
-            result.push((*id, front));
-        }
-        // Enable to detect possible bugs, but save time otherwise
         if false {
-            validate_positions(&result, cars, now, self.id)
+            if let Some(intermediate_results) = intermediate_results {
+                validate_positions(intermediate_results, cars, now, self.id)
+            }
         }
-        result
+        previous
     }
 
     pub fn get_idx_to_insert_car(


### PR DESCRIPTION
`inner_get_car_positions` is a hot function, and it recurses.  In its hottest invocation (including it's own recursion) we only care about the position of the last car, so we can avoid allocating all the intermediate positions. This complicates the method a a bit, but it's a pretty hefty performance gain: 12-13% less runtime for me.

Command ran:

    $ cargo flamegraph --bin run_scenario -- --disable_turn_conflicts --infinite_parking --disable_block_the_box --alerts=silence --disable_recalc_lc data/system/scenarios/downtown/weekday.bin --hours=8

**before**
```
- After 3m26.7s, the sim is at 08:00:00.0. 19,606 live agents
Advance sim to 08:00:00.0 took 206.7296s
run simulation... plus 0.0000s
run simulation took 206.7296s
```

<img width="1792" alt="Screen Shot 2020-10-19 at 12 29 39 PM" src="https://user-images.githubusercontent.com/217057/96502533-c8a08980-1206-11eb-92f1-8336c8809f41.png">
(search highlight is for "malloc" which accounts for most of the improvement)

**after**

```
- After 2m59.9s, the sim is at  07:59:53.4. 18,968 live agents
Advance sim to 08:00:00.0 took 180.3246s                             
run simulation... plus 0.0000s                                             
run simulation took 180.3246s
```

<img width="1792" alt="Screen Shot 2020-10-19 at 12 29 21 PM" src="https://user-images.githubusercontent.com/217057/96502544-cccca700-1206-11eb-83fa-9bc2999892b9.png">
