### PR TITLE
Automatically toggle between day/night colorschemes at 6am and 6pm, if

### DIFF
--- a/game/src/app.rs
+++ b/game/src/app.rs
@@ -11,7 +11,7 @@ use sim::{Analytics, Scenario, Sim, SimCallback, SimFlags};
 use widgetry::{Canvas, EventCtx, GfxCtx, Prerender, SharedAppState};
 
 use crate::challenges::HighScore;
-use crate::colors::ColorScheme;
+use crate::colors::{ColorScheme, ColorSchemeChoice};
 use crate::helpers::ID;
 use crate::layer::Layer;
 use crate::options::Options;
@@ -426,6 +426,25 @@ impl App {
         borrows.sort_by_key(|x| x.get_zorder());
 
         borrows
+    }
+
+    /// Change the color scheme. Idempotent. Return true if there was a change.
+    pub fn change_color_scheme(&mut self, ctx: &mut EventCtx, cs: ColorSchemeChoice) -> bool {
+        if self.opts.color_scheme == cs {
+            return false;
+        }
+        self.opts.color_scheme = cs;
+        self.cs = ColorScheme::new(self.opts.color_scheme);
+        ctx.set_style(self.cs.gui_style.clone());
+
+        ctx.loading_screen("rerendering map colors", |ctx, timer| {
+            let (draw_map, zorder_range) =
+                DrawMap::new(&self.primary.map, &self.opts, &self.cs, ctx, timer);
+            self.primary.draw_map = draw_map;
+            self.primary.zorder_range = zorder_range;
+        });
+
+        true
     }
 }
 

