### PR TITLE
Mkirk/switch buildings

### DIFF
--- a/game/src/devtools/fifteen_min/mod.rs
+++ b/game/src/devtools/fifteen_min/mod.rs
@@ -75,12 +75,8 @@ impl State<App> for Viewer {
         // Allow panning and zooming
         ctx.canvas_movement();
 
-        if ctx.redo_mouseover() {
-            app.recalculate_current_selection(ctx);
-        }
-
         if ctx.input.left_mouse_button_pressed() {
-            if let Some(ID::Building(building_id)) = app.primary.current_selection.clone() {
+            if let Some(ID::Building(building_id)) = app.mouseover_unzoomed_buildings(ctx) {
                 let building = app.primary.map.get_b(building_id);
                 debug!("clicked on building: {:?}", building);
                 self.isochrone = Isochrone::new(ctx, app, building_id);

--- a/game/src/devtools/fifteen_min/mod.rs
+++ b/game/src/devtools/fifteen_min/mod.rs
@@ -112,5 +112,5 @@ impl State<App> for Viewer {
 fn draw_star(center: Pt2D, ctx: &mut EventCtx) -> GeomBatch {
     GeomBatch::load_svg(ctx.prerender, "system/assets/tools/star.svg")
         .centered_on(center)
-        .color(RewriteColor::ChangeAll(Color::YELLOW))
+        .color(RewriteColor::ChangeAll(Color::BLACK))
 }


### PR DESCRIPTION
fixes #395 

You can now select a different building to re-focus the isochrone origin

![star_move mov](https://user-images.githubusercontent.com/217057/99886144-1be36e80-2bef-11eb-9ae7-a96c05585707.gif)

Also changed the star's yellow outline to be black instead for better contrast with the isochrone's yellow/green background.

One weirdness is that it currently only works while zoomed in. I'm assuming this is some quirk of `recalculate_current_selection` - any quick tips on how to fix this, or do you think this is an acceptable limitation for the prototype?