### PR TITLE
replace custom logger with env_logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,7 @@ version = "0.1.0"
 dependencies = [
  "bincode",
  "console_log",
+ "env_logger",
  "include_dir 0.6.1-alpha.0",
  "instant",
  "itertools",
@@ -59,6 +60,15 @@ name = "ahash"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6789e291be47ace86a60303502173d84af8327e3627ecf334356ee0f87a164c"
+
+[[package]]
+name = "aho-corasick"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "andrew"
@@ -698,6 +708,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26ecb66b4bdca6c1409b40fb255eefc2bd4f6d135dab3c3124f80ffa2a9661e"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
 ]
 
 [[package]]
@@ -1379,6 +1402,12 @@ name = "httpdate"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
+
+[[package]]
+name = "humantime"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a"
 
 [[package]]
 name = "hyper"
@@ -2514,6 +2543,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+ "thread_local",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2521,6 +2562,12 @@ checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
 dependencies = [
  "byteorder",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
 
 [[package]]
 name = "remove_dir_all"
@@ -2980,6 +3027,15 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]

--- a/abstutil/Cargo.toml
+++ b/abstutil/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2018"
 
 [dependencies]
 bincode = "1.3.1"
+env_logger = { version = "0.8.2" }
 instant = "0.1.7"
 itertools = "0.9.0"
 lazy_static = "1.4.0"
 log = { version = "0.4.11", features=["std"] }
-env_logger = { version = "0.8.2" }
 num_cpus = "1.13.0"
 scoped_threadpool = "0.1.9"
 serde = "1.0.116"

--- a/abstutil/Cargo.toml
+++ b/abstutil/Cargo.toml
@@ -10,6 +10,7 @@ instant = "0.1.7"
 itertools = "0.9.0"
 lazy_static = "1.4.0"
 log = { version = "0.4.11", features=["std"] }
+env_logger = { version = "0.8.2" }
 num_cpus = "1.13.0"
 scoped_threadpool = "0.1.9"
 serde = "1.0.116"

