### PR TITLE
census areas import

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,9 +37,9 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b6a2d3371669ab3ca9797670853d61402b03d0b4b9ebf33d677dfa720203072"
+checksum = "7c0929d69e78dd9bf5408269919fcbcaeb2e35e5d43e5815517cdc6a8e11a423"
 dependencies = [
  "gimli",
 ]
@@ -58,9 +58,9 @@ checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
 name = "ahash"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6789e291be47ace86a60303502173d84af8327e3627ecf334356ee0f87a164c"
+checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
 
 [[package]]
 name = "aho-corasick"
@@ -123,9 +123,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1fd36ffbb1fb7c834eac128ea8d0e310c5aeb635548f9d58861e1308d46e71c"
+checksum = "2c0df63cb2955042487fad3aefd2c6e3ae7389ac5dc1beb28921de0b69f779d4"
 
 [[package]]
 name = "approx"
@@ -133,14 +133,8 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0e60b75072ecd4168020818c0107f2857bb6c4e64252d8d3983f6263b40a5c3"
 dependencies = [
- "num-traits 0.2.12",
+ "num-traits 0.2.14",
 ]
-
-[[package]]
-name = "arc-swap"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d25d88fd6b8041580a654f9d0c581a047baee2b3efee13275f2fc392fc75034"
 
 [[package]]
 name = "arrayvec"
