### PR TITLE
quick fix crash in tutorial on web

### DIFF
--- a/abstutil/src/io_web.rs
+++ b/abstutil/src/io_web.rs
@@ -18,6 +18,8 @@ static SYSTEM_DATA: include_dir::Dir = include_dir::include_dir!(
     "cities/",
     "fonts/",
     "maps/montlake.bin",
+    // used by tutorial
+    "prebaked_results/montlake/car vs bike contention.bin",
     "proposals/"
 );
 


### PR DESCRIPTION
This file is used in step 6 of the tutorial.

As a desktop app, we had a bunch of files we just read from disk when
needed. Translating this to web requires some thinkging (things are
slower, they can fail, etc.).

As a first step we simply agglomerated all the files into the wasm
binary, but since some of the files are rather large, we tried to only
include the essential and small files.

This one was missed. Though some of the prebaked results files are very
large, this one is a mere 5k.

Longer term, I think we'll want to have the web serve all these files separately, 
but that'll require a bit more thought.