### PR TITLE
integrate census scenario

### DIFF
--- a/game/src/sandbox/gameplay/freeform.rs
+++ b/game/src/sandbox/gameplay/freeform.rs
@@ -196,12 +196,6 @@ pub fn make_change_traffic(
         &btn,
         choices,
         Box::new(|scenario_name, ctx, app| {
-            if scenario_name == "census" {
-                return Transition::Push(crate::sandbox::gameplay::census::CensusGenerator::new(
-                    ctx,
-                ));
-            }
-
             Transition::Multi(vec![
                 Transition::Pop,
                 Transition::Replace(SandboxMode::simple_new(

--- a/game/src/sandbox/gameplay/mod.rs
+++ b/game/src/sandbox/gameplay/mod.rs
@@ -118,6 +118,12 @@ impl GameplayMode {
             LoadScenario::Scenario(ScenarioGenerator::small_run(map).generate(map, &mut rng, timer))
         } else if name == "home_to_work" {
             LoadScenario::Scenario(ScenarioGenerator::proletariat_robot(map, &mut rng, timer))
+        } else if name == "census" {
+            let config = popdat::Config::default();
+            LoadScenario::Scenario(
+                popdat::generate_scenario("typical monday", config, map, &mut rng)
+                    .expect("unable to build census scenario"),
+            )
         } else {
             LoadScenario::Path(abstutil::path_scenario(map.get_name(), &name))
         }

--- a/popdat/src/lib.rs
+++ b/popdat/src/lib.rs
@@ -120,9 +120,9 @@ pub fn generate_scenario(
     let mut scenario = Scenario::empty(map, scenario_name);
     timer.start("building people");
 
-    scenario
-        .people
-        .append(&mut make_person::make_people(people, map, rng, &config));
+    scenario.people.append(&mut make_person::make_people(
+        people, map, &mut timer, rng, &config,
+    ));
 
     timer.stop("building people");
     Ok(scenario)

--- a/popdat/src/lib.rs
+++ b/popdat/src/lib.rs
@@ -68,7 +68,7 @@ pub struct Schedule {
 
 /// Different things people might do in the day. Maybe it's more clear to call this a
 /// DestinationType or similar.
-#[derive(Clone, Copy, Debug)]
+#[derive(Hash, PartialEq, Eq, Clone, Copy, Debug)]
 pub enum Activity {
     Breakfast,
     Lunch,
@@ -119,13 +119,11 @@ pub fn generate_scenario(
 
     let mut scenario = Scenario::empty(map, scenario_name);
     timer.start("building people");
-    for person in people {
-        // TODO If we need to parallelize because make_person is slow, the sim crate has a fork_rng
-        // method that could be useful
-        scenario
-            .people
-            .push(make_person::make_person(person, map, rng, &config));
-    }
+
+    scenario
+        .people
+        .append(&mut make_person::make_people(people, map, rng, &config));
+
     timer.stop("building people");
     Ok(scenario)
 }

--- a/popdat/src/lib.rs
+++ b/popdat/src/lib.rs
@@ -122,7 +122,11 @@ pub fn generate_scenario(
     scenario.people.extend(make_person::make_people(
         people, map, &mut timer, rng, &config,
     ));
-
     timer.stop("building people");
+
+    timer.start("removing weird schedules");
+    scenario = scenario.remove_weird_schedules();
+    timer.stop("removing weird schedules");
+
     Ok(scenario)
 }

--- a/popdat/src/lib.rs
+++ b/popdat/src/lib.rs
@@ -119,8 +119,7 @@ pub fn generate_scenario(
 
     let mut scenario = Scenario::empty(map, scenario_name);
     timer.start("building people");
-
-    scenario.people.append(&mut make_person::make_people(
+    scenario.people.extend(make_person::make_people(
         people, map, &mut timer, rng, &config,
     ));
 

--- a/popdat/src/make_person.rs
+++ b/popdat/src/make_person.rs
@@ -23,7 +23,7 @@ pub fn make_people(
     // an incoming border "near" the outgoing border, to allow a broader set of
     // realistic options.
     // TODO: prefer larger thoroughfares to better reflect reality.
-    let commuter_borders: Vec<map_model::IntersectionID> = map
+    let commuter_borders: Vec<IntersectionID> = map
         .all_outgoing_borders()
         .into_iter()
         .filter(|b| b.is_incoming_border())

--- a/popdat/src/make_person.rs
+++ b/popdat/src/make_person.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::HashMap;
 
 use rand::seq::SliceRandom;
 use rand::Rng;
@@ -9,150 +9,207 @@ use sim::{IndividTrip, PersonSpec, TripEndpoint, TripMode, TripPurpose};
 
 use crate::{Activity, CensusPerson, Config};
 
-pub fn make_person(
-    person: CensusPerson,
+pub fn make_people(
+    people: Vec<CensusPerson>,
     map: &Map,
     rng: &mut XorShiftRng,
     config: &Config,
-) -> PersonSpec {
-    let schedule = person.generate_schedule(config, rng);
-
-    let mut output = PersonSpec {
-        orig_id: None,
-        origin: TripEndpoint::Bldg(person.home),
-        trips: Vec::new(),
-    };
-
+) -> Vec<PersonSpec> {
     // Only consider two-way intersections, so the agent can return the same way
     // they came.
     // TODO: instead, if it's not a two-way border, we should find an intersection
     // an incoming border "near" the outgoing border, to allow a broader set of
     // realistic options.
     // TODO: prefer larger thoroughfares to better reflect reality.
-    let commuter_borders: Vec<IntersectionID> = map
+    let commuter_borders: Vec<map_model::IntersectionID> = map
         .all_outgoing_borders()
         .into_iter()
         .filter(|b| b.is_incoming_border())
         .map(|b| b.id)
         .collect();
+
+    let person_factory = PersonFactory::new(map);
+
     // TODO Where should we validate that at least one border exists? Probably in
     // generate_scenario, at minimum.
-
-    let mut current_location = TripEndpoint::Bldg(person.home);
-    for (departure_time, activity) in schedule.activities {
-        // TODO This field isn't that important; later we could map Activity to a TripPurpose
-        // better.
-        let purpose = TripPurpose::Shopping;
-
-        let goto = if let Some(destination) =
-            find_building_for_activity(activity, current_location, map, rng)
-        {
-            TripEndpoint::Bldg(destination)
-        } else {
-            // No buildings satisfy the activity. Just go somewhere off-map.
-            TripEndpoint::Border(*commuter_borders.choose(rng).unwrap())
-        };
-
-        let mode = pick_mode(current_location, goto, map, rng, config);
-        output
-            .trips
-            .push(IndividTrip::new(departure_time, purpose, goto, mode));
-
-        current_location = goto;
-    }
-
-    output
+    people
+        .into_iter()
+        .map(|person| {
+            // TODO If we need to parallelize because make_person is slow, the sim crate has a
+            // fork_rng method that could be useful
+            person_factory.make_person(person, map, &commuter_borders, rng, &config)
+        })
+        .collect()
 }
 
-fn find_building_for_activity(
-    activity: Activity,
-    _start: TripEndpoint,
-    map: &Map,
-    _rng: &mut XorShiftRng,
-) -> Option<BuildingID> {
-    // What types of OpenStreetMap amenities will satisfy each activity?
-    let categories: HashSet<&'static str> = match activity {
-        Activity::Breakfast => vec!["cafe"],
-        Activity::Lunch => vec!["pub", "food_court", "fast_food"],
-        Activity::Dinner => vec!["restaurant", "theatre", "biergarten"],
-        Activity::School => vec![
-            "college",
-            "kindergarten",
-            "language_school",
-            "library",
-            "music_school",
-            "university",
-        ],
-        Activity::Entertainment => vec![
-            "arts_centre",
-            "casino",
-            "cinema",
-            "community_centre",
-            "fountain",
-            "gambling",
-            "nightclub",
-            "planetarium",
-            "public_bookcase",
-            "pool",
-            "dojo",
-            "social_centre",
-            "social_centre",
-            "studio",
-            "theatre",
-            "bar",
-            "bbq",
-            "bicycle_rental",
-            "boat_rental",
-            "boat_sharing",
-            "dive_centre",
-            "internet_cafe",
-        ],
-        Activity::Errands => vec![
-            "marketplace",
-            "post_box",
-            "photo_booth",
-            "recycling",
-            "townhall",
-        ],
-        Activity::Financial => vec!["bank", "atm", "bureau_de_change"],
-        Activity::Healthcare => vec![
-            "baby_hatch",
-            "clinic",
-            "dentist",
-            "doctors",
-            "hospital",
-            "nursing_home",
-            "pharmacy",
-            "social_facility",
-            "veterinary",
-            "childcare",
-        ],
-        Activity::Work => vec!["bank", "clinic"],
-        // TODO Fill this out. amenity_type in map_gui/src/tools/mod.rs might be helpful. It might
-        // also be helpful to edit the list of possible activities in lib.rs too.
-        _ => vec![],
-    }
-    .into_iter()
-    .collect();
+struct PersonFactory {
+    activity_to_buildings: HashMap<Activity, Vec<BuildingID>>,
+}
 
-    // Find all buildings with a matching amenity
-    let mut candidates: Vec<BuildingID> = Vec::new();
-    for b in map.all_buildings() {
-        for amenity in &b.amenities {
-            if categories.contains(amenity.amenity_type.as_str()) {
-                candidates.push(b.id);
-            }
+impl PersonFactory {
+    fn new(map: &Map) -> Self {
+        let activity_to_buildings = Self::activity_to_buildings(map);
+        Self {
+            activity_to_buildings,
         }
     }
 
-    // TODO If there are several choices of building that satisfy an activity, which one will
-    // someone choose? One simple approach could just calculate the difficulty of going from the
-    // previous location (starting from home) to that place, using some mode of travel. Then either
-    // pick the closest choice, or even better, randomize, but weight based on the cost of getting
-    // there. map.pathfind() may be helpful.
+    fn activity_to_buildings(map: &Map) -> HashMap<Activity, Vec<BuildingID>> {
+        // What types of OpenStreetMap amenities will satisfy each activity?
+        let categories = vec![
+            (Activity::Breakfast, vec!["cafe"]),
+            (Activity::Lunch, vec!["pub", "food_court", "fast_food"]),
+            (
+                Activity::Dinner,
+                vec!["restaurant", "theatre", "biergarten"],
+            ),
+            (
+                Activity::School,
+                vec![
+                    "college",
+                    "kindergarten",
+                    "language_school",
+                    "library",
+                    "music_school",
+                    "university",
+                ],
+            ),
+            (
+                Activity::Entertainment,
+                vec![
+                    "arts_centre",
+                    "casino",
+                    "cinema",
+                    "community_centre",
+                    "fountain",
+                    "gambling",
+                    "nightclub",
+                    "planetarium",
+                    "public_bookcase",
+                    "pool",
+                    "dojo",
+                    "social_centre",
+                    "social_centre",
+                    "studio",
+                    "theatre",
+                    "bar",
+                    "bbq",
+                    "bicycle_rental",
+                    "boat_rental",
+                    "boat_sharing",
+                    "dive_centre",
+                    "internet_cafe",
+                ],
+            ),
+            (
+                Activity::Errands,
+                vec![
+                    "marketplace",
+                    "post_box",
+                    "photo_booth",
+                    "recycling",
+                    "townhall",
+                ],
+            ),
+            (Activity::Financial, vec!["bank", "atm", "bureau_de_change"]),
+            (
+                Activity::Healthcare,
+                vec![
+                    "baby_hatch",
+                    "clinic",
+                    "dentist",
+                    "doctors",
+                    "hospital",
+                    "nursing_home",
+                    "pharmacy",
+                    "social_facility",
+                    "veterinary",
+                    "childcare",
+                ],
+            ),
+            (Activity::Work, vec!["bank", "clinic"]),
+        ];
 
-    // For now, just pick the first choice arbitrarily
-    candidates.get(0).cloned()
+        // TODO Others to fill out. amenity_type in map_gui/src/tools/mod.rs might be helpful. It
+        // might also be helpful to edit the list of possible activities in lib.rs too.
+
+        // Find all buildings with a matching amenity
+        let mut candidates: HashMap<Activity, Vec<BuildingID>> = HashMap::new();
+        for b in map.all_buildings() {
+            for (activity, categories) in &categories {
+                for amenity in &b.amenities {
+                    if categories.contains(&amenity.amenity_type.as_str()) {
+                        candidates
+                            .entry(*activity)
+                            .and_modify(|v| v.push(b.id))
+                            .or_insert(vec![b.id]);
+                    }
+                }
+            }
+        }
+        candidates
+    }
+
+    fn find_building_for_activity(
+        &self,
+        activity: Activity,
+        _start: TripEndpoint,
+        _map: &Map,
+        rng: &mut XorShiftRng,
+    ) -> Option<BuildingID> {
+        // TODO If there are several choices of building that satisfy an activity, which one will
+        // someone choose? One simple approach could just calculate the difficulty of going from the
+        // previous location (starting from home) to that place, using some mode of travel. Then
+        // either pick the closest choice, or even better, randomize, but weight based on
+        // the cost of getting there. map.pathfind() may be helpful.
+
+        // For now, just pick a random one
+        self.activity_to_buildings
+            .get(&activity)
+            .and_then(|buildings| buildings.choose(rng).cloned())
+    }
+
+    pub fn make_person(
+        &self,
+        person: CensusPerson,
+        map: &Map,
+        commuter_borders: &Vec<IntersectionID>,
+        rng: &mut XorShiftRng,
+        config: &Config,
+    ) -> PersonSpec {
+        let schedule = person.generate_schedule(config, rng);
+
+        let mut output = PersonSpec {
+            orig_id: None,
+            origin: TripEndpoint::Bldg(person.home),
+            trips: Vec::new(),
+        };
+
+        let mut current_location = TripEndpoint::Bldg(person.home);
+        for (departure_time, activity) in schedule.activities {
+            // TODO This field isn't that important; later we could map Activity to a TripPurpose
+            // better.
+            let purpose = TripPurpose::Shopping;
+
+            let goto = if let Some(destination) =
+                self.find_building_for_activity(activity, current_location, map, rng)
+            {
+                TripEndpoint::Bldg(destination)
+            } else {
+                // No buildings satisfy the activity. Just go somewhere off-map.
+                TripEndpoint::Border(*commuter_borders.choose(rng).unwrap())
+            };
+
+            let mode = pick_mode(current_location, goto, map, rng, config);
+            output
+                .trips
+                .push(IndividTrip::new(departure_time, purpose, goto, mode));
+
+            current_location = goto;
+        }
+
+        output
+    }
 }
 
 fn pick_mode(

--- a/sim/src/lib.rs
+++ b/sim/src/lib.rs
@@ -34,7 +34,7 @@ pub(crate) use self::events::Event;
 pub use self::events::{AlertLocation, TripPhaseType};
 pub(crate) use self::make::TripSpec;
 pub use self::make::{
-    BorderSpawnOverTime, ExternalPerson, ExternalTrip, ExternalTripEndpoint, IndividTrip,
+    fork_rng, BorderSpawnOverTime, ExternalPerson, ExternalTrip, ExternalTripEndpoint, IndividTrip,
     PersonSpec, Scenario, ScenarioGenerator, ScenarioModifier, SimFlags, SpawnOverTime,
     TripEndpoint, TripPurpose,
 };

--- a/sim/src/make/scenario.rs
+++ b/sim/src/make/scenario.rs
@@ -294,7 +294,7 @@ impl Scenario {
                 false
             }
         });
-        println!(
+        warn!(
             "{} of {} people have nonsense schedules",
             prettyprint_usize(orig - self.people.len()),
             prettyprint_usize(orig)

--- a/sim/src/make/scenario.rs
+++ b/sim/src/make/scenario.rs
@@ -145,7 +145,8 @@ impl Scenario {
             timer.next();
 
             if let Err(err) = p.check_schedule() {
-                panic!("{}", err);
+                error!("skipping invalid schedule: {}", err);
+                continue;
             }
 
             let (vehicle_specs, cars_initially_parked_at, vehicle_foreach_trip) =

--- a/sim/src/make/scenario.rs
+++ b/sim/src/make/scenario.rs
@@ -145,8 +145,7 @@ impl Scenario {
             timer.next();
 
             if let Err(err) = p.check_schedule() {
-                error!("skipping invalid schedule: {}", err);
-                continue;
+                panic!("{}", err);
             }
 
             let (vehicle_specs, cars_initially_parked_at, vehicle_foreach_trip) =


### PR DESCRIPTION
Based on #425 so review that first.

Integrates the census based scenario and does some perf work to speed up the census scenario's creation.

Previously it'd take ~440s. 

I got it down to something like 40s by caching the boundary nodes and the activity->building_ids map.

Then down to about 15s by parallelizing the make_person calls.

Oh! And some proof that it works:
![lower_manhattan mov](https://user-images.githubusercontent.com/217057/102158069-7742fe00-3e35-11eb-8901-8a1d513d13cd.gif)