@@ -185,9 +179,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.53"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707b586e0e2f247cbde68cdd2c3ce69ea7b7be43e1c5b426e37c9319c4b9838e"
+checksum = "ef5140344c85b01f9bbb4d4b7288a8aa4b3287ccef913a14bcc78a1063623598"
 dependencies = [
  "addr2line",
  "cfg-if 1.0.0",
@@ -279,9 +273,9 @@ dependencies = [
 
 [[package]]
 name = "built"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fa7899958f4aa3c40edc1b033d0e956763319e398924abb80a0034dda5bb198"
+checksum = "c8f1b029cb3929cb0c99780b0c10fe512f60be5438adf5f757e4afa1bc75a984"
 dependencies = [
  "cargo-lock",
  "chrono",
@@ -352,9 +346,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.61"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed67cbde08356238e75fc4656be4749481eeffb09e19f320a25237d5221c985d"
+checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
 
 [[package]]
 name = "cesu8"
@@ -368,7 +362,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4aedb84272dbe89af497cf81375129abda4fc0a9e7c5d317498c15cc30c0d27"
 dependencies = [
- "nom",
+ "nom 5.1.2",
 ]
 
 [[package]]
@@ -400,7 +394,7 @@ checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
 dependencies = [
  "libc",
  "num-integer",
- "num-traits 0.2.12",
+ "num-traits 0.2.14",
  "time",
  "winapi 0.3.9",
 ]
@@ -438,15 +432,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cloudabi"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4344512281c643ae7638bbabc3af17a11307803ec8f0fcad9fae512a8bf36467"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "cocoa"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -456,7 +441,7 @@ dependencies = [
  "block",
  "cocoa-foundation",
  "core-foundation 0.9.1",
- "core-graphics 0.22.1",
+ "core-graphics 0.22.2",
  "foreign-types",
  "libc",
  "objc",
@@ -536,7 +521,17 @@ checksum = "b9417a0c314565e2abffaece67e95a8cb51f9238cd39f3764d9dfdf09e72b20c"
 dependencies = [
  "bytes",
  "memchr",
- "pin-project-lite",
+ "pin-project-lite 0.1.11",
+]
+
+[[package]]
+name = "console_error_panic_hook"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8d976903543e0c48546a91908f21588a680a8c8f984df9a5d69feccb2b2a211"
+dependencies = [
+ "cfg-if 0.1.10",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -552,7 +547,6 @@ dependencies = [
 [[package]]
 name = "contour"
 version = "0.1.0"
-source = "git+https://github.com/dabreegster/contour-rs#5cdc08c3c566cb15339f090cbfc9f22fe19a0092"
 dependencies = [
  "geojson",
  "lazy_static",
@@ -637,9 +631,9 @@ dependencies = [
 
 [[package]]
 name = "core-graphics"
-version = "0.22.1"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc239bba52bab96649441699533a68de294a101533b0270b2d65aa402b29a7f9"
+checksum = "269f35f69b542b80e736a20a89a05215c0ce80c2c03c514abb2e318b78379d86"
 dependencies = [
  "bitflags",
  "core-foundation 0.9.1",
@@ -728,9 +722,9 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4666154fd004af3fd6f1da2e81a96fd5a81927fe8ddb6ecc79e2aa6e138b54"
+checksum = "f9d58633299b24b515ac72a3f869f8b91306a3cec616a602843a383acd6f9e97"
 dependencies = [
  "bstr",
  "csv-core",
@@ -760,9 +754,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
+checksum = "15d658711a12632b5574c8d5b3fc5d2f0d2f87b9fbf9237ee0f759b88bb6bdec"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -770,23 +764,23 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
+checksum = "16d3514d243331d8acde56bfcf45d0147aabbda853c2f49dce081ea85f9a7220"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.9.3",
+ "strsim 0.10.0",
  "syn",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
+checksum = "44f63c369ef0c17ad17585d31d5f2bf10dece2710bf0766e01db57a6f9849a2e"
 dependencies = [
  "darling_core",
  "quote",
@@ -845,12 +839,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
-name = "dtoa"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
-
-[[package]]
 name = "earcutr"
 version = "0.1.0"
 source = "git+https://github.com/donbright/earcutr#aaa18bfdfe581db26bb9869aec170329b4e14f4c"
@@ -863,11 +851,11 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.24"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a51b8cf747471cb9499b6d59e59b0444f4c90eba8968c4e44874e92b5b64ace2"
+checksum = "801bbab217d7f79c0062f4f7205b5d4427c6d1a7bd7aafdd1475f7c59d62b283"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -889,7 +877,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "959a80a2062fedd66ed41d99736212de987b3a8c83a4c2cef243968075256bd1"
 dependencies = [
  "enumset_derive",
- "num-traits 0.2.12",
+ "num-traits 0.2.14",
  "serde",
 ]
 
@@ -934,7 +922,7 @@ version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5337024b8293bdce5265dc9570ef6e608a34bfacbbc87fe1a5dcb5f1dac2f4e2"
 dependencies = [
- "num-traits 0.2.12",
+ "num-traits 0.2.14",
 ]
 
 [[package]]
@@ -1054,7 +1042,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fc612c5837986b7104a87a0df74a5460931f1c5274be12f8d0f40aa2f30d632"
 dependencies = [
- "num-traits 0.2.12",
+ "num-traits 0.2.14",
 ]
 
 [[package]]
@@ -1203,7 +1191,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project 1.0.1",
+ "pin-project 1.0.2",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -1255,7 +1243,7 @@ dependencies = [
  "gdal-sys",
  "geo-types 0.4.3",
  "libc",
- "num-traits 0.2.12",
+ "num-traits 0.2.14",
 ]
 
 [[package]]
@@ -1302,9 +1290,9 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "139007e3210dfc1d010e166e779059be5e0f31967a71f3edae97116aefb74450"
 dependencies = [
- "geo-types 0.6.1",
+ "geo-types 0.6.2",
  "geographiclib-rs",
- "num-traits 0.2.12",
+ "num-traits 0.2.14",
  "rstar",
 ]
 
@@ -1314,9 +1302,22 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1488b04daa30b25f0beb19c2110fa507484ac8c2b8cad83d548cdda857f7f7a"
 dependencies = [
- "geo-types 0.6.1",
+ "geo-types 0.6.2",
  "geographiclib-rs",
- "num-traits 0.2.12",
+ "num-traits 0.2.14",
+ "robust 0.2.2",
+ "rstar",
+]
+
+[[package]]
+name = "geo"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d893ed768bba4866e3e16b756c96ed7ef23ca270eac190000fc4e40c5d733467"
+dependencies = [
+ "geo-types 0.6.2",
+ "geographiclib-rs",
+ "num-traits 0.2.14",
  "robust 0.2.2",
  "rstar",
 ]
@@ -1328,8 +1329,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4b68ff17c819296610e9eee41bdf5eb37f71b09870a95f0086e07d8fcc1f45b"
 dependencies = [
  "float_next_after",
- "geo-types 0.6.1",
- "num-traits 0.2.12",
+ "geo-types 0.6.2",
+ "num-traits 0.2.14",
  "robust 0.1.2",
 ]
 
@@ -1339,17 +1340,17 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "866e8f6dbd2218b05ea8a25daa1bfac32b0515fe7e0a37cb6a7b9ed0ed82a07e"
 dependencies = [
- "num-traits 0.2.12",
+ "num-traits 0.2.14",
 ]
 
 [[package]]
 name = "geo-types"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0e91cb835a9b740d38fc45efdf6392bedd20101f1e7419e464cd54f61373a1"
+checksum = "7583925a1fdb2b450c461fe0878ba6e99a8f1332b2bc72fb1383fd25b2f13bf2"
 dependencies = [
  "approx",
- "num-traits 0.2.12",
+ "num-traits 0.2.14",
  "rstar",
 ]
 
@@ -1364,12 +1365,10 @@ dependencies = [
 
 [[package]]
 name = "geojson"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df48768ce77d725b32f692a4653d4529a24e2882c8740bcaa03a0f788c853af6"
+version = "0.21.0"
 dependencies = [
- "geo-types 0.6.1",
- "num-traits 0.2.12",
+ "geo-types 0.6.2",
+ "num-traits 0.2.14",
  "serde",
  "serde_json",
  "thiserror",
@@ -1405,9 +1404,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
+checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 
 [[package]]
 name = "gl_generator"
@@ -1656,7 +1655,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project 1.0.1",
+ "pin-project 1.0.2",
  "socket2",
  "tokio",
  "tower-service",
@@ -1710,16 +1709,16 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.23.11"
+version = "0.23.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f0a8345b33b082aedec2f4d7d4a926b845cee184cbe78b703413066564431b"
+checksum = "7ce04077ead78e39ae8610ad26216aed811996b043d47beed5090db674f9e9b5"
 dependencies = [
  "bytemuck",
  "byteorder",
  "color_quant",
  "num-iter",
  "num-rational",
- "num-traits 0.2.12",
+ "num-traits 0.2.14",
  "png",
 ]
 
@@ -1802,9 +1801,9 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb1fc4429a33e1f80d41dc9fea4d108a88bec1de8053878898ae448a0b52f613"
+checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -1878,9 +1877,9 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "js-sys"
-version = "0.3.45"
+version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca059e81d9486668f12d455a4ea6daa600bd408134cd17e3d3fb5a32d1f016f8"
+checksum = "cf3d7383929f7c9c7c2d0fa596f325832df98c3704f2c60553080f7127a58175"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1941,14 +1940,14 @@ checksum = "be42bea7971f4ba0ea1e215730c29bc1ff9bd2a9c10013912f42a8dcf8d77c0d"
 dependencies = [
  "byteorder",
  "ogg",
- "tinyvec",
+ "tinyvec 0.3.4",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
+checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
 
 [[package]]
 name = "libflate"
@@ -1964,9 +1963,9 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1090080fe06ec2648d0da3881d9453d97e71a45f00eb179af7fdd7e3f686fdb0"
+checksum = "e9367bdfa836b7e3cf895867f7a570283444da90562980ec2263d6e1569b16bc"
 dependencies = [
  "cfg-if 1.0.0",
  "winapi 0.3.9",
@@ -1986,9 +1985,9 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 
 [[package]]
 name = "lock_api"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28247cc5a5be2f05fbcd76dd0cf2c7d3b5400cb978a28042abcd4fa0b3f8261c"
+checksum = "dd96ffd135b2fd7b973ac026d28085defbe8983df057ced3eb4f2130b0831312"
 dependencies = [
  "scopeguard",
 ]
@@ -2045,7 +2044,7 @@ checksum = "6ce4e12203c428a58200b8cf1c0a3aad1cda907008ea11310bb3729593e5f933"
 dependencies = [
  "arrayvec",
  "euclid",
- "num-traits 0.2.12",
+ "num-traits 0.2.14",
 ]
 
 [[package]]
@@ -2168,19 +2167,9 @@ checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
-version = "2.3.3"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
-
-[[package]]
-name = "memmap"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
-dependencies = [
- "libc",
- "winapi 0.3.9",
-]
+checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "memmap2"
@@ -2228,9 +2217,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.22"
+version = "0.6.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430"
+checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
 dependencies = [
  "cfg-if 0.1.10",
  "fuchsia-zircon",
@@ -2239,7 +2228,7 @@ dependencies = [
  "kernel32-sys",
  "libc",
  "log",
- "miow 0.2.1",
+ "miow 0.2.2",
  "net2",
  "slab",
  "winapi 0.2.8",
@@ -2265,7 +2254,7 @@ checksum = "0840c1c50fd55e521b247f949c241c9997709f23bd7f023b9762cd561e935656"
 dependencies = [
  "log",
  "mio",
- "miow 0.3.5",
+ "miow 0.3.6",
  "winapi 0.3.9",
 ]
 
@@ -2282,9 +2271,9 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
+checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
 dependencies = [
  "kernel32-sys",
  "net2",
@@ -2294,9 +2283,9 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07b88fb9795d4d36d62a012dfbf49a8f5cf12751f36d31a9dbe66d528e58979e"
+checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
 dependencies = [
  "socket2",
  "winapi 0.3.9",
@@ -2358,9 +2347,9 @@ checksum = "c44922cb3dbb1c70b5e5f443d63b64363a898564d739ba5198e3a9138442868d"
 
 [[package]]
 name = "net2"
-version = "0.2.35"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ebc3ec692ed7c9a255596c67808dee269f64655d8baf7b4f0638e51ba1d6853"
+checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
@@ -2403,6 +2392,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88034cfd6b4a0d54dd14f4a507eceee36c0b70e5a02236c4e4df571102be17f0"
+dependencies = [
+ "memchr",
+ "version_check",
+]
+
+[[package]]
 name = "num-derive"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2415,34 +2414,34 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg",
- "num-traits 0.2.12",
+ "num-traits 0.2.14",
 ]
 
 [[package]]
 name = "num-iter"
-version = "0.1.41"
+version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6e6b7c748f995c4c29c5f5ae0248536e04a5739927c74ec0fa564805094b9f"
+checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
 dependencies = [
  "autocfg",
  "num-integer",
- "num-traits 0.2.12",
+ "num-traits 0.2.14",
 ]
 
 [[package]]
 name = "num-rational"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5b4d7360f362cfb50dde8143501e6940b22f644be75a4cc90b2d81968908138"
+checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
 dependencies = [
  "autocfg",
  "num-integer",
- "num-traits 0.2.12",
+ "num-traits 0.2.14",
 ]
 
 [[package]]
@@ -2451,14 +2450,14 @@ version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
 dependencies = [
- "num-traits 0.2.12",
+ "num-traits 0.2.14",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
  "libm 0.2.1",
@@ -2513,9 +2512,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37fd5004feb2ce328a52b0b3d01dbf4ffff72583493900ed15f22d4111c51693"
+checksum = "8d3b63360ec3cb337817c2dbd47ab4a0f170d285d8e5a2064600f3def1402397"
 
 [[package]]
 name = "oboe"
@@ -2527,7 +2526,7 @@ dependencies = [
  "ndk",
  "ndk-glue",
  "num-derive",
- "num-traits 0.2.12",
+ "num-traits 0.2.14",
  "oboe-sys",
 ]
 
@@ -2551,17 +2550,17 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.4.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "260e51e7efe62b592207e9e13a68e43692a7a279171d6ba57abd208bf23645ad"
+checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
 
 [[package]]
 name = "ordered-float"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fe9037165d7023b1228bc4ae9a2fa1a2b0095eca6c2998c624723dfd01314a5"
+checksum = "dacdec97876ef3ede8c50efc429220641a0b11ba0048b4b0c357bccbc47c5204"
 dependencies = [
- "num-traits 0.2.12",
+ "num-traits 0.2.14",
  "serde",
 ]
 
@@ -2596,9 +2595,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4893845fa2ca272e647da5d0e46660a314ead9c2fdd9a883aabc32e481a8733"
+checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
 dependencies = [
  "instant",
  "lock_api",
@@ -2607,12 +2606,11 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
+checksum = "d7c6d9b8427445284a09c55be860a15855ab580a417ccad9da88f5a06787ced0"
 dependencies = [
- "cfg-if 0.1.10",
- "cloudabi",
+ "cfg-if 1.0.0",
  "instant",
  "libc",
  "redox_syscall",
@@ -2695,11 +2693,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee41d838744f60d959d7074e3afb6b35c7456d0f61cad38a24e35e6553f73841"
+checksum = "9ccc2237c2c489783abd8c4c80e5450fc0e98644555b1364da68cc29aa151ca7"
 dependencies = [
- "pin-project-internal 1.0.1",
+ "pin-project-internal 1.0.2",
 ]
 
 [[package]]
@@ -2715,9 +2713,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a4ffa594b66bff340084d4081df649a7dc049ac8d7fc458d8e628bfbbb2f86"
+checksum = "f8e8d2bf0b23038a4424865103a4df472855692821aab4e4f5c3312d461d9e5f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2729,6 +2727,12 @@ name = "pin-project-lite"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b063f57ec186e6140e2b8b6921e5f1bd89c7356dda5b33acc5401203ca6131c"
 
 [[package]]
 name = "pin-utils"
@@ -2744,9 +2748,9 @@ checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "png"
-version = "0.16.7"
+version = "0.16.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfe7f9f1c730833200b134370e1d5098964231af8450bce9b78ee3ab5278b970"
+checksum = "3c3287920cb847dee3de33d301c463fba14dda99db24214ddf93f83d3021f4c6"
 dependencies = [
  "bitflags",
  "crc32fast",
@@ -2763,7 +2767,7 @@ dependencies = [
  "cbindgen",
  "geo 0.14.2",
  "libc",
- "num-traits 0.2.12",
+ "num-traits 0.2.14",
  "thiserror",
 ]
 
@@ -2772,8 +2776,8 @@ name = "popdat"
 version = "0.1.0"
 dependencies = [
  "abstutil",
- "geo 0.15.0",
- "geo-types 0.6.1",
+ "geo 0.16.0",
+ "geo-types 0.6.2",
  "geojson",
  "geom",
  "log",
@@ -2786,15 +2790,15 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20"
+checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "priority-queue"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51e18113edd707f361302ce1229da05854e786d78f03e1eddae3f1ffb8da663"
+checksum = "8a6f1a563bbd2d93b9c5a2e4b3af6f0fc728bca22653f31cb515ea932604ea57"
 dependencies = [
  "autocfg",
  "indexmap",
@@ -2886,7 +2890,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9e9532ada3929fb8b2e9dbe28d1e06c9b2cc65813f074fcb6bd5fbefeff9d56"
 dependencies = [
- "num-traits 0.2.12",
+ "num-traits 0.2.14",
  "rand",
 ]
 
@@ -2976,11 +2980,11 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9eaa17ac5d7b838b7503d118fa16ad88f440498bf9ffe5424e621f93190d61e"
+checksum = "fb15d6255c792356a0f578d8a645c677904dc02e862bebe2ecc18e0c01b9a0ce"
 dependencies = [
- "base64 0.12.3",
+ "base64 0.13.0",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -2996,7 +3000,7 @@ dependencies = [
  "mime",
  "mime_guess",
  "percent-encoding 2.1.0",
- "pin-project-lite",
+ "pin-project-lite 0.2.0",
  "rustls 0.18.1",
  "serde",
  "serde_urlencoded",
@@ -3005,16 +3009,17 @@ dependencies = [
  "url 2.2.0",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-bindgen-test",
  "web-sys",
- "webpki-roots 0.19.0",
+ "webpki-roots 0.20.0",
  "winreg",
 ]
 
 [[package]]
 name = "ring"
-version = "0.16.15"
+version = "0.16.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "952cd6b98c85bbc30efa1ba5783b8abf12fec8b3287ffa52605b9432313e34e4"
+checksum = "024a1e66fea74c66c66624ee5622a7ff0e4b73a13b4f5c326ddb50c708944226"
 dependencies = [
  "cc",
  "libc",
@@ -3069,7 +3074,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9a31b6d446dcdf5b1c9677068e147bd86ce5efcdbce4741f0b55d747381924"
 dependencies = [
  "heapless",
- "num-traits 0.2.12",
+ "num-traits 0.2.14",
  "pdqselect",
  "smallvec",
 ]
@@ -3210,18 +3215,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.117"
+version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a"
+checksum = "06c64263859d87aa2eb554587e2d23183398d617427327cf2b3d0ed8c69e4800"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.117"
+version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e"
+checksum = "c84d3526699cd55261af4b941e4e725444df67aa4f9e6a3564f18030d12672df"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3230,9 +3235,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.59"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcac07dbffa1c65e7f816ab9eba78eb142c6d44410f4eeba1e26e4f5dfa56b95"
+checksum = "1500e84d27fe482ed1dc791a56eddc2f230046a040fa908c08bda1d9fb615779"
 dependencies = [
  "itoa",
  "ryu",
@@ -3241,14 +3246,14 @@ dependencies = [
 
 [[package]]
 name = "serde_urlencoded"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
+checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
 dependencies = [
- "dtoa",
+ "form_urlencoded",
  "itoa",
+ "ryu",
  "serde",
- "url 2.2.0",
 ]
 
 [[package]]
@@ -3273,16 +3278,15 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd5ac56c121948b4879bba9e519852c211bcdd8f014efff766441deff0b91bdb"
 dependencies = [
- "num-traits 0.2.12",
+ "num-traits 0.2.14",
 ]
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e12110bc539e657a646068aaf5eb5b63af9d0c1f7b29c97113fad80e15f035"
+checksum = "ce32ea0c6c56d5eacaeb814fbed9960547021d3edd010ded1425f180536b20ab"
 dependencies = [
- "arc-swap",
  "libc",
 ]
 
@@ -3334,15 +3338,15 @@ checksum = "c46a3482db8f247956e464d783693ece164ca056e6e67563ee5505bdb86452cd"
 
 [[package]]
 name = "smallvec"
-version = "1.4.2"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
+checksum = "ae524f056d7d770e174287294f562e95044c68e88dec909a00d2094805db9d75"
 
 [[package]]
 name = "smithay-client-toolkit"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ec5c077def8af49f9b5aeeb5fcf8079c638c6615c3a8f9305e2dea601de57f7"
+checksum = "86d1d080d3dc98d68251d073b231dfaa200fdc2ddebc435b313ad937d0ae9dfd"
 dependencies = [
  "andrew",
  "bitflags",
@@ -3351,7 +3355,7 @@ dependencies = [
  "dlib",
  "lazy_static",
  "log",
- "memmap",
+ "memmap2",
  "nix 0.18.0",
  "wayland-client",
  "wayland-cursor",
@@ -3360,11 +3364,11 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.3.15"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1fa70dc5c8104ec096f4fe7ede7a221d35ae13dcd19ba1ad9a81d2cab9a1c44"
+checksum = "2c29947abdee2a218277abeca306f25789c938e500ea5a9d4b12a5a504466902"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
  "winapi 0.3.9",
@@ -3406,9 +3410,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "strsim"
-version = "0.9.3"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "svg_face"
@@ -3431,9 +3435,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.48"
+version = "1.0.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc371affeffc477f42a221a1e4297aedcea33d47d19b61455588bd9d8f6b19ac"
+checksum = "9a2af957a63d6bd42255c359c93d9bfdb97076bd3b820897ce55ffbfbf107f44"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3528,18 +3532,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "318234ffa22e0920fe9a40d7b8369b5f649d490980cf7aadcf1eb91594869b42"
+checksum = "0e9ae34b84616eedaaf1e9dd6026dbe00dcafa92aa0c8077cb69df1fcfe5e53e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cae2447b6282786c3493999f40a9be2a6ad20cb8bd268b0a0dbf5a065535c0ab"
+checksum = "9ba20f23e85b10754cd195504aebf6a27e2e6cbe28c17778a0c930724628dd56"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3573,10 +3577,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "238ce071d267c5710f9d31451efec16c5ee22de34df17cc05e56cbc92e967117"
 
 [[package]]
-name = "tokio"
-version = "0.2.22"
+name = "tinyvec"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d34ca54d84bf2b5b4d7d31e901a8464f7b60ac145a284fba25ceb801f2ddccd"
+checksum = "ccf8dbc19eb42fba10e8feaaec282fb50e2c14b2726d6301dbfeed0f73306a6f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
+name = "tokio"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "099837d3464c16a808060bb3f02263b412f6fafcb5d01c533d309985fbeebe48"
 dependencies = [
  "bytes",
  "fnv",
@@ -3589,7 +3608,7 @@ dependencies = [
  "mio-named-pipes",
  "mio-uds",
  "num_cpus",
- "pin-project-lite",
+ "pin-project-lite 0.1.11",
  "signal-hook-registry",
  "slab",
  "tokio-macros",
@@ -3629,7 +3648,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite",
+ "pin-project-lite 0.1.11",
  "tokio",
 ]
 
@@ -3650,13 +3669,13 @@ checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
 
 [[package]]
 name = "tracing"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
+checksum = "9f47026cdc4080c07e49b37087de021820269d996f581aac150ef9e5583eefe3"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "log",
- "pin-project-lite",
+ "pin-project-lite 0.2.0",
  "tracing-core",
 ]
 
@@ -3705,9 +3724,9 @@ checksum = "3e5d7cd7ab3e47dda6e56542f4bbf3824c15234958c6e1bd6aaa347e93499fdc"
 
 [[package]]
 name = "ttf-parser"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d973cfa0e6124166b50a1105a67c85de40bbc625082f35c0f56f84cb1fb0a827"
+checksum = "7622061403fd00f0820df288e5a580e87d3ce15a1c4313c59fd1ffb77129903f"
 
 [[package]]
 name = "ttf-parser"
@@ -3759,11 +3778,11 @@ checksum = "7f9af028e052a610d99e066b33304625dea9613170a2563314490a4e6ec5cf7f"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.13"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb19cf769fa8c6a80a162df694621ebeb4dafb606470b2b2fce0be40a98a977"
+checksum = "a13e63ab62dbe32aeee58d1c5408d35c36c392bba5d9d3142287219721afe606"
 dependencies = [
- "tinyvec",
+ "tinyvec 1.1.0",
 ]
 
 [[package]]
@@ -3937,11 +3956,11 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac64ead5ea5f05873d7c12b545865ca2b8d28adfc50a49b84770a3a97265d42"
+checksum = "3cd364751395ca0f68cafb17666eee36b63077fb5ecd972bbcd74c90c4bf736e"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "serde",
  "serde_json",
  "wasm-bindgen-macro",
@@ -3949,9 +3968,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f22b422e2a757c35a73774860af8e112bff612ce6cb604224e8e47641a9e4f68"
+checksum = "1114f89ab1f4106e5b55e688b828c0ab0ea593a1ea7c094b141b14cbaaec2d62"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -3964,11 +3983,11 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7866cab0aa01de1edf8b5d7936938a7e397ee50ce24119aef3e1eaa3b6171da"
+checksum = "1fe9756085a84584ee9457a002b7cdfe0bfff169f45d2591d8be1345a6780e35"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -3976,9 +3995,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b13312a745c08c469f0b292dd2fcd6411dba5f7160f593da6ef69b64e407038"
+checksum = "7a6ac8995ead1f084a8dea1e65f194d0973800c7f571f6edd70adf06ecf77084"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3986,9 +4005,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
+checksum = "b5a48c72f299d80557c7c62e37e7225369ecc0c963964059509fbafe917c7549"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3999,15 +4018,39 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d649a3145108d7d3fbcde896a468d1bd636791823c9921135218ad89be08307"
+checksum = "7e7811dd7f9398f14cc76efd356f98f03aa30419dea46aa810d71e819fc97158"
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0355fa0c1f9b792a09b6dcb6a8be24d51e71e6d74972f9eb4a44c4c004d24a25"
+dependencies = [
+ "console_error_panic_hook",
+ "js-sys",
+ "scoped-tls",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27e07b46b98024c2ba2f9e83a10c2ef0515f057f2da299c1762a2017de80438b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "wayland-client"
-version = "0.28.1"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80c54f9b90b2c044784f91fe22c5619a8a9c681db38492f2fd78ff968cf3f184"
+checksum = "222b227f47871e47d657c1c5e5360b4af9a877aa9c892716787be1c192c78c42"
 dependencies = [
  "bitflags",
  "downcast-rs",
@@ -4021,9 +4064,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-commons"
-version = "0.28.1"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7602d75560fe6f02cac723609cce658042fe60541b5107999818d29d4dab7cfa"
+checksum = "230b3ffeda101f877ff8ecb8573f5d26e7beb345b197807c4df34ec06879a3e6"
 dependencies = [
  "nix 0.18.0",
  "once_cell",
@@ -4033,9 +4076,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-cursor"
-version = "0.28.1"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0446b959c5b5b4b2c11f63112fc7cbeb50ecd9f2c340d2b0ea632875685baf04"
+checksum = "0aad1b4301cdccfb5f64056a4736e8155a5f4734bac41fdbca80b1fdbe1ab3e1"
 dependencies = [
  "nix 0.18.0",
  "wayland-client",
@@ -4044,9 +4087,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-egl"
-version = "0.28.1"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ca6190c84bcdc58beccc619bf4866709db32d653255e89da38867f97f90d61"
+checksum = "308f3ec651a099d1aa4e60625c81f67b4264d72d1b524bc7fb1a7675f7c050b4"
 dependencies = [
  "wayland-client",
  "wayland-sys",
@@ -4054,9 +4097,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.28.1"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d419585bbdb150fb541579cff205c6095a86cd874530e41838d1f18a9569a08"
+checksum = "dc16a9db803cae58b45f9a84a6cf364434cc49a95c8b1ef98ffeb467d228bdc9"
 dependencies = [
  "bitflags",
  "wayland-client",
@@ -4066,9 +4109,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.28.1"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cc091af4b05a435312f7cefe3a26824d2017966a58362ca913f72c3d68e5e2"
+checksum = "5ee5bd43a1d746efc486515fec561e47205f328b74802b959f10f5500f7e56cc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4077,9 +4120,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-sys"
-version = "0.28.1"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5640f53d1fe6eaaa2e77b9ff015fe9a556173ce8388607f941aecfd9b05c73e"
+checksum = "0814adbecc7ea97869971e1d1c1b657e31863dda6fd768f119ad3dc408a01e58"
 dependencies = [
  "dlib",
  "lazy_static",
@@ -4088,9 +4131,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.45"
+version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bf6ef87ad7ae8008e15a355ce696bed26012b7caa21605188cfd8214ab51e2d"
+checksum = "222b1ef9334f92a21d3fb53dc3fd80f30836959a90f9274a626d7e06315ba3c3"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4109,9 +4152,9 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.21.3"
+version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab146130f5f790d45f82aeeb09e55a256573373ec64409fc19a6fb82fb1032ae"
+checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
 dependencies = [
  "ring",
  "untrusted",
@@ -4128,9 +4171,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8eff4b7516a57307f9349c64bf34caa34b940b66fed4b2fb3136cb7386e5739"
+checksum = "0f20dea7535251981a9670857150d571846545088359b28e4951d350bdaf179f"
 dependencies = [
  "webpki",
 ]
@@ -4158,7 +4201,7 @@ dependencies = [
  "lyon",
  "serde",
  "stretch",
- "ttf-parser 0.8.2",
+ "ttf-parser 0.8.3",
  "usvg",
  "wasm-bindgen",
  "web-sys",
@@ -4231,7 +4274,7 @@ dependencies = [
  "bitflags",
  "cocoa 0.24.0",
  "core-foundation 0.9.1",
- "core-graphics 0.22.1",
+ "core-graphics 0.22.2",
  "core-video-sys",
  "dispatch",
  "instant",
@@ -4297,11 +4340,11 @@ dependencies = [
 
 [[package]]
 name = "xcursor"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3a481cfdefd35e1c50073ae33a8000d695c98039544659f5dc5dd71311b0d01"
+checksum = "3a9a231574ae78801646617cefd13bfe94be907c0e4fa979cfd8b770aa3c5d08"
 dependencies = [
- "nom",
+ "nom 6.0.1",
 ]
 
 [[package]]
@@ -4324,9 +4367,9 @@ checksum = "114ba2b24d2167ef6d67d7d04c8cc86522b87f490025f39f0303b7db5bf5e3d8"
 
 [[package]]
 name = "xmltree"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f76badaccb0313f1f0cb6582c2973f2dd0620f9652eb7a5ff6ced0cc3ac922b3"
+checksum = "d046fd42d4137234742eae0d05b4fb6fbdda9aed7c78e523ae890fd87c7e11dd"
 dependencies = [
  "xml-rs",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1368,6 +1368,7 @@ version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df48768ce77d725b32f692a4653d4529a24e2882c8740bcaa03a0f788c853af6"
 dependencies = [
+ "geo-types 0.6.1",
  "num-traits 0.2.12",
  "serde",
  "serde_json",
@@ -2771,11 +2772,15 @@ name = "popdat"
 version = "0.1.0"
 dependencies = [
  "abstutil",
+ "geo 0.15.0",
+ "geo-types 0.6.1",
+ "geojson",
  "geom",
  "log",
  "map_model",
  "rand",
  "rand_xorshift",
+ "serde_json",
  "sim",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2779,6 +2779,7 @@ name = "popdat"
 version = "0.1.0"
 dependencies = [
  "abstutil",
+ "anyhow",
  "geo 0.16.0",
  "geojson",
  "geom",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -457,7 +457,7 @@ dependencies = [
  "block",
  "cocoa-foundation",
  "core-foundation 0.9.1",
- "core-graphics 0.22.1",
+ "core-graphics 0.22.2",
  "foreign-types",
  "libc",
  "objc",
@@ -546,7 +546,9 @@ dependencies = [
 
 [[package]]
 name = "contour"
-version = "0.1.0"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "059e75b593068b026cb434c0140dd6a4557c1824ee029d5d3414fc77ecbe8494"
 dependencies = [
  "geojson",
  "lazy_static",
@@ -1366,6 +1368,7 @@ dependencies = [
 [[package]]
 name = "geojson"
 version = "0.21.0"
+source = "git+https://github.com/georust/geojson?branch=mkirk/try_from#ac0429218756af96c379a8701383ef4d36d78779"
 dependencies = [
  "geo-types 0.6.2",
  "num-traits 0.2.14",
@@ -2003,9 +2006,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be716eb6878ca2263eb5d00a781aa13264a794f519fe6af4fbb2668b2d5441c0"
+checksum = "3abe07af102235a56ac9a6dd904aab1e05483e2e8afdfffec3598be55b1b7606"
 dependencies = [
  "hashbrown",
 ]
@@ -2777,7 +2780,6 @@ version = "0.1.0"
 dependencies = [
  "abstutil",
  "geo 0.16.0",
- "geo-types 0.6.2",
  "geojson",
  "geom",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,7 @@ members = [
 # update dependencies often).
 [profile.dev.package."*"]
 opt-level = 3
+
+[patch.crates-io]
+geojson = { path = "../../georust/geojson" }
+contour = { path = "../contour-rs" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,5 +33,4 @@ members = [
 opt-level = 3
 
 [patch.crates-io]
-geojson = { path = "../../georust/geojson" }
-contour = { path = "../contour-rs" }
+geojson = { git = "https://github.com/georust/geojson", branch = "mkirk/try_from" }

--- a/fifteen_min/Cargo.toml
+++ b/fifteen_min/Cargo.toml
@@ -9,7 +9,7 @@ default = ["map_gui/native", "widgetry/native-backend"]
 
 [dependencies]
 abstutil = { path = "../abstutil" }
-contour = "0.1.0"
+contour = "0.3.0"
 geojson = "0.21.0"
 geom = { path = "../geom" }
 log = "0.4"

--- a/fifteen_min/Cargo.toml
+++ b/fifteen_min/Cargo.toml
@@ -9,8 +9,8 @@ default = ["map_gui/native", "widgetry/native-backend"]
 
 [dependencies]
 abstutil = { path = "../abstutil" }
-contour = { git = "https://github.com/dabreegster/contour-rs" }
-geojson = "0.20.1"
+contour = "0.1.0"
+geojson = "0.21.0"
 geom = { path = "../geom" }
 log = "0.4"
 map_gui = { path = "../map_gui" }

--- a/game/Cargo.toml
+++ b/game/Cargo.toml
@@ -21,10 +21,10 @@ built = { version = "0.4.3", optional = true, features=["chrono"] }
 chrono = "0.4.15"
 collisions = { path = "../collisions" }
 colorous = "1.0.3"
-contour = { git = "https://github.com/dabreegster/contour-rs" }
+contour = "0.1.0"
 downcast-rs = "1.2.0"
 enumset = "1.0.1"
-geojson = "0.20.1"
+geojson = "0.21.0"
 geom = { path = "../geom" }
 instant = "0.1.7"
 kml = { path = "../kml" }

--- a/game/Cargo.toml
+++ b/game/Cargo.toml
@@ -21,7 +21,7 @@ built = { version = "0.4.3", optional = true, features=["chrono"] }
 chrono = "0.4.15"
 collisions = { path = "../collisions" }
 colorous = "1.0.3"
-contour = "0.1.0"
+contour = "0.3.0"
 downcast-rs = "1.2.0"
 enumset = "1.0.1"
 geojson = "0.21.0"

--- a/game/src/sandbox/gameplay/census.rs
+++ b/game/src/sandbox/gameplay/census.rs
@@ -44,7 +44,8 @@ impl State<App> for CensusGenerator {
                         config,
                         &app.primary.map,
                         &mut app.primary.current_flags.sim_flags.make_rng(),
-                    );
+                    )
+                    .expect("failed to generate scenario");
                     // TODO Do something with it -- save it, launch it in sandboxmode, display some
                     // stats about it?
                     return Transition::Pop;

--- a/geom/Cargo.toml
+++ b/geom/Cargo.toml
@@ -10,7 +10,7 @@ abstutil = { path = "../abstutil" }
 earcutr = { git = "https://github.com/donbright/earcutr" }
 geo = "0.15.0"
 geo-booleanop = "= 0.3.2"
-geojson = "0.20.1"
+geojson = "0.21.0"
 histogram = "0.6.9"
 instant = "0.1.7"
 ordered-float = { version = "2.0.0", features=["serde"] }

--- a/geom/src/polygon.rs
+++ b/geom/src/polygon.rs
@@ -478,31 +478,30 @@ fn to_geo(pts: &Vec<Pt2D>) -> geo::Polygon<f64> {
 
 impl From<geo::Polygon<f64>> for Polygon {
     fn from(poly: geo::Polygon<f64>) -> Self {
-        Polygon::buggy_new(
-            poly.into_inner()
-                .0
-                .into_points()
-                .into_iter()
-                .map(|pt| Pt2D::new(pt.x(), pt.y()))
-                .collect(),
+        let (exterior, interiors) = poly.into_inner();
+        Polygon::with_holes(
+            Ring::from(exterior),
+            interiors.into_iter().map(Ring::from).collect(),
         )
     }
 }
 
 impl From<Polygon> for geo::Polygon<f64> {
     fn from(poly: Polygon) -> Self {
-        let exterior_coords = poly
-            .points
-            .into_iter()
-            .map(geo::Coordinate::from)
-            .collect::<Vec<_>>();
-        let exterior = geo::LineString(exterior_coords);
-
-        let interiors: Vec<geo::LineString<f64>> = poly
-            .rings
-            .map(|rings| rings.into_iter().map(geo::LineString::from).collect())
-            .unwrap_or(Vec::new());
-        Self::new(exterior, interiors)
+        if let Some(mut rings) = poly.rings {
+            let exterior = rings.pop().expect("expected poly.rings[0] to be exterior");
+            let interiors: Vec<geo::LineString<f64>> =
+                rings.into_iter().map(geo::LineString::from).collect();
+            Self::new(exterior.into(), interiors)
+        } else {
+            let exterior_coords = poly
+                .points
+                .into_iter()
+                .map(geo::Coordinate::from)
+                .collect::<Vec<_>>();
+            let exterior = geo::LineString(exterior_coords);
+            Self::new(exterior, Vec::new())
+        }
     }
 }
 

--- a/geom/src/polygon.rs
+++ b/geom/src/polygon.rs
@@ -304,7 +304,7 @@ impl Polygon {
 
     pub fn convex_hull(list: Vec<Polygon>) -> Polygon {
         let mp: geo::MultiPolygon<f64> = list.into_iter().map(|p| to_geo(p.points())).collect();
-        from_geo(mp.convex_hull())
+        mp.convex_hull().into()
     }
 
     pub fn polylabel(&self) -> Pt2D {
@@ -476,19 +476,21 @@ fn to_geo(pts: &Vec<Pt2D>) -> geo::Polygon<f64> {
     )
 }
 
-fn from_geo(p: geo::Polygon<f64>) -> Polygon {
-    Polygon::buggy_new(
-        p.into_inner()
-            .0
-            .into_points()
-            .into_iter()
-            .map(|pt| Pt2D::new(pt.x(), pt.y()))
-            .collect(),
-    )
+impl From<geo::Polygon<f64>> for Polygon {
+    fn from(poly: geo::Polygon<f64>) -> Self {
+        Polygon::buggy_new(
+            poly.into_inner()
+                .0
+                .into_points()
+                .into_iter()
+                .map(|pt| Pt2D::new(pt.x(), pt.y()))
+                .collect(),
+        )
+    }
 }
 
 fn from_multi(multi: geo::MultiPolygon<f64>) -> Vec<Polygon> {
-    multi.into_iter().map(from_geo).collect()
+    multi.into_iter().map(From::from).collect()
 }
 
 fn downsize(input: Vec<usize>) -> Vec<u16> {

--- a/geom/src/polygon.rs
+++ b/geom/src/polygon.rs
@@ -489,8 +489,25 @@ impl From<geo::Polygon<f64>> for Polygon {
     }
 }
 
+impl From<Polygon> for geo::Polygon<f64> {
+    fn from(poly: Polygon) -> Self {
+        let exterior_coords = poly
+            .points
+            .into_iter()
+            .map(geo::Coordinate::from)
+            .collect::<Vec<_>>();
+        let exterior = geo::LineString(exterior_coords);
+
+        let interiors: Vec<geo::LineString<f64>> = poly
+            .rings
+            .map(|rings| rings.into_iter().map(geo::LineString::from).collect())
+            .unwrap_or(Vec::new());
+        Self::new(exterior, interiors)
+    }
+}
+
 fn from_multi(multi: geo::MultiPolygon<f64>) -> Vec<Polygon> {
-    multi.into_iter().map(From::from).collect()
+    multi.into_iter().map(Polygon::from).collect()
 }
 
 fn downsize(input: Vec<usize>) -> Vec<u16> {

--- a/geom/src/pt.rs
+++ b/geom/src/pt.rs
@@ -182,3 +182,12 @@ impl HashablePt2D {
         Pt2D::new(self.x_nan.into_inner(), self.y_nan.into_inner())
     }
 }
+
+impl From<Pt2D> for geo::Coordinate<f64> {
+    fn from(pt: Pt2D) -> Self {
+        geo::Coordinate {
+            x: pt.inner_x,
+            y: pt.inner_y,
+        }
+    }
+}

--- a/geom/src/pt.rs
+++ b/geom/src/pt.rs
@@ -191,3 +191,21 @@ impl From<Pt2D> for geo::Coordinate<f64> {
         }
     }
 }
+
+impl From<Pt2D> for geo::Point<f64> {
+    fn from(pt: Pt2D) -> Self {
+        geo::Point::new(pt.inner_x, pt.inner_y)
+    }
+}
+
+impl From<geo::Coordinate<f64>> for Pt2D {
+    fn from(coord: geo::Coordinate<f64>) -> Self {
+        Pt2D::new(coord.x, coord.y)
+    }
+}
+
+impl From<geo::Point<f64>> for Pt2D {
+    fn from(point: geo::Point<f64>) -> Self {
+        Pt2D::new(point.x(), point.y())
+    }
+}

--- a/geom/src/ring.rs
+++ b/geom/src/ring.rs
@@ -188,3 +188,14 @@ impl fmt::Display for Ring {
         write!(f, "])")
     }
 }
+
+impl From<Ring> for geo::LineString<f64> {
+    fn from(ring: Ring) -> Self {
+        let coords = ring
+            .pts
+            .into_iter()
+            .map(geo::Coordinate::from)
+            .collect::<Vec<_>>();
+        Self(coords)
+    }
+}

--- a/geom/src/ring.rs
+++ b/geom/src/ring.rs
@@ -199,3 +199,9 @@ impl From<Ring> for geo::LineString<f64> {
         Self(coords)
     }
 }
+
+impl From<geo::LineString<f64>> for Ring {
+    fn from(line_string: geo::LineString<f64>) -> Self {
+        Self::must_new(line_string.0.into_iter().map(Pt2D::from).collect())
+    }
+}

--- a/headless/Cargo.toml
+++ b/headless/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 abstutil = { path = "../abstutil" }
-geojson = "0.20.1"
+geojson = "0.21.0"
 geom = { path = "../geom" }
 hyper = "0.13.9"
 lazy_static = "1.4.0"

--- a/importer/Cargo.toml
+++ b/importer/Cargo.toml
@@ -14,7 +14,7 @@ abstutil = { path = "../abstutil" }
 collisions = { path = "../collisions" }
 convert_osm = { path = "../convert_osm" }
 csv = "1.1.4"
-geojson = "0.20.1"
+geojson = "0.21.0"
 geom = { path = "../geom" }
 gdal = { version = "0.6.0", optional = true }
 kml = { path = "../kml" }

--- a/map_gui/Cargo.toml
+++ b/map_gui/Cargo.toml
@@ -16,11 +16,11 @@ release_s3 = []
 aabb-quadtree = "0.1.0"
 abstutil = { path = "../abstutil" }
 colorous = "1.0.3"
-contour = { git = "https://github.com/dabreegster/contour-rs" }
+contour = "0.1.0"
 flate2 = "1.0.19"
 futures = { version = "0.3.8", optional = true }
 futures-channel = { version = "0.3.8", optional = true }
-geojson = "0.20.1"
+geojson = "0.21.0"
 geom = { path = "../geom" }
 instant = "0.1.7"
 js-sys = { version = "0.3.45", optional = true }

--- a/map_gui/Cargo.toml
+++ b/map_gui/Cargo.toml
@@ -16,7 +16,7 @@ release_s3 = []
 aabb-quadtree = "0.1.0"
 abstutil = { path = "../abstutil" }
 colorous = "1.0.3"
-contour = "0.1.0"
+contour = "0.3.0"
 flate2 = "1.0.19"
 futures = { version = "0.3.8", optional = true }
 futures-channel = { version = "0.3.8", optional = true }

--- a/popdat/Cargo.toml
+++ b/popdat/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 abstutil = { path = "../abstutil" }
-geo = "*"
+geo = "0.16.0"
 geojson = { version = "0.21.0", features = ["geo-types"] }
 geom = { path = "../geom" }
 log = "0.4.11"
@@ -14,5 +14,5 @@ map_model = { path = "../map_model" }
 rand = "0.7.0"
 rand_xorshift = "0.2.0"
 sim = { path = "../sim" }
-serde_json = "*"
-
+serde_json = "1.0.60"
+anyhow = "1.0.35"

--- a/popdat/Cargo.toml
+++ b/popdat/Cargo.toml
@@ -6,13 +6,13 @@ edition = "2018"
 
 [dependencies]
 abstutil = { path = "../abstutil" }
+geo = "*"
+geojson = { version = "0.21.0", features = ["geo-types"] }
 geom = { path = "../geom" }
 log = "0.4.11"
 map_model = { path = "../map_model" }
 rand = "0.7.0"
 rand_xorshift = "0.2.0"
 sim = { path = "../sim" }
-geojson = { version = "0.21.0", features = ["geo-types"] }
 serde_json = "*"
-geo = "*"
 

--- a/popdat/Cargo.toml
+++ b/popdat/Cargo.toml
@@ -15,5 +15,4 @@ sim = { path = "../sim" }
 geojson = { version = "0.21.0", features = ["geo-types"] }
 serde_json = "*"
 geo = "*"
-geo-types = "*"
 

--- a/popdat/Cargo.toml
+++ b/popdat/Cargo.toml
@@ -12,3 +12,8 @@ map_model = { path = "../map_model" }
 rand = "0.7.0"
 rand_xorshift = "0.2.0"
 sim = { path = "../sim" }
+geojson = { version = "0.20.1", features = ["geo-types"] }
+serde_json = "*"
+geo = "*"
+geo-types = "*"
+

--- a/popdat/Cargo.toml
+++ b/popdat/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 abstutil = { path = "../abstutil" }
+anyhow = "1.0.35"
 geo = "0.16.0"
 geojson = { version = "0.21.0", features = ["geo-types"] }
 geom = { path = "../geom" }
@@ -13,6 +14,5 @@ log = "0.4.11"
 map_model = { path = "../map_model" }
 rand = "0.7.0"
 rand_xorshift = "0.2.0"
-sim = { path = "../sim" }
 serde_json = "1.0.60"
-anyhow = "1.0.35"
+sim = { path = "../sim" }

--- a/popdat/Cargo.toml
+++ b/popdat/Cargo.toml
@@ -12,7 +12,7 @@ map_model = { path = "../map_model" }
 rand = "0.7.0"
 rand_xorshift = "0.2.0"
 sim = { path = "../sim" }
-geojson = { version = "0.20.1", features = ["geo-types"] }
+geojson = { version = "0.21.0", features = ["geo-types"] }
 serde_json = "*"
 geo = "*"
 geo-types = "*"

--- a/popdat/src/distribute_people.rs
+++ b/popdat/src/distribute_people.rs
@@ -28,7 +28,7 @@ pub fn assign_people_to_houses(
         let pct_overlap = Polygon::union_all(area.polygon.intersection(map.get_boundary_polygon()))
             .area()
             / area.polygon.area();
-        let num_residents = (pct_overlap * (area.total_population as f64)) as usize;
+        let num_residents = (pct_overlap * (area.population as f64)) as usize;
         debug!(
             "Distributing {} residents to {} buildings. {}% of this area overlapped with the map, \
              scaled residents accordingly.",

--- a/popdat/src/import_census.rs
+++ b/popdat/src/import_census.rs
@@ -19,10 +19,8 @@ impl CensusArea {
         ));
         let bytes = abstutil::slurp_file(&path).map_err(|s| anyhow!(s))?;
         debug!("parsing geojson at path: {}", &path);
-
-        let str = String::from_utf8(bytes)?;
         timer.start("parsing geojson");
-        let geojson = str.parse::<GeoJson>()?;
+        let geojson = GeoJson::from_reader(&*bytes)?;
         timer.stop("parsing geojson");
         let mut results = vec![];
         let collection = geojson::FeatureCollection::try_from(geojson)?;

--- a/popdat/src/import_census.rs
+++ b/popdat/src/import_census.rs
@@ -1,14 +1,74 @@
-use abstutil::Timer;
-use map_model::Map;
-
 use crate::CensusArea;
+use abstutil::Timer;
+use geojson::GeoJson;
+use map_model::Map;
+use std::convert::TryInto;
 
 impl CensusArea {
     pub fn find_data_for_map(map: &Map, timer: &mut Timer) -> Result<Vec<CensusArea>, String> {
-        // TODO importer/src/utils.rs has a download() helper that we could copy here. (And later
-        // dedupe, after deciding how this crate will integrate with the importer)
-        let name = map.get_name();
-        let mut shapes = abstutil::read_binary::<ExtraShapes>(kml_path.to_string(), timer);
-        abstutil::load_bin(format!("system/{}/{}/popdata.json", name.city, name.map));
+        // TODO eventually it'd be nice to lazily download the info needed. For now we expect a
+        // prepared geojson file to exist in data/system/<city>/population_areas.geojson
+        //
+        // When we implement downloading, importer/src/utils.rs has a download() helper that we
+        // could copy here. (And later dedupe, after deciding how this crate will integrate with
+        // the importer)
+        let path = abstutil::path(format!(
+            "system/{}/population_areas.geojson",
+            map.get_name().city
+        ));
+        let bytes = abstutil::slurp_file(&path)?;
+        debug!("parsing geojson at path: {}", &path);
+
+        // TODO - can we change to Result<_,Box<dyn std::error::Error>> and avoid all these map_err?
+        let str = String::from_utf8(bytes).map_err(|e| e.to_string())?;
+        let geojson = str.parse::<GeoJson>().map_err(|e| e.to_string())?;
+        let mut results = vec![];
+        if let GeoJson::FeatureCollection(collection) = geojson {
+            debug!("collection.features: {}", &collection.features.len());
+            for feature in collection.features {
+                let properties = feature.properties.expect("malformed population data.");
+
+                let total_population = match properties.get("population").unwrap() {
+                    serde_json::Value::Number(n) => n
+                        .as_u64()
+                        .expect(&format!("unexpected total population number: {:?}", n))
+                        as usize,
+                    _ => {
+                        return Err(format!(
+                            "unexpected format for 'population': {:?}",
+                            properties.get("population")
+                        ));
+                    }
+                };
+
+                let geometry = feature.geometry.expect("geojson feature missing geometry");
+                debug!("geometry: {:?}", &geometry);
+                use std::convert::TryFrom;
+                let multi_poly: Result<geo::MultiPolygon<f64>, _> = geometry.value.try_into();
+                let mut multi_poly = multi_poly.map_err(|e| e.to_string())?;
+                let geo_polygon = multi_poly
+                    .0
+                    .pop()
+                    .expect("multipolygon was unexpectedly empty");
+                if !multi_poly.0.is_empty() {
+                    // Annoyingly upstream GIS has packaged all these individual polygons into
+                    // "multipolygon" of length 1 Make sure nothing surprising is
+                    // happening since we only use the first poly
+                    error!(
+                        "feature unexpectedly had multiple polygons: {:?}",
+                        &properties
+                    );
+                }
+
+                let polygon = geom::Polygon::from(geo_polygon);
+                results.push(CensusArea {
+                    polygon,
+                    total_population,
+                });
+            }
+        } else {
+            error!("unexpected geojson contents");
+        }
+        Ok(results)
     }
 }

--- a/popdat/src/import_census.rs
+++ b/popdat/src/import_census.rs
@@ -46,7 +46,6 @@ impl CensusArea {
             };
 
             let geometry = feature.geometry.expect("geojson feature missing geometry");
-            debug!("geometry: {:?}", &geometry);
             let mut multi_poly =
                 geo::MultiPolygon::<f64>::try_from(geometry.value).map_err(|e| e.to_string())?;
             let geo_polygon = multi_poly
@@ -58,8 +57,8 @@ impl CensusArea {
                 // "multipolygon" of length 1 Make sure nothing surprising is
                 // happening since we only use the first poly
                 error!(
-                    "feature unexpectedly had multiple polygons: {:?}",
-                    multi_poly.0[0]
+                    "unexpectedly had {} extra area polygons",
+                    multi_poly.0.len()
                 );
             }
 

--- a/popdat/src/import_census.rs
+++ b/popdat/src/import_census.rs
@@ -1,11 +1,14 @@
+use abstutil::Timer;
 use map_model::Map;
 
 use crate::CensusArea;
 
 impl CensusArea {
-    pub fn find_data_for_map(_map: &Map) -> Result<Vec<CensusArea>, String> {
+    pub fn find_data_for_map(map: &Map, timer: &mut Timer) -> Result<Vec<CensusArea>, String> {
         // TODO importer/src/utils.rs has a download() helper that we could copy here. (And later
         // dedupe, after deciding how this crate will integrate with the importer)
-        todo!()
+        let name = map.get_name();
+        let mut shapes = abstutil::read_binary::<ExtraShapes>(kml_path.to_string(), timer);
+        abstutil::load_bin(format!("system/{}/{}/popdata.json", name.city, name.map));
     }
 }

--- a/popdat/src/import_census.rs
+++ b/popdat/src/import_census.rs
@@ -54,7 +54,7 @@ impl CensusArea {
 
             let geometry = feature.geometry.expect("geojson feature missing geometry");
             let mut multi_poly = geo::MultiPolygon::<f64>::try_from(geometry.value)?;
-            let geo_polygon = multi_poly
+            let mut geo_polygon = multi_poly
                 .0
                 .pop()
                 .expect("multipolygon was unexpectedly empty");
@@ -76,6 +76,10 @@ impl CensusArea {
                 continue;
             }
 
+            geo_polygon.map_coords_inplace(|(x, y)| {
+                let point = geom::LonLat::new(*x, *y).to_pt(bounds);
+                (point.x(), point.y())
+            });
             let polygon = geom::Polygon::from(geo_polygon);
             results.push(CensusArea {
                 polygon,

--- a/popdat/src/import_census.rs
+++ b/popdat/src/import_census.rs
@@ -1,9 +1,12 @@
-use crate::CensusArea;
-use abstutil::Timer;
+use std::convert::TryFrom;
+
 use geo::algorithm::intersects::Intersects;
 use geojson::GeoJson;
+
+use abstutil::Timer;
 use map_model::Map;
-use std::convert::TryFrom;
+
+use crate::CensusArea;
 
 impl CensusArea {
     pub fn find_data_for_map(map: &Map, timer: &mut Timer) -> anyhow::Result<Vec<CensusArea>> {

--- a/popdat/src/lib.rs
+++ b/popdat/src/lib.rs
@@ -22,6 +22,7 @@ extern crate log;
 
 use rand_xorshift::XorShiftRng;
 
+use abstutil::Timer;
 use geom::Polygon;
 use geom::{Distance, Time};
 use map_model::{BuildingID, Map};
@@ -105,7 +106,8 @@ pub fn generate_scenario(
 ) -> Result<Scenario, String> {
     // find_data_for_map may return an error. If so, just plumb it back to the caller using the ?
     // operator
-    let areas = CensusArea::find_data_for_map(map)?;
+    let mut timer = Timer::new("generate census scenario");
+    let areas = CensusArea::find_data_for_map(map, &mut timer)?;
     let people = distribute_people::assign_people_to_houses(areas, map, rng, &config);
 
     let mut scenario = Scenario::empty(map, scenario_name);

--- a/popdat/src/lib.rs
+++ b/popdat/src/lib.rs
@@ -18,10 +18,9 @@
 //! 4) Pick specific buildings to visit to satisfy the Schedule.
 
 #[macro_use]
-extern crate log;
-
-#[macro_use]
 extern crate anyhow;
+#[macro_use]
+extern crate log;
 
 use rand_xorshift::XorShiftRng;
 

--- a/popdat/src/lib.rs
+++ b/popdat/src/lib.rs
@@ -42,7 +42,7 @@ mod make_person;
 /// have two overlapping areas.
 pub struct CensusArea {
     pub polygon: Polygon,
-    pub total_population: usize,
+    pub population: usize,
     // TODO Not sure what goes here, whatever census data actually has that could be useful
 }
 

--- a/popdat/src/lib.rs
+++ b/popdat/src/lib.rs
@@ -107,10 +107,16 @@ pub fn generate_scenario(
     // find_data_for_map may return an error. If so, just plumb it back to the caller using the ?
     // operator
     let mut timer = Timer::new("generate census scenario");
+    timer.start("building population areas for map");
     let areas = CensusArea::find_data_for_map(map, &mut timer)?;
+    timer.stop("building population areas for map");
+
+    timer.start("assigning people to houses");
     let people = distribute_people::assign_people_to_houses(areas, map, rng, &config);
+    timer.stop("assigning people to houses");
 
     let mut scenario = Scenario::empty(map, scenario_name);
+    timer.start("building people");
     for person in people {
         // TODO If we need to parallelize because make_person is slow, the sim crate has a fork_rng
         // method that could be useful
@@ -118,5 +124,6 @@ pub fn generate_scenario(
             .people
             .push(make_person::make_person(person, map, rng, &config));
     }
+    timer.stop("building people");
     Ok(scenario)
 }

--- a/popdat/src/lib.rs
+++ b/popdat/src/lib.rs
@@ -20,6 +20,9 @@
 #[macro_use]
 extern crate log;
 
+#[macro_use]
+extern crate anyhow;
+
 use rand_xorshift::XorShiftRng;
 
 use abstutil::Timer;
@@ -108,7 +111,7 @@ pub fn generate_scenario(
     // operator
     let mut timer = Timer::new("generate census scenario");
     timer.start("building population areas for map");
-    let areas = CensusArea::find_data_for_map(map, &mut timer)?;
+    let areas = CensusArea::find_data_for_map(map, &mut timer).map_err(|e| e.to_string())?;
     timer.stop("building population areas for map");
 
     timer.start("assigning people to houses");


### PR DESCRIPTION
Currently broken - I know at least one reason why (comment inline), but wanted to check in on direction.

This assumes you have a file like this downloaded and in your data/system directory for any city using the census travel model:
[population_areas.geojson.zip](https://github.com/dabreegster/abstreet/files/5683537/population_areas.geojson.zip)

```
{
    "type": "FeatureCollection",
    "name": "nyc_block_populations",
    "crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:OGC:1.3:CRS84" } },
        "features": [
            { 
                "type": "Feature", 
                "properties": { 
                    "GISJOIN": "G36000500516005011", 
                    "population": 123 
                }, 
                "geometry": { 
                    "type": "MultiPolygon", 
                    "coordinates": [ [ [ [ -73.769348000110327, 40.857214999638309 ], [ -73.769408999338665, 40.857162000206102 ], ...] ] ] 
                } 
            },
            ...
        ]
 }
```