### PR TITLE
Slightly simplify how some states specify what map objects can be

### DIFF
--- a/game/src/app.rs
+++ b/game/src/app.rs
@@ -10,7 +10,7 @@ use map_gui::colors::ColorScheme;
 use map_gui::options::Options;
 use map_gui::render::{unzoomed_agent_radius, AgentCache, DrawMap, DrawOptions, Renderable};
 use map_gui::ID;
-use map_model::{IntersectionID, Map, Traversable};
+use map_model::{IntersectionID, LaneID, Map, Traversable};
 use sim::{AgentID, Analytics, Scenario, Sim, SimCallback, SimFlags};
 use widgetry::{Canvas, EventCtx, GfxCtx, Prerender, SharedAppState, State};
 
@@ -248,6 +248,13 @@ impl App {
     pub fn mouseover_unzoomed_roads_and_intersections(&self, ctx: &EventCtx) -> Option<ID> {
         self.calculate_current_selection(ctx, &ShowEverything::new(), false, true, false)
     }
+    pub fn mouseover_unzoomed_intersections(&self, ctx: &EventCtx) -> Option<ID> {
+        self.calculate_current_selection(ctx, &ShowEverything::new(), false, true, false)
+            .filter(|id| match id {
+                ID::Intersection(_) => true,
+                _ => false,
+            })
+    }
     pub fn mouseover_unzoomed_buildings(&self, ctx: &EventCtx) -> Option<ID> {
         self.calculate_current_selection(ctx, &ShowEverything::new(), false, false, true)
     }
@@ -423,6 +430,36 @@ impl App {
             self.primary.clear_sim();
             self.set_prebaked(None);
         });
+    }
+}
+
+impl App {
+    /// If an intersection was clicked, return its ID.
+    pub fn click_on_intersection<S: Into<String>>(
+        &mut self,
+        ctx: &mut EventCtx,
+        label: S,
+    ) -> Option<IntersectionID> {
+        if let Some(ID::Intersection(i)) = self.primary.current_selection {
+            if self.per_obj.left_click(ctx, label) {
+                return Some(i);
+            }
+        }
+        None
+    }
+
+    /// If a lane was clicked, return its ID.
+    pub fn click_on_lane<S: Into<String>>(
+        &mut self,
+        ctx: &mut EventCtx,
+        label: S,
+    ) -> Option<LaneID> {
+        if let Some(ID::Lane(l)) = self.primary.current_selection {
+            if self.per_obj.left_click(ctx, label) {
+                return Some(l);
+            }
+        }
+        None
     }
 }
 

