### PR TITLE
    Improve lane changing vis-a-vis uber turns.

### DIFF
--- a/abstutil/src/logger.rs
+++ b/abstutil/src/logger.rs
@@ -16,7 +16,7 @@ impl Logger {
     pub fn setup() {
         #[cfg(target_arch = "wasm32")]
         {
-            console_log::init_with_level(log::Level::Debug).unwrap();
+            console_log::init_with_level(log::Level::Info).unwrap();
         }
 
         #[cfg(not(target_arch = "wasm32"))]
@@ -25,7 +25,7 @@ impl Logger {
                 last_fast_paths_note: RwLock::new(None),
             }))
             .unwrap();
-            log::set_max_level(log::LevelFilter::Debug);
+            log::set_max_level(log::LevelFilter::Info);
         }
     }
 }

--- a/sim/src/mechanics/intersection.rs
+++ b/sim/src/mechanics/intersection.rs
@@ -52,6 +52,7 @@ pub(crate) struct IntersectionSimState {
 #[derive(Clone, Serialize, Deserialize)]
 struct State {
     id: IntersectionID,
+    // The in-progress turns which any potential new turns must not conflict with
     accepted: BTreeSet<Request>,
     // Track when a request is first made.
     #[serde(

--- a/sim/src/mechanics/queue.rs
+++ b/sim/src/mechanics/queue.rs
@@ -258,7 +258,12 @@ impl Queue {
 
     pub fn free_reserved_space(&mut self, car: &Car) {
         self.reserved_length -= car.vehicle.length + FOLLOWING_DISTANCE;
-        assert!(self.reserved_length >= Distance::ZERO);
+        assert!(
+            self.reserved_length >= Distance::ZERO,
+            "invalid reserved length: {:?}, car: {:?}",
+            self.reserved_length,
+            car
+        );
     }
 
     pub fn target_lane_penalty(&self) -> (usize, usize) {


### PR DESCRIPTION
Effectively three behavioral changes:

1. Allow lane changing in an uber turn. Because of the way uber turns work, we lock in and commit to all the lane changes just before entering the uber turn.

2. Avoid overzealous lane changing by combining number-of-lanes-crossed and numer-of-vehicles-in-lane into a single cost, rather than always preferring the least  number-of-vehicles-in-lane.
    
3. Don't lane-change unless the candidate lane's cost is strictly better than the current lane cost.

## Results (vs. prebake run on b5ea263fc):

Montlake and Lakeslice are affected, but seemingly not by much. In both case the "saved time" slightly outweighs the "lost time". 

I have noticed a pattern where it seems like in general long trips are improved while short trips suffer. I'm not really sure why. One guess would be that previously longer trips were more likely to be clogged up in the major thoroughfares, leaving the back roads relatively empty.

**montlake**

<img width="1792" alt="Screen Shot 2020-12-01 at 1 59 47 PM" src="https://user-images.githubusercontent.com/217057/100801910-7ba2fc00-33dd-11eb-8c8b-385ef8b3ac4f.png">

**lakeslice**

<img width="1792" alt="Screen Shot 2020-12-01 at 2 14 39 PM" src="https://user-images.githubusercontent.com/217057/100803236-aee68a80-33df-11eb-9fa0-5cfaaab68ce4.png">

**south seattle (until 8am)**

Things are pretty deadlocked by 8am, but on average, things are a little bit better for this map.

<img width="1792" alt="Screen Shot 2020-12-01 at 2 22 34 PM" src="https://user-images.githubusercontent.com/217057/100803839-b65a6380-33e0-11eb-9fad-b45526e10aad.png">

_before_:  34,366 agents left by end of day
_after_:  33,923 agents left by end of day
_difference_: 443 more trips completed

**Krakow (until 9am)**

_before_: 14,465 agents left by end of day
_after_: 13,686 agents left by end of day    
_difference_: 1,779 more trips completed

Krakow's improvement is a bit more pronounced. My hypothesis is that this change mostly helps with complex compound intersections, of which Krakow has no shortage.

Here's the GIF that started this whole pursuit:

before:
![intersection_traversal before](https://user-images.githubusercontent.com/899988/98115670-78345780-1ea7-11eb-9cde-a3ac15a059ca.gif)

and here's the behavior after:
![intersection_traversal after](https://user-images.githubusercontent.com/217057/100814033-9ed9a580-33f5-11eb-9a1b-687f9cbb42df.gif)
Note people are much more likely to stay in their lanes, and all the lanes get used.

One interesting thing - this change doesn't really seem to help anything until there's a bit of traffic. e.g. in the Krakow case there's basically 0 extra trips from 12:00am-7:00am, but then by 7:30 when traffic picks up we suddenly start to rack up extra trips.

One thing that surprised me here:

...so by 8am we have 1k+ bonus trips.
<img width="781" alt="Screen Shot 2020-12-01 at 4 58 29 PM" src="https://user-images.githubusercontent.com/217057/100814424-828a3880-33f6-11eb-9ff9-13f93f694882.png">

But the stats show slower trips.
<img width="1792" alt="Screen Shot 2020-12-01 at 4 58 43 PM" src="https://user-images.githubusercontent.com/217057/100814426-8322cf00-33f6-11eb-873c-f14f6d07e5b1.png">

From looking at that, it seems like things are *worse* than before. However I'm wondering if this is due to their being more completed trips in the *after* scenario than in the *before* scenario. Maybe these charts weren't meant to compare to partial/incomplete prebakes.

---

As a side note, would you be open to including the partial day south Seattle and Krakow into the default prebake? It might be nice to help avoid regressing there.