--- a/abstutil/src/cli.rs
+++ b/abstutil/src/cli.rs
@@ -15,7 +15,7 @@ impl CmdArgs {
     /// Calling this has the side-effect of initializing logging on both native and web. This
     /// should probably be done independently, but for the moment, every app wants both.
     pub fn new() -> CmdArgs {
-        crate::Logger::setup();
+        crate::logger::setup();
 
         if cfg!(target_arch = "wasm32") {
             CmdArgs::from_args(Vec::new())

--- a/abstutil/src/logger.rs
+++ b/abstutil/src/logger.rs
@@ -1,74 +1,16 @@
-use std::sync::RwLock;
-
-use instant::Instant;
-
-use crate::elapsed_seconds;
-
-pub struct Logger {
-    last_fast_paths_note: RwLock<Option<Instant>>,
-}
-
-impl Logger {
-    /// On native: intercept messages using the `log` crate and print them to STDOUT. Contains
-    /// special handling to filter/throttle spammy messages from `fast_paths` and `hyper`.
-    ///
-    /// On web: Just use console_log.
-    pub fn setup() {
-        #[cfg(target_arch = "wasm32")]
-        {
-            console_log::init_with_level(log::Level::Info).unwrap();
-        }
-
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            log::set_boxed_logger(Box::new(Logger {
-                last_fast_paths_note: RwLock::new(None),
-            }))
-            .unwrap();
-            log::set_max_level(log::LevelFilter::Info);
-        }
-    }
-}
-
-impl log::Log for Logger {
-    fn enabled(&self, _: &log::Metadata) -> bool {
-        true
+/// On native: intercept messages using the `log` crate and print them to STDOUT. Contains
+/// special handling to filter/throttle spammy messages from `fast_paths` and `hyper`.
+///
+/// On web: Just use console_log.
+pub fn setup() {
+    #[cfg(target_arch = "wasm32")]
+    {
+        console_log::init_with_level(log::Level::Info).unwrap();
     }
 
-    fn log(&self, record: &log::Record) {
-        let target = if record.target().len() > 0 {
-            record.target()
-        } else {
-            record.module_path().unwrap_or_default()
-        };
-
-        // Throttle these. Only triggered by the importer, by way of map_model
-        if target == "fast_paths::fast_graph_builder" {
-            let mut last = self.last_fast_paths_note.write().unwrap();
-            if last
-                .map(|start| elapsed_seconds(start) < 1.0)
-                .unwrap_or(false)
-            {
-                return;
-            }
-            *last = Some(Instant::now());
-        }
-
-        let contents = format!("{}", record.args());
-
-        // Silence these; they're expected on any map using simplified Chinese or kanji. Triggered
-        // by anything using widgetry.
-        if target == "usvg::convert::text::shaper" && contents.contains("Fallback") {
-            return;
-        }
-
-        // Silence byte counts from hyper.
-        if target == "hyper::proto::h1::io" {
-            return;
-        }
-
-        println!("[{}] {}: {}", record.level(), target, contents);
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        use env_logger::{Builder, Env};
+        Builder::from_env(Env::default().default_filter_or("info")).init();
     }
-
-    fn flush(&self) {}
 }

--- a/abstutil/src/logger.rs
+++ b/abstutil/src/logger.rs
@@ -1,7 +1,30 @@
-/// On native: intercept messages using the `log` crate and print them to STDOUT. Contains
-/// special handling to filter/throttle spammy messages from `fast_paths` and `hyper`.
+/// ## On native: uses env_log
 ///
-/// On web: Just use console_log.
+/// You can adjust the log level without recompiling with the RUST_LOG env variable.
+///
+///     RUST_LOG=debug cargo run --bin game
+///
+/// This can be done on a per lib basis:
+///
+///     RUST_LOG=my_lib=debug cargo run --bin game
+///
+/// Or a module-by-module basis:
+///
+///     RUST_LOG=my_lib::module=debug cargo run --bin game
+///
+/// You can mix and match:
+///
+///     # error logging by default, except the foo:bar module at debug level
+///     # and the entire baz crate at info level
+///     RUST_LOG=error,foo::bar=debug,baz=info cargo run --bin game
+///
+/// For some special cases, you might want to use regex matching by specifying a pattern with the
+/// "/":
+///
+///     # only log once every 10k
+///     RUST_LOG="fast_paths=debug/contracted node [0-9]+0000 " mike import_la
+///
+/// ## On web: uses console_log
 pub fn setup() {
     #[cfg(target_arch = "wasm32")]
     {

--- a/book/src/dev/README.md
+++ b/book/src/dev/README.md
@@ -79,6 +79,12 @@ King County GIS, and so on. If the mirrors are slow or the files vanish, you
 could fill out `data/config` and use the `updater` described above to grab the
 latest input.
 
+Building contraction hierarchies for pathfinding occurs in the --map stage. It
+can take a few minutes for larger maps. To view occasional progress updates,
+you can run the importer with 
+
+    RUST_LOG="fast_paths=debug/contracted node [0-9]+0000 "
+
 You can rerun specific stages of the importer:
 
 - If you're modifying the initial OSM data -> RawMap conversion in
@@ -91,7 +97,7 @@ You can rerun specific stages of the importer:
   `./import.sh --map downtown`.
 - By default, Seattle is assumed as the city. You have to specify otherwise:
   `./import.sh --city=los_angeles --map downtown_la`.
-
+ 
 You can also make the importer [import a new city](../howto/new_city.md).
 
 ## Understanding stuff
@@ -165,12 +171,42 @@ problems is useful. It's also fine to crash when initially constructing all of
 the renderable map objects, because this crash will consistently happen at
 startup-time and be noticed by somebody developing before a player gets to it.
 
-Prefer using `info!`, `warn!`, `error!`, etc from the `log` crate. Or if a
-`Timer` is available and you want to collect all notes together, `timer.note`.
-There are still many places calling `println!`, but we're trying to clean these
-up.
-
 See the [testing strategy](testing.md) page.
+
+## Logging
+
+Prefer using `info!`, `warn!`, `error!`, etc from the `log` crate rather than
+`println`. Or if a `Timer` is available and you want to collect all notes
+together, `timer.note`. There are still many places calling `println!`, but
+we're trying to clean these up.
+
+Adjust the log level without recompiling via the `RUST_LOG` env variable.
+
+    RUST_LOG=debug cargo run --bin game
+
+This can be done on a per lib basis:
+
+    RUST_LOG=my_lib=debug cargo run --bin game
+
+Or a module-by-module basis:
+
+    RUST_LOG=my_lib::module=debug cargo run --bin game
+
+You can mix and match:
+
+    # error logging by default, except the foo:bar module at debug level
+    # and the entire baz crate at info level
+    RUST_LOG=error,foo::bar=debug,baz=info cargo run --bin game
+
+For some special cases, you might want to use regex matching by specifying a
+pattern with the "/":
+
+    # only log once every 10k
+    RUST_LOG="fast_paths=debug/contracted node [0-9]+0000 " mike import_la
+
+See the [env_logger
+documentation](https://docs.rs/env_logger/0.8.2/env_logger/) for more usage
+examples.
 
 ## Profiling
 


### PR DESCRIPTION
It's nice to be able to adjust log levels without re-compiling/linking.

    RUST_LOG=debug cargo run --bin game

Note that this can be done on a per lib basis:

    RUST_LOG=my_lib=debug cargo run --bin game

a module-by-module basis:

    RUST_LOG=my_lib::module=debug cargo run --bin game

And you can mix and match:

    # error logging by default, except the foo:bar module at debug level
    # and the entire baz crate at info level
    RUST_LOG=error,foo::bar=debug,baz=info cargo run --bin game

This is the logging flow that I like - I often spend some significant
time implementing fairly verbose and structured logging while developing
a feature, only to delete it so as not to spam us in general. With this
approach I can leave more of the useful logging in and enable debug
level for just the modules I'm focused on.

Note that this loses the special-case throttling behavior for fastpaths
logging. Now that default level is info we're not seeing any of this output
anyway. But if we want it - an alternative to implementing our custom logger
could use env_loggers regex handling:

    # only log once every 10k
    RUST_LOG="fast_paths=debug/contracted node [0-9]+0000 " mike import_la

It's a bit unpleasant, but seems like it could work and uses standard stuff.

```
[2020-12-07T19:11:10Z DEBUG fast_paths::fast_graph_builder] contracted node 10000 / 31505, num edges fwd: 18009, num edges bwd: 19719
[2020-12-07T19:11:10Z DEBUG fast_paths::fast_graph_builder] contracted node 20000 / 31505, num edges fwd: 19381, num edges bwd: 21131
[2020-12-07T19:11:13Z DEBUG fast_paths::fast_graph_builder] contracted node 30000 / 31505, num edges fwd: 48427, num edges bwd: 50510                  
prepare pathfinding for bikes took 8.8064s                                                                                                             
prepare pathfinding for buses...
[2020-12-07T19:11:19Z DEBUG fast_paths::fast_graph_builder] contracted node 10000 / 31505, num edges fwd: 20422, num edges bwd: 21676
[2020-12-07T19:11:19Z DEBUG fast_paths::fast_graph_builder] contracted node 20000 / 31505, num edges fwd: 21710, num edges bwd: 22990
[2020-12-07T19:11:19Z DEBUG fast_paths::fast_graph_builder] contracted node 30000 / 31505, num edges fwd: 49486, num edges bwd: 50139                  
prepare pathfinding for buses took 0.7516s                                                                                                            
prepare pathfinding for trains...
[2020-12-07T19:11:19Z DEBUG fast_paths::fast_graph_builder] contracted node 10000 / 31505, num edges fwd: 0, num edges bwd: 2
```
Read more: https://docs.rs/env_logger/0.8.2/env_logger/