### PR TITLE
Handle line segments intersecting at their endpoints. The algorithm I

### DIFF
--- a/geom/src/line.rs
+++ b/geom/src/line.rs
@@ -60,8 +60,8 @@ impl Line {
         self.pt1().dist_to(self.pt2())
     }
 
-    /// If two line segments intersect -- including endpoints -- return the point where they hit.
-    /// Undefined if the two lines have more than one intersection point!
+    /// If two line segments intersect at exactly one point, including endpoints, return that
+    /// point.
     // TODO Also return the distance along self
     pub fn intersection(&self, other: &Line) -> Option<Pt2D> {
         // From http://bryceboe.com/2006/10/23/line-segment-intersection-algorithm/
@@ -70,6 +70,19 @@ impl Line {
             || is_counter_clockwise(self.pt1(), self.pt2(), other.pt1())
                 == is_counter_clockwise(self.pt1(), self.pt2(), other.pt2())
         {
+            // This algorithm doesn't handle endpoints matching, so do that here.
+            if self.pt1() == other.pt1() {
+                return Some(self.pt1());
+            }
+            if self.pt1() == other.pt2() {
+                return Some(self.pt1());
+            }
+            if self.pt2() == other.pt1() {
+                return Some(self.pt2());
+            }
+            if self.pt2() == other.pt2() {
+                return Some(self.pt2());
+            }
             return None;
         }
 
@@ -279,5 +292,17 @@ impl fmt::Display for InfiniteLine {
         writeln!(f, "  Pt2D::new({}, {}),", self.0.x(), self.0.y())?;
         writeln!(f, "  Pt2D::new({}, {}),", self.1.x(), self.1.y())?;
         write!(f, ")")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn intersection() {
+        let l1 = Line::must_new(Pt2D::new(0.0, 0.0), Pt2D::new(1.0, 1.0));
+        let l2 = Line::must_new(Pt2D::new(2.0, 2.0), Pt2D::new(1.0, 1.0));
+        assert_eq!(Some(Pt2D::new(1.0, 1.0)), l1.intersection(&l2));
     }
 }

--- a/geom/src/polyline.rs
+++ b/geom/src/polyline.rs
@@ -653,14 +653,6 @@ impl PolyLine {
             }
         }
 
-        // TODO Why is any of this necessary? Found a test case at the intersection geometry for
-        // https://www.openstreetmap.org/node/274088813 where this made a huge difference!
-        if closest_intersection.is_none() {
-            if self.last_pt() == other.last_pt() {
-                return Some((self.last_pt(), self.last_line().angle()));
-            }
-        }
-
         closest_intersection
     }
 
@@ -843,4 +835,19 @@ fn to_set(pts: &[Pt2D]) -> (HashSet<HashablePt2D>, HashSet<HashablePt2D>) {
         }
     }
     (deduped, dupes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn intersection() {
+        let pl1 = PolyLine::must_new(vec![Pt2D::new(0.0, 0.0), Pt2D::new(1.0, 1.0)]);
+        let pl2 = PolyLine::must_new(vec![Pt2D::new(2.0, 2.0), Pt2D::new(1.0, 1.0)]);
+        assert_eq!(
+            Some((Pt2D::new(1.0, 1.0), Angle::degrees(45.0))),
+            pl1.intersection(&pl2)
+        );
+    }
 }


### PR DESCRIPTION
ported ages ago doesn't handle this, and somehow I didn't notice until
b2519e3050a1b90da12f7d5509e453cf8378b928.

@michaelkirk, any thoughts on this incremental improvement? I wanted to take this opportunity to rely on a better tested library for line segment intersection, but all I found was https://crates.io/crates/line_intersection. I gave it a shot at https://github.com/dabreegster/abstreet/blob/21eb14ba52afd549f0d6d0732ec3fe405a19869e/geom/src/line.rs#L75, but it said the line segments in the unit test were co-linear, which doesn't seem correct to me.

I'll keep looking around for ways to reduce the core code in `geom`. Ideally it'd mostly just wrap other crates that're better tested.