### PR TITLE
modify glutin context config and shader files to resolve GLSL version build error

### DIFF
--- a/widgetry/src/backend_glow_native.rs
+++ b/widgetry/src/backend_glow_native.rs
@@ -11,10 +11,9 @@ pub fn setup(window_title: &str) -> (PrerenderInnards, winit::event_loop::EventL
         .with_maximized(true);
     // TODO If people are hitting problems with context not matching what their GPU provides, dig up
     // backend_glium.rs from git and bring the fallback behavior here. (Ideally, there'd be
-    // something in glutin to directly express this.) multisampling: 2 looks bad, 4 looks fine
+    // something in glutin to directly express this) multisampling: 2 looks bad, 4 looks fine
     let context = match glutin::ContextBuilder::new()
-        .with_multisampling(4)
-        .with_depth_buffer(2)
+        .with_vsync(true)
         .build_windowed(window, &event_loop)
     {
         Ok(ctx) => ctx,
@@ -30,10 +29,10 @@ pub fn setup(window_title: &str) -> (PrerenderInnards, winit::event_loop::EventL
 
     unsafe {
         let shaders = [
-            (glow::VERTEX_SHADER, include_str!("shaders/vertex_140.glsl")),
+            (glow::VERTEX_SHADER, include_str!("shaders/vertex_300.glsl")),
             (
                 glow::FRAGMENT_SHADER,
-                include_str!("shaders/fragment_140.glsl"),
+                include_str!("shaders/fragment_300.glsl"),
             ),
         ]
         .iter()


### PR DESCRIPTION
When building, I met this error:

```
gedalia-kott@gedalia-home-pc:~/abstreet$ RUST_BACKTRACE=1 cargo run --bin game
   Compiling widgetry v0.1.0 (/home/gedalia-kott/abstreet/widgetry)
   Compiling game v0.1.0 (/home/gedalia-kott/abstreet/game)
    Finished dev [unoptimized + debuginfo] target(s) in 26.58s
     Running `target/debug/game`
[INFO] winit::platform_impl::platform::x11::window: Guessed window scale factor: 1
[DEBUG] winit::platform_impl::platform::x11::window: Calculated physical dimensions: 800x600
libEGL warning: DRI2: failed to authenticate
[INFO] winit::platform_impl::platform::x11::window: Guessed window scale factor: 1
[DEBUG] winit::platform_impl::platform::x11::window: Calculated physical dimensions: 800x600
thread 'main' panicked at '0:1(10): error: GLSL 4.10 is not supported. Supported versions are: 1.10, 1.20, 1.30, 1.40, 1.50, 3.30, 1.00 ES, and 3.00 ES
', widgetry/src/backend_glow_native.rs:49:17
stack backtrace:
   0: std::panicking::begin_panic
             at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/std/src/panicking.rs:505
   1: widgetry::backend_glow_native::setup::{{closure}}
             at ./widgetry/src/backend_glow_native.rs:49
   2: core::iter::adapters::map_fold::{{closure}}
             at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/core/src/iter/adapters/mod.rs:905
   3: core::iter::traits::iterator::Iterator::fold
             at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/core/src/iter/traits/iterator.rs:2023
   4: <core::iter::adapters::Map<I,F> as core::iter::traits::iterator::Iterator>::fold
             at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/core/src/iter/adapters/mod.rs:945
   5: core::iter::traits::iterator::Iterator::for_each
             at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/core/src/iter/traits/iterator.rs:678
   6: <alloc::vec::Vec<T> as alloc::vec::SpecExtend<T,I>>::spec_extend
             at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/alloc/src/vec.rs:2378
   7: <alloc::vec::Vec<T> as alloc::vec::SpecFromIterNested<T,I>>::from_iter
             at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/alloc/src/vec.rs:2152
   8: <alloc::vec::Vec<T> as alloc::vec::SpecFromIter<T,I>>::from_iter
             at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/alloc/src/vec.rs:2162
   9: <alloc::vec::Vec<T> as core::iter::traits::collect::FromIterator<T>>::from_iter
             at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/alloc/src/vec.rs:2002
  10: core::iter::traits::iterator::Iterator::collect
             at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/core/src/iter/traits/iterator.rs:1670
  11: widgetry::backend_glow_native::setup
             at ./widgetry/src/backend_glow_native.rs:34
  12: widgetry::runner::run
             at ./widgetry/src/runner.rs:200
  13: game::main
             at ./game/src/lib.rs:121
  14: game::main
             at ./game/src/main.rs:2
  15: core::ops::function::FnOnce::call_once
             at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/core/src/ops/function.rs:227
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

I resolved it by A) modifying the config to remove multi sampling
and depth buffer.
They were not supported by my computer (hardware/software).

And B) I modified the shader files to use the 300 version of GLSL
syntax instead of the 4.X my computer was using (see output above
for the versions).

If useful, here is the output of glxinfo:

```
gedalia-kott@gedalia-home-pc:~/abstreet$ glxinfo | grep "version"
server glx version string: 1.4
client glx version string: 1.4
GLX version: 1.4
    Max core profile version: 3.3
    Max compat profile version: 3.1
    Max GLES1 profile version: 1.1
    Max GLES[23] profile version: 3.1
OpenGL core profile version string: 3.3 (Core Profile) Mesa 20.0.8
OpenGL core profile shading language version string: 3.30
OpenGL version string: 3.1 Mesa 20.0.8
OpenGL shading language version string: 1.40
OpenGL ES profile version string: OpenGL ES 3.1 Mesa 20.0.8
OpenGL ES profile shading language version string: OpenGL ES GLSL ES 3.10
    GL_EXT_shader_implicit_conversions, GL_EXT_shader_integer_mix,
```