### PR TITLE
Start refactoring a common UI pattern: recalculate some value only when

### DIFF
--- a/experiment/src/game.rs
+++ b/experiment/src/game.rs
@@ -217,7 +217,7 @@ impl OverBldg {
         None
     }
 
-    fn value(ctx: &mut EventCtx, app: &mut SimpleApp, key: BuildingID) -> OverBldg {
+    fn value(ctx: &mut EventCtx, app: &SimpleApp, key: BuildingID) -> OverBldg {
         OverBldg(ctx.upload(GeomBatch::from(vec![(
             Color::YELLOW,
             app.map.get_b(key).polygon.clone(),

--- a/experiment/src/game.rs
+++ b/experiment/src/game.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use geom::{Circle, Distance, Pt2D, Speed};
 use map_gui::tools::{nice_map_name, CityPicker};
-use map_gui::{SimpleApp, ID};
+use map_gui::{Cached, SimpleApp, ID};
 use map_model::{BuildingID, BuildingType};
 use widgetry::{
     lctrl, Btn, Checkbox, Color, Drawable, EventCtx, GeomBatch, GfxCtx, HorizontalAlignment, Key,
@@ -17,8 +17,7 @@ pub struct Game {
 
     sleigh: Pt2D,
     score: Score,
-    // TODO That Cached thing would be nice here
-    over_bldg: Option<(BuildingID, Drawable)>,
+    over_bldg: Cached<BuildingID, OverBldg>,
 }
 
 impl Game {
@@ -56,24 +55,8 @@ impl Game {
 
             sleigh,
             score: Score::new(ctx, app),
-            over_bldg: None,
+            over_bldg: Cached::new(),
         })
-    }
-
-    fn over_bldg(&self, app: &SimpleApp) -> Option<BuildingID> {
-        for id in app
-            .draw_map
-            .get_matching_objects(Circle::new(self.sleigh, Distance::meters(3.0)).get_bounds())
-        {
-            if let ID::Building(b) = id {
-                if app.map.get_b(b).polygon.contains_pt(self.sleigh) {
-                    if let Some(BldgState::Undelivered(_)) = self.score.houses.get(&b) {
-                        return Some(b);
-                    }
-                }
-            }
-        }
-        None
     }
 
     fn update_panel(&mut self, ctx: &mut EventCtx) {
@@ -92,30 +75,16 @@ impl State<SimpleApp> for Game {
             self.sleigh = self.sleigh.offset(dx, dy);
             ctx.canvas.center_on_map_pt(self.sleigh);
 
-            if let Some(b) = self.over_bldg(app) {
-                if self
-                    .over_bldg
-                    .as_ref()
-                    .map(|(id, _)| *id != b)
-                    .unwrap_or(true)
-                {
-                    self.over_bldg = Some((
-                        b,
-                        ctx.upload(GeomBatch::from(vec![(
-                            Color::YELLOW,
-                            app.map.get_b(b).polygon.clone(),
-                        )])),
-                    ));
-                }
-            } else {
-                self.over_bldg = None;
-            }
+            self.over_bldg
+                .update(OverBldg::key(app, self.sleigh, &self.score), |key| {
+                    OverBldg::value(ctx, app, key)
+                });
         }
 
-        if let Some((b, _)) = &self.over_bldg {
+        if let Some(b) = self.over_bldg.key() {
             if ctx.input.pressed(Key::Space) {
-                if self.score.present_dropped(ctx, app, *b) {
-                    self.over_bldg = None;
+                if self.score.present_dropped(ctx, app, b) {
+                    self.over_bldg.clear();
                     self.update_panel(ctx);
                 }
             }
@@ -159,8 +128,8 @@ impl State<SimpleApp> for Game {
 
         g.redraw(&self.score.draw_scores);
         g.redraw(&self.score.draw_done);
-        if let Some((_, ref draw)) = self.over_bldg {
-            g.redraw(draw);
+        if let Some(draw) = self.over_bldg.value() {
+            g.redraw(&draw.0);
         }
         g.draw_polygon(
             Color::RED,
@@ -227,4 +196,31 @@ enum BldgState {
     // The score ready to claim
     Undelivered(usize),
     Done,
+}
+
+struct OverBldg(Drawable);
+
+impl OverBldg {
+    fn key(app: &SimpleApp, sleigh: Pt2D, score: &Score) -> Option<BuildingID> {
+        for id in app
+            .draw_map
+            .get_matching_objects(Circle::new(sleigh, Distance::meters(3.0)).get_bounds())
+        {
+            if let ID::Building(b) = id {
+                if app.map.get_b(b).polygon.contains_pt(sleigh) {
+                    if let Some(BldgState::Undelivered(_)) = score.houses.get(&b) {
+                        return Some(b);
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    fn value(ctx: &mut EventCtx, app: &mut SimpleApp, key: BuildingID) -> OverBldg {
+        OverBldg(ctx.upload(GeomBatch::from(vec![(
+            Color::YELLOW,
+            app.map.get_b(key).polygon.clone(),
+        )])))
+    }
 }

--- a/fifteen_min/src/viewer.rs
+++ b/fifteen_min/src/viewer.rs
@@ -63,6 +63,9 @@ impl State<SimpleApp> for Viewer {
                 .update(HoverOnBuilding::key(ctx, app), |key| {
                     HoverOnBuilding::value(ctx, app, key, isochrone)
                 });
+            // Also update this to conveniently get an outline drawn. Note we don't want to do this
+            // inside the callback above, because it doesn't run when the key becomes None.
+            app.current_selection = self.hovering_on_bldg.key().map(|(b, _)| ID::Building(b));
         }
 
         // Don't call normal_left_click unless we're hovering on something in map-space; otherwise
@@ -249,7 +252,7 @@ impl HoverOnBuilding {
 
     fn value(
         ctx: &mut EventCtx,
-        app: &mut SimpleApp,
+        app: &SimpleApp,
         key: HoverKey,
         isochrone: &Isochrone,
     ) -> HoverOnBuilding {
@@ -268,9 +271,6 @@ impl HoverOnBuilding {
             );
             batch.extend(Color::BLACK, dashed_lines);
         }
-
-        // Also update this to conveniently get an outline drawn
-        app.current_selection = Some(ID::Building(hover_id));
 
         HoverOnBuilding {
             tooltip: if let Some(time) = isochrone.time_to_reach_building.get(&hover_id) {

--- a/fifteen_min/src/viewer.rs
+++ b/fifteen_min/src/viewer.rs
@@ -6,7 +6,7 @@
 
 use geom::{Distance, Pt2D};
 use map_gui::tools::{amenity_type, nice_map_name, CityPicker, PopupMsg};
-use map_gui::{SimpleApp, ID};
+use map_gui::{Cached, SimpleApp, ID};
 use map_model::{Building, BuildingID, PathConstraints};
 use widgetry::{
     lctrl, Btn, Checkbox, Color, Drawable, EventCtx, GeomBatch, GfxCtx, HorizontalAlignment, Key,
@@ -21,14 +21,7 @@ pub struct Viewer {
     highlight_start: Drawable,
     isochrone: Isochrone,
 
-    hovering_on_bldg: Option<HoverOnBuilding>,
-}
-
-struct HoverOnBuilding {
-    id: BuildingID,
-    tooltip: Text,
-    drawn_route: Option<Drawable>,
-    scale_factor: f64,
+    hovering_on_bldg: Cached<HoverKey, HoverOnBuilding>,
 }
 
 impl Viewer {
@@ -54,7 +47,7 @@ impl Viewer {
             panel,
             highlight_start: highlight_start,
             isochrone,
-            hovering_on_bldg: None,
+            hovering_on_bldg: Cached::new(),
         })
     }
 }
@@ -65,68 +58,24 @@ impl State<SimpleApp> for Viewer {
         ctx.canvas_movement();
 
         if ctx.redo_mouseover() {
-            let scale_factor = if ctx.canvas.cam_zoom >= app.opts.min_zoom_for_detail {
-                1.0
-            } else {
-                10.0
-            };
-            self.hovering_on_bldg = match app.mouseover_unzoomed_buildings(ctx) {
-                Some(ID::Building(hover_id)) => match self.hovering_on_bldg.take() {
-                    Some(previous_hover)
-                        if (previous_hover.id, previous_hover.scale_factor)
-                            == (hover_id, scale_factor) =>
-                    {
-                        Some(previous_hover)
-                    }
-                    _ => {
-                        debug!("drawing new hover");
-                        let drawn_route = self
-                            .isochrone
-                            .path_to(&app.map, hover_id)
-                            .and_then(|path| path.trace(&app.map, Distance::ZERO, None))
-                            .map(|polyline| {
-                                let dashed_lines = polyline.dashed_lines(
-                                    Distance::meters(0.75 * scale_factor),
-                                    Distance::meters(1.0 * scale_factor),
-                                    Distance::meters(0.4 * scale_factor),
-                                );
-                                let mut batch = GeomBatch::new();
-                                batch.extend(Color::BLACK, dashed_lines);
-                                ctx.prerender.upload(batch)
-                            });
-                        Some(HoverOnBuilding {
-                            id: hover_id,
-                            tooltip: if let Some(time) =
-                                self.isochrone.time_to_reach_building.get(&hover_id)
-                            {
-                                Text::from(Line(format!("{} away", time)))
-                            } else {
-                                Text::from(Line("This is more than 15 minutes away"))
-                            },
-                            scale_factor,
-                            drawn_route,
-                        })
-                    }
-                },
-                _ => None,
-            };
-
-            // Also update this to conveniently get an outline drawn
-            app.current_selection = self.hovering_on_bldg.as_ref().map(|h| ID::Building(h.id));
+            let isochrone = &self.isochrone;
+            self.hovering_on_bldg
+                .update(HoverOnBuilding::key(ctx, app), |key| {
+                    HoverOnBuilding::value(ctx, app, key, isochrone)
+                });
         }
 
         // Don't call normal_left_click unless we're hovering on something in map-space; otherwise
         // panel.event never sees clicks.
-        if let Some(ref hover) = self.hovering_on_bldg {
+        if let Some((hover_id, _)) = self.hovering_on_bldg.key() {
             if ctx.normal_left_click() {
-                debug!("selected new");
-                let start = app.map.get_b(hover.id);
+                let start = app.map.get_b(hover_id);
                 self.isochrone = Isochrone::new(ctx, app, start.id, self.isochrone.constraints);
                 self.highlight_start = draw_star(ctx, start.polygon.center());
                 self.panel = build_panel(ctx, app, start, &self.isochrone);
                 // Any previous hover is from the perspective of the old `highlight_start`.
                 // Remove it so we don't have a dotted line to the previous isochrone's origin
-                self.hovering_on_bldg = None;
+                self.hovering_on_bldg.clear();
             }
         }
 
@@ -207,11 +156,9 @@ impl State<SimpleApp> for Viewer {
         g.redraw(&self.isochrone.draw);
         g.redraw(&self.highlight_start);
         self.panel.draw(g);
-        if let Some(ref hover) = self.hovering_on_bldg {
+        if let Some(ref hover) = self.hovering_on_bldg.value() {
             g.draw_mouse_tooltip(hover.tooltip.clone());
-            if let Some(ref drawn_route) = hover.drawn_route {
-                g.redraw(drawn_route);
-            }
+            g.redraw(&hover.drawn_route);
         }
     }
 }
@@ -276,4 +223,62 @@ fn build_panel(
     Panel::new(Widget::col(rows))
         .aligned(HorizontalAlignment::Right, VerticalAlignment::Top)
         .build(ctx)
+}
+
+struct HoverOnBuilding {
+    tooltip: Text,
+    drawn_route: Drawable,
+}
+/// (building, scale factor)
+type HoverKey = (BuildingID, f64);
+
+impl HoverOnBuilding {
+    fn key(ctx: &EventCtx, app: &SimpleApp) -> Option<HoverKey> {
+        match app.mouseover_unzoomed_buildings(ctx) {
+            Some(ID::Building(b)) => {
+                let scale_factor = if ctx.canvas.cam_zoom >= app.opts.min_zoom_for_detail {
+                    1.0
+                } else {
+                    10.0
+                };
+                Some((b, scale_factor))
+            }
+            _ => None,
+        }
+    }
+
+    fn value(
+        ctx: &mut EventCtx,
+        app: &mut SimpleApp,
+        key: HoverKey,
+        isochrone: &Isochrone,
+    ) -> HoverOnBuilding {
+        debug!("Calculating route for {:?}", key);
+
+        let (hover_id, scale_factor) = key;
+        let mut batch = GeomBatch::new();
+        if let Some(polyline) = isochrone
+            .path_to(&app.map, hover_id)
+            .and_then(|path| path.trace(&app.map, Distance::ZERO, None))
+        {
+            let dashed_lines = polyline.dashed_lines(
+                Distance::meters(0.75 * scale_factor),
+                Distance::meters(1.0 * scale_factor),
+                Distance::meters(0.4 * scale_factor),
+            );
+            batch.extend(Color::BLACK, dashed_lines);
+        }
+
+        // Also update this to conveniently get an outline drawn
+        app.current_selection = Some(ID::Building(hover_id));
+
+        HoverOnBuilding {
+            tooltip: if let Some(time) = isochrone.time_to_reach_building.get(&hover_id) {
+                Text::from(Line(format!("{} away", time)))
+            } else {
+                Text::from(Line("This is more than 15 minutes away"))
+            },
+            drawn_route: ctx.upload(batch),
+        }
+    }
 }

--- a/map_gui/src/lib.rs
+++ b/map_gui/src/lib.rs
@@ -6,7 +6,7 @@ use map_model::{AreaID, BuildingID, BusStopID, IntersectionID, LaneID, Map, Park
 use sim::{AgentID, CarID, PedestrianID, Sim};
 use widgetry::{EventCtx, GfxCtx, State};
 
-pub use self::simple_app::SimpleApp;
+pub use self::simple_app::{Cached, SimpleApp};
 use crate::render::DrawOptions;
 use colors::{ColorScheme, ColorSchemeChoice};
 use options::Options;

--- a/map_gui/src/simple_app.rs
+++ b/map_gui/src/simple_app.rs
@@ -287,3 +287,39 @@ impl State<SimpleApp> for SimpleWarper {
 
     fn draw(&self, _: &mut GfxCtx, _: &SimpleApp) {}
 }
+
+/// Store a cached key/value pair, only recalculating when the key changes.
+pub struct Cached<K, V> {
+    contents: Option<(K, V)>,
+}
+
+impl<K: PartialEq + Clone, V> Cached<K, V> {
+    pub fn new() -> Cached<K, V> {
+        Cached { contents: None }
+    }
+
+    /// Get the current key.
+    pub fn key(&self) -> Option<K> {
+        self.contents.as_ref().map(|(k, _)| k.clone())
+    }
+
+    /// Get the current value.
+    pub fn value(&self) -> Option<&V> {
+        self.contents.as_ref().map(|(_, v)| v)
+    }
+
+    /// Update the value if the key has changed.
+    pub fn update<F: FnMut(K) -> V>(&mut self, key: Option<K>, mut produce_value: F) {
+        if let Some(new_key) = key {
+            if self.key() != Some(new_key.clone()) {
+                self.contents = Some((new_key.clone(), produce_value(new_key)));
+            }
+        } else {
+            self.contents = None;
+        }
+    }
+
+    pub fn clear(&mut self) {
+        self.contents = None;
+    }
+}

--- a/map_gui/src/simple_app.rs
+++ b/map_gui/src/simple_app.rs
@@ -289,7 +289,7 @@ impl State<SimpleApp> for SimpleWarper {
 }
 
 /// Store a cached key/value pair, only recalculating when the key changes.
-pub struct Cached<K, V> {
+pub struct Cached<K: PartialEq + Clone, V> {
     contents: Option<(K, V)>,
 }
 


### PR DESCRIPTION
a key changes.

It's quite verbose right now for some widgetry States to determine if
the mouse is over a particular type of object, check if that object has
changed since the last time, and calculate something based on it. This
introduces a new helper for expressing the pattern a little more
clearly.

@michaelkirk Actually, I think this approach is better. Less boilerplate, works for App/SimpleApp, no weird lifetime issues, more flexible to pass params to key/value functions as needed.