--- a/game/src/edit/mod.rs
+++ b/game/src/edit/mod.rs
@@ -157,18 +157,15 @@ impl State<App> for EditMode {
         // Restrict what can be selected.
         if ctx.redo_mouseover() {
             app.primary.current_selection = app.mouseover_unzoomed_roads_and_intersections(ctx);
-            if let Some(ID::Lane(l)) = app.primary.current_selection {
-                if !can_edit_lane(&self.mode, l, app) {
-                    app.primary.current_selection = None;
+            if match app.primary.current_selection {
+                Some(ID::Lane(l)) => !can_edit_lane(&self.mode, l, app),
+                Some(ID::Intersection(i)) => {
+                    !self.mode.can_edit_stop_signs()
+                        && app.primary.map.maybe_get_stop_sign(i).is_some()
                 }
-            } else if let Some(ID::Intersection(i)) = app.primary.current_selection {
-                if app.primary.map.maybe_get_stop_sign(i).is_some()
-                    && !self.mode.can_edit_stop_signs()
-                {
-                    app.primary.current_selection = None;
-                }
-            } else if let Some(ID::Road(_)) = app.primary.current_selection {
-            } else {
+                Some(ID::Road(_)) => false,
+                _ => true,
+            } {
                 app.primary.current_selection = None;
             }
         }

--- a/game/src/edit/traffic_signals/picker.rs
+++ b/game/src/edit/traffic_signals/picker.rs
@@ -47,28 +47,26 @@ impl State<App> for SignalPicker {
     fn event(&mut self, ctx: &mut EventCtx, app: &mut App) -> Transition {
         ctx.canvas_movement();
         if ctx.redo_mouseover() {
-            app.primary.current_selection = app.mouseover_unzoomed_roads_and_intersections(ctx);
+            app.primary.current_selection =
+                app.mouseover_unzoomed_intersections(ctx).filter(|id| {
+                    app.primary
+                        .map
+                        .maybe_get_traffic_signal(id.as_intersection())
+                        .is_some()
+                });
         }
         if let Some(ID::Intersection(i)) = app.primary.current_selection {
-            if app.primary.map.maybe_get_traffic_signal(i).is_some() {
-                if !self.members.contains(&i)
-                    && app.per_obj.left_click(ctx, "add this intersection")
-                {
-                    self.members.insert(i);
-                    let btn = make_btn(ctx, self.members.len());
-                    self.panel.replace(ctx, "edit", btn);
-                } else if self.members.contains(&i)
-                    && app.per_obj.left_click(ctx, "remove this intersection")
-                {
-                    self.members.remove(&i);
-                    let btn = make_btn(ctx, self.members.len());
-                    self.panel.replace(ctx, "edit", btn);
-                }
-            } else {
-                app.primary.current_selection = None;
+            if !self.members.contains(&i) && app.per_obj.left_click(ctx, "add this intersection") {
+                self.members.insert(i);
+                let btn = make_btn(ctx, self.members.len());
+                self.panel.replace(ctx, "edit", btn);
+            } else if self.members.contains(&i)
+                && app.per_obj.left_click(ctx, "remove this intersection")
+            {
+                self.members.remove(&i);
+                let btn = make_btn(ctx, self.members.len());
+                self.panel.replace(ctx, "edit", btn);
             }
-        } else {
-            app.primary.current_selection = None;
         }
 
         match self.panel.event(ctx) {

--- a/game/src/sandbox/dashboards/traffic_signals.rs
+++ b/game/src/sandbox/dashboards/traffic_signals.rs
@@ -68,7 +68,7 @@ impl TrafficSignalDemand {
 impl State<App> for TrafficSignalDemand {
     fn event(&mut self, ctx: &mut EventCtx, app: &mut App) -> Transition {
         ctx.canvas_movement();
-        // TODO DrawWithTooltips works great in screenspace; make a similar tool for mapspace?
+        // TODO Use MapspaceTooltips here?
         if ctx.redo_mouseover() {
             self.selected = None;
             app.recalculate_current_selection(ctx);

--- a/game/src/sandbox/gameplay/freeform.rs
+++ b/game/src/sandbox/gameplay/freeform.rs
@@ -345,12 +345,11 @@ impl State<App> for AgentSpawner {
 
         if ctx.redo_mouseover() {
             app.primary.current_selection = app.mouseover_unzoomed_everything(ctx);
-            if let Some(ID::Intersection(i)) = app.primary.current_selection {
-                if !app.primary.map.get_i(i).is_border() {
-                    app.primary.current_selection = None;
-                }
-            } else if let Some(ID::Building(_)) = app.primary.current_selection {
-            } else {
+            if match app.primary.current_selection {
+                Some(ID::Intersection(i)) => !app.primary.map.get_i(i).is_border(),
+                Some(ID::Building(_)) => false,
+                _ => true,
+            } {
                 app.primary.current_selection = None;
             }
         }

--- a/game/src/sandbox/misc_tools.rs
+++ b/game/src/sandbox/misc_tools.rs
@@ -101,7 +101,7 @@ impl State<App> for TrafficRecorder {
     fn event(&mut self, ctx: &mut EventCtx, app: &mut App) -> Transition {
         ctx.canvas_movement();
         if ctx.redo_mouseover() {
-            app.primary.current_selection = app.mouseover_unzoomed_roads_and_intersections(ctx);
+            app.primary.current_selection = app.mouseover_unzoomed_intersections(ctx);
         }
         if let Some(ID::Intersection(i)) = app.primary.current_selection {
             if !self.members.contains(&i) && app.per_obj.left_click(ctx, "add this intersection") {
@@ -115,8 +115,6 @@ impl State<App> for TrafficRecorder {
                 let btn = make_btn(ctx, self.members.len());
                 self.panel.replace(ctx, "record", btn);
             }
-        } else {
-            app.primary.current_selection = None;
         }
 
         match self.panel.event(ctx) {

--- a/game/src/sandbox/uber_turns.rs
+++ b/game/src/sandbox/uber_turns.rs
@@ -84,7 +84,7 @@ impl SimpleState for UberTurnPicker {
     }
 
     fn on_mouseover(&mut self, ctx: &mut EventCtx, app: &mut App) {
-        app.recalculate_current_selection(ctx);
+        app.primary.current_selection = app.mouseover_unzoomed_intersections(ctx);
     }
     fn other_event(&mut self, ctx: &mut EventCtx, app: &mut App) -> Transition {
         ctx.canvas_movement();

--- a/map_gui/src/lib.rs
+++ b/map_gui/src/lib.rs
@@ -100,4 +100,11 @@ impl ID {
             _ => None,
         }
     }
+
+    pub fn as_intersection(&self) -> IntersectionID {
+        match *self {
+            ID::Intersection(i) => i,
+            _ => panic!("Can't call as_intersection on {:?}", self),
+        }
+    }
 }


### PR DESCRIPTION
selected and clicked on.

@michaelkirk : This adds a few convenience methods to `app` for some commonish cases. In others, more explicitly filter out the valid set of selectable things.

I'm trying to tease apart the ad-hocness of `event()`. Three really common pieces are handling a panel, recalculating the selected map-space thing, and handling clicks on map-space objects.