### PR TITLE
Start refactoring a common UI pattern: recalculate some value only when

### DIFF
--- a/experiment/src/game.rs
+++ b/experiment/src/game.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use geom::{Circle, Distance, Pt2D, Speed};
 use map_gui::tools::{nice_map_name, CityPicker};
-use map_gui::{SimpleApp, ID};
+use map_gui::{Cacheable, Cached, SimpleApp, ID};
 use map_model::{BuildingID, BuildingType};
 use widgetry::{
     lctrl, Btn, Checkbox, Color, Drawable, EventCtx, GeomBatch, GfxCtx, HorizontalAlignment, Key,
@@ -17,8 +17,7 @@ pub struct Game {
 
     sleigh: Pt2D,
     score: Score,
-    // TODO That Cached thing would be nice here
-    over_bldg: Option<(BuildingID, Drawable)>,
+    over_bldg: Cached<OverBldg>,
 }
 
 impl Game {
@@ -56,24 +55,8 @@ impl Game {
 
             sleigh,
             score: Score::new(ctx, app),
-            over_bldg: None,
+            over_bldg: Cached::new(),
         })
-    }
-
-    fn over_bldg(&self, app: &SimpleApp) -> Option<BuildingID> {
-        for id in app
-            .draw_map
-            .get_matching_objects(Circle::new(self.sleigh, Distance::meters(3.0)).get_bounds())
-        {
-            if let ID::Building(b) = id {
-                if app.map.get_b(b).polygon.contains_pt(self.sleigh) {
-                    if let Some(BldgState::Undelivered(_)) = self.score.houses.get(&b) {
-                        return Some(b);
-                    }
-                }
-            }
-        }
-        None
     }
 
     fn update_panel(&mut self, ctx: &mut EventCtx) {
@@ -92,30 +75,14 @@ impl State<SimpleApp> for Game {
             self.sleigh = self.sleigh.offset(dx, dy);
             ctx.canvas.center_on_map_pt(self.sleigh);
 
-            if let Some(b) = self.over_bldg(app) {
-                if self
-                    .over_bldg
-                    .as_ref()
-                    .map(|(id, _)| *id != b)
-                    .unwrap_or(true)
-                {
-                    self.over_bldg = Some((
-                        b,
-                        ctx.upload(GeomBatch::from(vec![(
-                            Color::YELLOW,
-                            app.map.get_b(b).polygon.clone(),
-                        )])),
-                    ));
-                }
-            } else {
-                self.over_bldg = None;
-            }
+            self.over_bldg
+                .update(ctx, app, OverBldg::key(app, self.sleigh, &self.score), &());
         }
 
-        if let Some((b, _)) = &self.over_bldg {
+        if let Some(b) = self.over_bldg.key() {
             if ctx.input.pressed(Key::Space) {
-                if self.score.present_dropped(ctx, app, *b) {
-                    self.over_bldg = None;
+                if self.score.present_dropped(ctx, app, b) {
+                    self.over_bldg.clear();
                     self.update_panel(ctx);
                 }
             }
@@ -159,8 +126,8 @@ impl State<SimpleApp> for Game {
 
         g.redraw(&self.score.draw_scores);
         g.redraw(&self.score.draw_done);
-        if let Some((_, ref draw)) = self.over_bldg {
-            g.redraw(draw);
+        if let Some(draw) = self.over_bldg.value() {
+            g.redraw(&draw.0);
         }
         g.draw_polygon(
             Color::RED,
@@ -227,4 +194,37 @@ enum BldgState {
     // The score ready to claim
     Undelivered(usize),
     Done,
+}
+
+struct OverBldg(Drawable);
+
+impl OverBldg {
+    fn key(app: &SimpleApp, sleigh: Pt2D, score: &Score) -> Option<BuildingID> {
+        for id in app
+            .draw_map
+            .get_matching_objects(Circle::new(sleigh, Distance::meters(3.0)).get_bounds())
+        {
+            if let ID::Building(b) = id {
+                if app.map.get_b(b).polygon.contains_pt(sleigh) {
+                    if let Some(BldgState::Undelivered(_)) = score.houses.get(&b) {
+                        return Some(b);
+                    }
+                }
+            }
+        }
+        None
+    }
+}
+
+impl Cacheable for OverBldg {
+    type Key = BuildingID;
+    type Value = OverBldg;
+    type Extra = ();
+
+    fn value(ctx: &mut EventCtx, app: &mut SimpleApp, key: BuildingID, _: &()) -> OverBldg {
+        OverBldg(ctx.upload(GeomBatch::from(vec![(
+            Color::YELLOW,
+            app.map.get_b(key).polygon.clone(),
+        )])))
+    }
 }

--- a/map_gui/src/lib.rs
+++ b/map_gui/src/lib.rs
@@ -6,7 +6,7 @@ use map_model::{AreaID, BuildingID, BusStopID, IntersectionID, LaneID, Map, Park
 use sim::{AgentID, CarID, PedestrianID, Sim};
 use widgetry::{EventCtx, GfxCtx, State};
 
-pub use self::simple_app::SimpleApp;
+pub use self::simple_app::{Cacheable, Cached, SimpleApp};
 use crate::render::DrawOptions;
 use colors::{ColorScheme, ColorSchemeChoice};
 use options::Options;


### PR DESCRIPTION
a key changes.

It's quite verbose right now for some widgetry States to determine if
the mouse is over a particular type of object, check if that object has
changed since the last time, and calculate something based on it. This
introduces a new helper for expressing the pattern a little more
clearly.

It might be worth removing the dependncy on SimpleApp, if some use cases
in game show up.


@michaelkirk Does this help? Is the `Cacheable` type overkill? Originally I had `fn key` as part of the trait too, but couldn't plumb all of the side parameters needed in while expressing the lifetimes correctly.