### PR TITLE
Refactor PathRequest creators that go between two buildings. #176

### DIFF
--- a/fifteen_min/src/isochrone.rs
+++ b/fifteen_min/src/isochrone.rs
@@ -4,7 +4,7 @@ use abstutil::MultiMap;
 use geom::{Duration, Polygon};
 use map_gui::tools::{amenity_type, Grid};
 use map_gui::SimpleApp;
-use map_model::{connectivity, BuildingID, Map, PathConstraints, PathRequest};
+use map_model::{connectivity, BuildingID, Map, Path, PathConstraints, PathRequest};
 use widgetry::{Color, Drawable, EventCtx, GeomBatch};
 
 /// Represents the area reachable from a single building.
@@ -51,26 +51,9 @@ impl Isochrone {
         }
     }
 
-    pub fn path_to(&self, map: &Map, destination_id: BuildingID) -> Option<map_model::Path> {
-        let (start, end) = match self.constraints {
-            PathConstraints::Pedestrian => (
-                map.get_b(self.start).sidewalk_pos,
-                map.get_b(destination_id).sidewalk_pos,
-            ),
-            PathConstraints::Bike => (
-                map.get_b(self.start).biking_connection(map)?.0,
-                map.get_b(destination_id).biking_connection(map)?.0,
-            ),
-            _ => unimplemented!("unhandled constraints: {:?}", self.constraints),
-        };
-
-        let path_request = PathRequest {
-            start,
-            end,
-            constraints: self.constraints,
-        };
-
-        map.pathfind(path_request)
+    pub fn path_to(&self, map: &Map, to: BuildingID) -> Option<Path> {
+        let req = PathRequest::between_buildings(map, self.start, to, self.constraints)?;
+        map.pathfind(req)
     }
 }
 

--- a/sim/src/make/activity_model.rs
+++ b/sim/src/make/activity_model.rs
@@ -219,15 +219,15 @@ fn create_prole(
         (TripEndpoint::Bldg(home_bldg), TripEndpoint::Bldg(work_bldg)) => {
             // Decide mode based on walking distance. If the buildings aren't connected,
             // probably a bug in importing; just skip this person.
-            let dist = if let Some(dist) = map
-                .pathfind(PathRequest {
-                    start: map.get_b(*home_bldg).sidewalk_pos,
-                    end: map.get_b(*work_bldg).sidewalk_pos,
-                    constraints: PathConstraints::Pedestrian,
-                })
-                .map(|p| p.total_length())
+            let dist = if let Some(path) = PathRequest::between_buildings(
+                map,
+                *home_bldg,
+                *work_bldg,
+                PathConstraints::Pedestrian,
+            )
+            .and_then(|req| map.pathfind(req))
             {
-                dist
+                path.total_length()
             } else {
                 return Err("no path found".into());
             };


### PR DESCRIPTION
@michaelkirk 

I started auditing all of the places in the code that create a `PathRequest` and found this small case to refactor. I'm not sure this is the right abstraction; it's possibly more useful to do something like `map.get_b(bldg).connection_for(PathConstraints::Bike, map)` and `map.get_i(border).start_for(PathConstraints::Car, map)` and `end_for`. But it's a first step, and makes further changes a little easier.

I'm also squinting more closely at sim's `DrivingGoal`. I think it can maybe go away entirely in favor of `TripEndpoint`.