--- a/game/src/lib.rs
+++ b/game/src/lib.rs
@@ -43,6 +43,10 @@ pub fn main(mut args: CmdArgs) {
     if args.enabled("--lowzoom") {
         opts.min_zoom_for_detail = 1.0;
     }
+    if args.enabled("--day_night") {
+        opts.toggle_day_night_colors = true;
+        opts.color_scheme = colors::ColorSchemeChoice::NightMode;
+    }
 
     if let Some(x) = args.optional("--color_scheme") {
         let mut ok = false;

--- a/game/src/sandbox/gameplay/commute.rs
+++ b/game/src/sandbox/gameplay/commute.rs
@@ -47,22 +47,7 @@ impl OptimizeCommute {
         let person = app.primary.sim.find_person_by_orig_id(orig_person).unwrap();
         let trips = app.primary.sim.get_person(person).trips.clone();
         Box::new(OptimizeCommute {
-            top_center: Panel::new(Widget::col(vec![
-                challenge_header(ctx, "Optimize the VIP's commute"),
-                Widget::row(vec![
-                    format!("Speed up the VIP's trips by {}", goal)
-                        .draw_text(ctx)
-                        .centered_vert(),
-                    Btn::svg(
-                        "system/assets/tools/hint.svg",
-                        RewriteColor::Change(Color::WHITE, app.cs.hovering),
-                    )
-                    .build(ctx, "hint", None)
-                    .align_right(),
-                ]),
-            ]))
-            .aligned(HorizontalAlignment::Center, VerticalAlignment::Top)
-            .build(ctx),
+            top_center: Panel::empty(ctx),
             meter: make_meter(ctx, app, Duration::ZERO, Duration::ZERO, 0, trips.len()),
             person,
             mode: GameplayMode::OptimizeCommute(orig_person, goal),
@@ -210,6 +195,27 @@ impl GameplayState for OptimizeCommute {
     fn draw(&self, g: &mut GfxCtx, _: &App) {
         self.top_center.draw(g);
         self.meter.draw(g);
+    }
+
+    fn recreate_panels(&mut self, ctx: &mut EventCtx, app: &App) {
+        self.top_center = Panel::new(Widget::col(vec![
+            challenge_header(ctx, "Optimize the VIP's commute"),
+            Widget::row(vec![
+                format!("Speed up the VIP's trips by {}", self.goal)
+                    .draw_text(ctx)
+                    .centered_vert(),
+                Btn::svg(
+                    "system/assets/tools/hint.svg",
+                    RewriteColor::Change(Color::WHITE, app.cs.hovering),
+                )
+                .build(ctx, "hint", None)
+                .align_right(),
+            ]),
+        ]))
+        .aligned(HorizontalAlignment::Center, VerticalAlignment::Top)
+        .build(ctx);
+
+        // self.meter is recreated as time passes
     }
 }
 

--- a/game/src/sandbox/gameplay/freeform.rs
+++ b/game/src/sandbox/gameplay/freeform.rs
@@ -27,9 +27,9 @@ pub struct Freeform {
 }
 
 impl Freeform {
-    pub fn new(ctx: &mut EventCtx, app: &App) -> Box<dyn GameplayState> {
+    pub fn new(ctx: &mut EventCtx) -> Box<dyn GameplayState> {
         Box::new(Freeform {
-            top_center: make_top_center(ctx, app),
+            top_center: Panel::empty(ctx),
         })
     }
 }
@@ -105,40 +105,44 @@ impl GameplayState for Freeform {
     fn draw(&self, g: &mut GfxCtx, _: &App) {
         self.top_center.draw(g);
     }
-}
 
-fn make_top_center(ctx: &mut EventCtx, app: &App) -> Panel {
-    let rows = vec![
-        Widget::row(vec![
-            Line("Sandbox").small_heading().draw(ctx),
-            Widget::vert_separator(ctx, 50.0),
-            "Map:".draw_text(ctx),
-            Btn::pop_up(ctx, Some(nice_map_name(app.primary.map.get_name()))).build(
-                ctx,
-                "change map",
-                lctrl(Key::L),
-            ),
-            "Traffic:".draw_text(ctx),
-            Btn::pop_up(ctx, Some("none")).build(ctx, "change traffic", Key::S),
-            Btn::svg_def("system/assets/tools/edit_map.svg").build(ctx, "edit map", lctrl(Key::E)),
-        ])
-        .centered(),
-        Widget::row(vec![
-            Btn::text_fg("Start a new trip").build_def(ctx, None),
-            Btn::text_fg("Record trips as a scenario").build_def(ctx, None),
-        ])
-        .centered(),
-        Text::from_all(vec![
-            Line("Select an intersection and press "),
-            Key::Z.txt(ctx),
-            Line(" to start traffic nearby"),
-        ])
-        .draw(ctx),
-    ];
+    fn recreate_panels(&mut self, ctx: &mut EventCtx, app: &App) {
+        let rows = vec![
+            Widget::row(vec![
+                Line("Sandbox").small_heading().draw(ctx),
+                Widget::vert_separator(ctx, 50.0),
+                "Map:".draw_text(ctx),
+                Btn::pop_up(ctx, Some(nice_map_name(app.primary.map.get_name()))).build(
+                    ctx,
+                    "change map",
+                    lctrl(Key::L),
+                ),
+                "Traffic:".draw_text(ctx),
+                Btn::pop_up(ctx, Some("none")).build(ctx, "change traffic", Key::S),
+                Btn::svg_def("system/assets/tools/edit_map.svg").build(
+                    ctx,
+                    "edit map",
+                    lctrl(Key::E),
+                ),
+            ])
+            .centered(),
+            Widget::row(vec![
+                Btn::text_fg("Start a new trip").build_def(ctx, None),
+                Btn::text_fg("Record trips as a scenario").build_def(ctx, None),
+            ])
+            .centered(),
+            Text::from_all(vec![
+                Line("Select an intersection and press "),
+                Key::Z.txt(ctx),
+                Line(" to start traffic nearby"),
+            ])
+            .draw(ctx),
+        ];
 
-    Panel::new(Widget::col(rows))
-        .aligned(HorizontalAlignment::Center, VerticalAlignment::Top)
-        .build(ctx)
+        self.top_center = Panel::new(Widget::col(rows))
+            .aligned(HorizontalAlignment::Center, VerticalAlignment::Top)
+            .build(ctx);
+    }
 }
 
 pub fn make_change_traffic(

--- a/game/src/sandbox/gameplay/mod.rs
+++ b/game/src/sandbox/gameplay/mod.rs
@@ -48,6 +48,7 @@ pub trait GameplayState: downcast_rs::Downcast {
     ) -> Option<Transition>;
     fn draw(&self, g: &mut GfxCtx, app: &App);
     fn on_destroy(&self, _: &mut App) {}
+    fn recreate_panels(&mut self, ctx: &mut EventCtx, app: &App);
 
     fn can_move_canvas(&self) -> bool {
         true
@@ -173,12 +174,13 @@ impl GameplayMode {
         true
     }
 
-    /// Must be called after the scenario has been setup
+    /// Must be called after the scenario has been setup. The caller will call recreate_panels
+    /// after this, so each constructor doesn't need to.
     pub fn initialize(&self, ctx: &mut EventCtx, app: &mut App) -> Box<dyn GameplayState> {
         match self {
-            GameplayMode::Freeform(_) => freeform::Freeform::new(ctx, app),
+            GameplayMode::Freeform(_) => freeform::Freeform::new(ctx),
             GameplayMode::PlayScenario(_, ref scenario, ref modifiers) => {
-                play_scenario::PlayScenario::new(ctx, app, scenario, modifiers.clone())
+                play_scenario::PlayScenario::new(ctx, scenario, modifiers.clone())
             }
             GameplayMode::FixTrafficSignals => {
                 fix_traffic_signals::FixTrafficSignals::new(ctx, app)

--- a/game/src/sandbox/gameplay/play_scenario.rs
+++ b/game/src/sandbox/gameplay/play_scenario.rs
@@ -26,12 +26,11 @@ pub struct PlayScenario {
 impl PlayScenario {
     pub fn new(
         ctx: &mut EventCtx,
-        app: &mut App,
         name: &String,
         modifiers: Vec<ScenarioModifier>,
     ) -> Box<dyn GameplayState> {
         Box::new(PlayScenario {
-            top_center: make_top_center(ctx, app, name, &modifiers),
+            top_center: Panel::empty(ctx),
             scenario_name: name.to_string(),
             modifiers,
         })
@@ -111,47 +110,47 @@ impl GameplayState for PlayScenario {
     fn on_destroy(&self, app: &mut App) {
         app.primary.has_modified_trips = false;
     }
-}
 
-fn make_top_center(
-    ctx: &mut EventCtx,
-    app: &App,
-    scenario_name: &str,
-    modifiers: &Vec<ScenarioModifier>,
-) -> Panel {
-    let rows = vec![
-        Widget::row(vec![
-            Line("Sandbox").small_heading().draw(ctx),
-            Widget::vert_separator(ctx, 50.0),
-            "Map:".draw_text(ctx),
-            Btn::pop_up(ctx, Some(nice_map_name(app.primary.map.get_name()))).build(
-                ctx,
-                "change map",
-                lctrl(Key::L),
-            ),
-            "Traffic:".draw_text(ctx),
-            Btn::pop_up(ctx, Some(scenario_name)).build(ctx, "change traffic", Key::S),
-            Btn::svg_def("system/assets/tools/edit_map.svg").build(ctx, "edit map", lctrl(Key::E)),
-        ])
-        .centered(),
-        if scenario_name == "weekday" {
+    fn recreate_panels(&mut self, ctx: &mut EventCtx, app: &App) {
+        let rows = vec![
             Widget::row(vec![
-                Btn::svg_def("system/assets/tools/pencil.svg").build(
+                Line("Sandbox").small_heading().draw(ctx),
+                Widget::vert_separator(ctx, 50.0),
+                "Map:".draw_text(ctx),
+                Btn::pop_up(ctx, Some(nice_map_name(app.primary.map.get_name()))).build(
                     ctx,
-                    "edit traffic patterns",
-                    None,
+                    "change map",
+                    lctrl(Key::L),
                 ),
-                format!("{} modifications to traffic patterns", modifiers.len()).draw_text(ctx),
+                "Traffic:".draw_text(ctx),
+                Btn::pop_up(ctx, Some(&self.scenario_name)).build(ctx, "change traffic", Key::S),
+                Btn::svg_def("system/assets/tools/edit_map.svg").build(
+                    ctx,
+                    "edit map",
+                    lctrl(Key::E),
+                ),
             ])
-            .centered_horiz()
-        } else {
-            Widget::nothing()
-        },
-    ];
+            .centered(),
+            if self.scenario_name == "weekday" {
+                Widget::row(vec![
+                    Btn::svg_def("system/assets/tools/pencil.svg").build(
+                        ctx,
+                        "edit traffic patterns",
+                        None,
+                    ),
+                    format!("{} modifications to traffic patterns", self.modifiers.len())
+                        .draw_text(ctx),
+                ])
+                .centered_horiz()
+            } else {
+                Widget::nothing()
+            },
+        ];
 
-    Panel::new(Widget::col(rows))
-        .aligned(HorizontalAlignment::Center, VerticalAlignment::Top)
-        .build(ctx)
+        self.top_center = Panel::new(Widget::col(rows))
+            .aligned(HorizontalAlignment::Center, VerticalAlignment::Top)
+            .build(ctx);
+    }
 }
 
 struct EditScenarioModifiers {

--- a/game/src/sandbox/gameplay/tutorial.rs
+++ b/game/src/sandbox/gameplay/tutorial.rs
@@ -396,6 +396,13 @@ impl GameplayState for Tutorial {
         }
     }
 
+    fn recreate_panels(&mut self, ctx: &mut EventCtx, app: &App) {
+        let tut = app.session.tutorial.as_ref().unwrap();
+        self.top_center = tut.make_top_center(ctx, self.last_finished_task >= Task::WatchBikes);
+
+        // Time can't pass while self.msg_panel is active
+    }
+
     fn can_move_canvas(&self) -> bool {
         self.msg_panel.is_none()
     }

--- a/game/src/sandbox/mod.rs
+++ b/game/src/sandbox/mod.rs
@@ -109,9 +109,8 @@ impl State<App> for SandboxMode {
                 app.change_color_scheme(ctx, ColorSchemeChoice::NightMode)
             };
             if cs_changed {
-                // TODO Recreate panels. This handles some of them, but it also loses minimap zoom
-                // state, and misses the top_panel managed by individual GameplayStates.
-                self.controls = SandboxControls::new(ctx, app, &self.gameplay);
+                self.controls.recreate_panels(ctx, app);
+                self.gameplay.recreate_panels(ctx, app);
             }
         }
 
@@ -776,7 +775,8 @@ impl State<App> for SandboxLoader {
                     continue;
                 }
                 LoadStage::Finalizing => {
-                    let gameplay = self.mode.initialize(ctx, app);
+                    let mut gameplay = self.mode.initialize(ctx, app);
+                    gameplay.recreate_panels(ctx, app);
                     let sandbox = Box::new(SandboxMode {
                         controls: SandboxControls::new(ctx, app, &gameplay),
                         gameplay,
@@ -873,6 +873,18 @@ impl SandboxControls {
             } else {
                 None
             },
+        }
+    }
+
+    fn recreate_panels(&mut self, ctx: &mut EventCtx, app: &App) {
+        if self.tool_panel.is_some() {
+            self.tool_panel = Some(tool_panel(ctx));
+        }
+        if let Some(ref mut speed) = self.speed {
+            speed.recreate_panel(ctx, app);
+        }
+        if let Some(ref mut minimap) = self.minimap {
+            minimap.recreate_panel(ctx, app);
         }
     }
 }

--- a/game/src/sandbox/speed.rs
+++ b/game/src/sandbox/speed.rs
@@ -32,10 +32,20 @@ enum SpeedSetting {
 }
 
 impl SpeedControls {
-    fn make_panel(ctx: &mut EventCtx, app: &App, paused: bool, setting: SpeedSetting) -> Panel {
+    pub fn new(ctx: &mut EventCtx, app: &App) -> SpeedControls {
+        let mut speed = SpeedControls {
+            panel: Panel::empty(ctx),
+            paused: false,
+            setting: SpeedSetting::Realtime,
+        };
+        speed.recreate_panel(ctx, app);
+        speed
+    }
+
+    pub fn recreate_panel(&mut self, ctx: &mut EventCtx, app: &App) {
         let mut row = Vec::new();
         row.push(
-            if paused {
+            if self.paused {
                 Btn::svg_def("system/assets/speed/triangle.svg").build(ctx, "play", Key::Space)
             } else {
                 Btn::svg_def("system/assets/speed/pause.svg").build(ctx, "pause", Key::Space)
@@ -61,7 +71,7 @@ impl SpeedControls {
                     txt.extend(Text::tooltip(ctx, Key::RightArrow, "speed up"));
 
                     GeomBatch::load_svg(ctx.prerender, "system/assets/speed/triangle.svg")
-                        .color(if setting >= s {
+                        .color(if self.setting >= s {
                             RewriteColor::NoOp
                         } else {
                             RewriteColor::ChangeAll(Color::WHITE.alpha(0.2))
@@ -110,21 +120,12 @@ impl SpeedControls {
             .bg(app.cs.section_bg),
         );
 
-        Panel::new(Widget::custom_row(row))
+        self.panel = Panel::new(Widget::custom_row(row))
             .aligned(
                 HorizontalAlignment::Center,
                 VerticalAlignment::BottomAboveOSD,
             )
-            .build(ctx)
-    }
-
-    pub fn new(ctx: &mut EventCtx, app: &App) -> SpeedControls {
-        let panel = SpeedControls::make_panel(ctx, app, false, SpeedSetting::Realtime);
-        SpeedControls {
-            panel,
-            paused: false,
-            setting: SpeedSetting::Realtime,
-        }
+            .build(ctx);
     }
 
     pub fn event(
@@ -137,27 +138,27 @@ impl SpeedControls {
             Outcome::Clicked(x) => match x.as_ref() {
                 "real-time speed" => {
                     self.setting = SpeedSetting::Realtime;
-                    self.panel = SpeedControls::make_panel(ctx, app, self.paused, self.setting);
+                    self.recreate_panel(ctx, app);
                     return None;
                 }
                 "5x speed" => {
                     self.setting = SpeedSetting::Fast;
-                    self.panel = SpeedControls::make_panel(ctx, app, self.paused, self.setting);
+                    self.recreate_panel(ctx, app);
                     return None;
                 }
                 "30x speed" => {
                     self.setting = SpeedSetting::Faster;
-                    self.panel = SpeedControls::make_panel(ctx, app, self.paused, self.setting);
+                    self.recreate_panel(ctx, app);
                     return None;
                 }
                 "3600x speed" => {
                     self.setting = SpeedSetting::Fastest;
-                    self.panel = SpeedControls::make_panel(ctx, app, self.paused, self.setting);
+                    self.recreate_panel(ctx, app);
                     return None;
                 }
                 "play" => {
                     self.paused = false;
-                    self.panel = SpeedControls::make_panel(ctx, app, self.paused, self.setting);
+                    self.recreate_panel(ctx, app);
                     return None;
                 }
                 "pause" => {
@@ -213,15 +214,15 @@ impl SpeedControls {
                 SpeedSetting::Realtime => self.pause(ctx, app),
                 SpeedSetting::Fast => {
                     self.setting = SpeedSetting::Realtime;
-                    self.panel = SpeedControls::make_panel(ctx, app, self.paused, self.setting);
+                    self.recreate_panel(ctx, app);
                 }
                 SpeedSetting::Faster => {
                     self.setting = SpeedSetting::Fast;
-                    self.panel = SpeedControls::make_panel(ctx, app, self.paused, self.setting);
+                    self.recreate_panel(ctx, app);
                 }
                 SpeedSetting::Fastest => {
                     self.setting = SpeedSetting::Faster;
-                    self.panel = SpeedControls::make_panel(ctx, app, self.paused, self.setting);
+                    self.recreate_panel(ctx, app);
                 }
             }
         }
@@ -230,19 +231,19 @@ impl SpeedControls {
                 SpeedSetting::Realtime => {
                     if self.paused {
                         self.paused = false;
-                        self.panel = SpeedControls::make_panel(ctx, app, self.paused, self.setting);
+                        self.recreate_panel(ctx, app);
                     } else {
                         self.setting = SpeedSetting::Fast;
-                        self.panel = SpeedControls::make_panel(ctx, app, self.paused, self.setting);
+                        self.recreate_panel(ctx, app);
                     }
                 }
                 SpeedSetting::Fast => {
                     self.setting = SpeedSetting::Faster;
-                    self.panel = SpeedControls::make_panel(ctx, app, self.paused, self.setting);
+                    self.recreate_panel(ctx, app);
                 }
                 SpeedSetting::Faster => {
                     self.setting = SpeedSetting::Fastest;
-                    self.panel = SpeedControls::make_panel(ctx, app, self.paused, self.setting);
+                    self.recreate_panel(ctx, app);
                 }
                 SpeedSetting::Fastest => {}
             }
@@ -320,7 +321,7 @@ impl SpeedControls {
     pub fn pause(&mut self, ctx: &mut EventCtx, app: &App) {
         if !self.paused {
             self.paused = true;
-            self.panel = SpeedControls::make_panel(ctx, app, self.paused, self.setting);
+            self.recreate_panel(ctx, app);
         }
     }
 
@@ -328,7 +329,7 @@ impl SpeedControls {
         if self.paused || self.setting != SpeedSetting::Realtime {
             self.paused = false;
             self.setting = SpeedSetting::Realtime;
-            self.panel = SpeedControls::make_panel(ctx, app, self.paused, self.setting);
+            self.recreate_panel(ctx, app);
         }
     }
 


### PR DESCRIPTION
you pass --day_night. Fails to update all panels immediately.

Two concerns:
1) On larger maps, recreating `DrawMap` can take a moment. Suddenly jumping to a loading screen can be a little jarring. Not a huge deal.

2) Panels need to get recreated, to trigger `PanelBuilder::build`, which grabs `ctx.style.panel_bg`. Based on Yuwen's designs, this will also need to change things like text color too. I can think of two general ways to do this. One is the approach half-done in this PR -- recreating the panel from scratch. This loses state like minimap zoom and sandbox speed, and currently doesn't have a nice way of recreating the top_panel for each individual gameplay state. Maybe we just have to pay the cost of adding custom code to a few of these pieces to trigger a panel recalculation, but not create the `SandboxControls` state completely from scratch.

The other approach is to try to plumb support through widgetry for this kind of thing. For changing Panel bg, it's easy enough -- `struct Widget` has `bg: Option<Drawable>`, so we could have a method to clear it out and force recalculation. Then `Panel` could have `fn change_bg` that changes `top_level.layout.bg_color`. But it wouldn't handle changing text color or inner panel styles, and I can't think of any reasonable way to do that without increasing memory+complexity and remembering that a particular `Text` led to the creation of a `JustDraw` widget.

@michaelkirk please review at your convenience -- thanks!

And the demo:
![screencast](https://user-images.githubusercontent.com/1664407/98704006-ff168380-2330-11eb-9022-5825c35d3e1a.gif)
