### PR TITLE
fetch US census data from a hosted FlatGeoBuf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,6 +161,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
 
 [[package]]
+name = "async-trait"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3a45e77e34375a7923b1e8febb049bb011f064714a8e17a1a616fef01da13d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1004,6 +1015,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
+name = "flatbuffers"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a788f068dd10687940565bf4b5480ee943176cbd114b12e811074bcf7c04e4b9"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1013,6 +1033,19 @@ dependencies = [
  "crc32fast",
  "libc",
  "miniz_oxide 0.4.3",
+]
+
+[[package]]
+name = "flatgeobuf"
+version = "0.3.4"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "flatbuffers",
+ "geozero",
+ "log",
+ "reqwest",
 ]
 
 [[package]]
@@ -1378,6 +1411,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "geozero"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b6299285fa39bde0802a8926affab1b4555663b970e2c6289aa77248da68233"
+dependencies = [
+ "async-trait",
+ "seek_bufread",
+ "thiserror",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1663,6 +1707,19 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "webpki",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d979acc56dcb5b8dddba3917601745e877576475aa046df3226eabdecef78eed"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-tls",
 ]
 
 [[package]]
@@ -2280,6 +2337,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nbez"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2543,6 +2618,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
 
 [[package]]
+name = "openssl"
+version = "0.10.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "038d43985d1ddca7a9900630d8cd031b56e4794eecc2e9ea39dd17aa04399a70"
+dependencies = [
+ "bitflags",
+ "cfg-if 1.0.0",
+ "foreign-types",
+ "lazy_static",
+ "libc",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "921fc71883267538946025deffb622905ecad223c28efbfdef9bb59a0175f3e6"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "ordered-float"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2766,6 +2874,7 @@ version = "0.1.0"
 dependencies = [
  "abstutil",
  "anyhow",
+ "flatgeobuf",
  "geo 0.16.0",
  "geojson",
  "geom",
@@ -2982,12 +3091,14 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "lazy_static",
  "log",
  "mime",
  "mime_guess",
+ "native-tls",
  "percent-encoding 2.1.0",
  "pin-project-lite 0.2.0",
  "rustls 0.18.1",
@@ -2995,6 +3106,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-rustls",
+ "tokio-tls",
  "url 2.2.0",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -3166,6 +3278,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
+dependencies = [
+ "lazy_static",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3192,6 +3314,35 @@ dependencies = [
  "ring",
  "untrusted",
 ]
+
+[[package]]
+name = "security-framework"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1759c2e3c8580017a484a7ac56d3abc5a6c1feadf88db2f3633f12ae4268c69"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.1",
+ "core-foundation-sys 0.8.2",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f99b9d5e26d2a71633cc4f2ebae7cc9f874044e0c351a27e17892d76dce5678b"
+dependencies = [
+ "core-foundation-sys 0.8.2",
+ "libc",
+]
+
+[[package]]
+name = "seek_bufread"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a248bca144497822c75e8a12d26b7c0bfd9240fc4baa0b2f64f81619ddd58d"
 
 [[package]]
 name = "semver"
@@ -3635,6 +3786,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3908,6 +4069,12 @@ dependencies = [
  "unicode-vo",
  "xmlwriter",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b00bca6106a5e23f3eee943593759b7fcddb00554332e856d990c893966879fb"
 
 [[package]]
 name = "vec_map"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1038,6 +1038,7 @@ dependencies = [
 [[package]]
 name = "flatgeobuf"
 version = "0.3.4"
+source = "git+https://github.com/bjornharrtell/flatgeobuf#4411e90a50a9d4647cc03a30cc719a714ea7f5ca"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -2899,6 +2900,7 @@ dependencies = [
  "abstutil",
  "anyhow",
  "flatgeobuf",
+ "futures",
  "geo 0.16.0",
  "geojson 0.21.0",
  "geom",
@@ -2909,6 +2911,7 @@ dependencies = [
  "rand_xorshift",
  "serde_json",
  "sim",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,7 +561,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "059e75b593068b026cb434c0140dd6a4557c1824ee029d5d3414fc77ecbe8494"
 dependencies = [
- "geojson 0.21.0",
+ "geojson",
  "lazy_static",
  "rustc-hash",
  "serde_json",
@@ -987,7 +987,7 @@ version = "0.1.0"
 dependencies = [
  "abstutil",
  "contour",
- "geojson 0.21.0",
+ "geojson",
  "geom",
  "log",
  "map_gui",
@@ -1232,7 +1232,7 @@ dependencies = [
  "contour",
  "downcast-rs",
  "enumset",
- "geojson 0.21.0",
+ "geojson",
  "geom",
  "instant",
  "kml",
@@ -1386,19 +1386,8 @@ dependencies = [
 
 [[package]]
 name = "geojson"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2b6970b36b77807a4ea232fcbc13b29026eab7c7e906500446c1e03d16f43af"
-dependencies = [
- "num-traits 0.2.14",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "geojson"
 version = "0.21.0"
-source = "git+https://github.com/georust/geojson?branch=mkirk/try_from#ac0429218756af96c379a8701383ef4d36d78779"
+source = "git+https://github.com/georust/geojson#7f1de484ae0e3a640a9539f6adec14b17f8f6fc1"
 dependencies = [
  "geo-types 0.6.2",
  "num-traits 0.2.14",
@@ -1416,7 +1405,7 @@ dependencies = [
  "earcutr",
  "geo 0.15.0",
  "geo-booleanop",
- "geojson 0.21.0",
+ "geojson",
  "histogram",
  "instant",
  "ordered-float",
@@ -1437,13 +1426,13 @@ dependencies = [
 
 [[package]]
 name = "geozero-core"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a014cc8c23c30539692ca943bd00ccdef79a5447a7fb6e58920083782192d3b"
+checksum = "33413ff58db476c26e398142bcfc861fa285b78a0d0d7a03192b7e385797cd35"
 dependencies = [
  "bytes",
  "geo-types 0.6.2",
- "geojson 0.18.0",
+ "geojson",
  "geozero",
  "scroll",
 ]
@@ -1609,7 +1598,7 @@ name = "headless"
 version = "0.1.0"
 dependencies = [
  "abstutil",
- "geojson 0.21.0",
+ "geojson",
  "geom",
  "hyper",
  "lazy_static",
@@ -1802,7 +1791,7 @@ dependencies = [
  "convert_osm",
  "csv",
  "gdal",
- "geojson 0.21.0",
+ "geojson",
  "geom",
  "kml",
  "map_model",
@@ -2179,7 +2168,7 @@ dependencies = [
  "flate2",
  "futures",
  "futures-channel",
- "geojson 0.21.0",
+ "geojson",
  "geom",
  "instant",
  "js-sys",
@@ -2907,7 +2896,7 @@ dependencies = [
  "futures",
  "geo 0.16.0",
  "geo-booleanop",
- "geojson 0.21.0",
+ "geojson",
  "geom",
  "geozero-core",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,8 +1037,9 @@ dependencies = [
 
 [[package]]
 name = "flatgeobuf"
-version = "0.3.4"
-source = "git+https://github.com/bjornharrtell/flatgeobuf#4411e90a50a9d4647cc03a30cc719a714ea7f5ca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bee1d16f8b1c0d3617e79167384c81b321af70ee98cceec763d9265fd8ae979"
 dependencies = [
  "async-trait",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2902,6 +2902,7 @@ dependencies = [
  "flatgeobuf",
  "futures",
  "geo 0.16.0",
+ "geo-booleanop",
  "geojson 0.21.0",
  "geom",
  "geozero-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,7 +561,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "059e75b593068b026cb434c0140dd6a4557c1824ee029d5d3414fc77ecbe8494"
 dependencies = [
- "geojson",
+ "geojson 0.21.0",
  "lazy_static",
  "rustc-hash",
  "serde_json",
@@ -987,7 +987,7 @@ version = "0.1.0"
 dependencies = [
  "abstutil",
  "contour",
- "geojson",
+ "geojson 0.21.0",
  "geom",
  "log",
  "map_gui",
@@ -1229,7 +1229,7 @@ dependencies = [
  "contour",
  "downcast-rs",
  "enumset",
- "geojson",
+ "geojson 0.21.0",
  "geom",
  "instant",
  "kml",
@@ -1383,6 +1383,17 @@ dependencies = [
 
 [[package]]
 name = "geojson"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2b6970b36b77807a4ea232fcbc13b29026eab7c7e906500446c1e03d16f43af"
+dependencies = [
+ "num-traits 0.2.14",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "geojson"
 version = "0.21.0"
 source = "git+https://github.com/georust/geojson?branch=mkirk/try_from#ac0429218756af96c379a8701383ef4d36d78779"
 dependencies = [
@@ -1402,7 +1413,7 @@ dependencies = [
  "earcutr",
  "geo 0.15.0",
  "geo-booleanop",
- "geojson",
+ "geojson 0.21.0",
  "histogram",
  "instant",
  "ordered-float",
@@ -1419,6 +1430,19 @@ dependencies = [
  "async-trait",
  "seek_bufread",
  "thiserror",
+]
+
+[[package]]
+name = "geozero-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a014cc8c23c30539692ca943bd00ccdef79a5447a7fb6e58920083782192d3b"
+dependencies = [
+ "bytes",
+ "geo-types 0.6.2",
+ "geojson 0.18.0",
+ "geozero",
+ "scroll",
 ]
 
 [[package]]
@@ -1582,7 +1606,7 @@ name = "headless"
 version = "0.1.0"
 dependencies = [
  "abstutil",
- "geojson",
+ "geojson 0.21.0",
  "geom",
  "hyper",
  "lazy_static",
@@ -1775,7 +1799,7 @@ dependencies = [
  "convert_osm",
  "csv",
  "gdal",
- "geojson",
+ "geojson 0.21.0",
  "geom",
  "kml",
  "map_model",
@@ -2151,7 +2175,7 @@ dependencies = [
  "flate2",
  "futures",
  "futures-channel",
- "geojson",
+ "geojson 0.21.0",
  "geom",
  "instant",
  "js-sys",
@@ -2876,8 +2900,9 @@ dependencies = [
  "anyhow",
  "flatgeobuf",
  "geo 0.16.0",
- "geojson",
+ "geojson 0.21.0",
  "geom",
+ "geozero-core",
  "log",
  "map_model",
  "rand",
@@ -3304,6 +3329,12 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "scroll"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fda28d4b4830b807a8b43f7b0e6b5df875311b3e7621d84577188c175b6ec1ec"
 
 [[package]]
 name = "sct"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,9 +123,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.35"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0df63cb2955042487fad3aefd2c6e3ae7389ac5dc1beb28921de0b69f779d4"
+checksum = "ee67c11feeac938fae061b232e38e0b6d94f97a9df10e6271319325ac4c56a86"
 
 [[package]]
 name = "approx"
@@ -1224,6 +1224,7 @@ version = "0.1.0"
 dependencies = [
  "aabb-quadtree",
  "abstutil",
+ "anyhow",
  "built",
  "chrono",
  "collisions",
@@ -2172,6 +2173,7 @@ version = "0.1.0"
 dependencies = [
  "aabb-quadtree",
  "abstutil",
+ "anyhow",
  "colorous",
  "contour",
  "flate2",
@@ -2186,6 +2188,7 @@ dependencies = [
  "reqwest",
  "serde",
  "sim",
+ "tokio",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -2913,7 +2916,6 @@ dependencies = [
  "rand_xorshift",
  "serde_json",
  "sim",
- "tokio",
 ]
 
 [[package]]
@@ -3466,9 +3468,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.2.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce32ea0c6c56d5eacaeb814fbed9960547021d3edd010ded1425f180536b20ab"
+checksum = "16f1d0fef1604ba8f7a073c7e701f213e056707210e9020af4528e0101ce11a6"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,4 +34,10 @@ members = [
 opt-level = 3
 
 [patch.crates-io]
+# Some niceties for parsing geojson feature properties.
+# Upstreaming at https://github.com/georust/geojson/pull/155
 geojson = { git = "https://github.com/georust/geojson", branch = "mkirk/try_from" }
+
+# Minimize bandwidth and requests
+# Waiting for release of https://github.com/bjornharrtell/flatgeobuf/pull/93)
+flatgeobuf = { git = "https://github.com/bjornharrtell/flatgeobuf" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,3 @@ opt-level = 3
 # Upstreaming at https://github.com/georust/geojson/pull/155
 geojson = { git = "https://github.com/georust/geojson", branch = "mkirk/try_from" }
 
-# Minimize bandwidth and requests
-# Waiting for release of https://github.com/bjornharrtell/flatgeobuf/pull/93)
-flatgeobuf = { git = "https://github.com/bjornharrtell/flatgeobuf" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,5 +36,5 @@ opt-level = 3
 [patch.crates-io]
 # Some niceties for parsing geojson feature properties.
 # Upstreaming at https://github.com/georust/geojson/pull/155
-geojson = { git = "https://github.com/georust/geojson", branch = "mkirk/try_from" }
+geojson = { git = "https://github.com/georust/geojson" }
 

--- a/README.md
+++ b/README.md
@@ -128,3 +128,4 @@ Data:
 - [King County GIS](https://www.kingcounty.gov/services/gis.aspx)
 - [Seattle Open Data](https://data.seattle.gov/)
 - [Puget Sound Regional Council](https://www.psrc.org/)
+- [IPUMS NHGIS, University of Minnesota](https://www.nhgis.org)

--- a/book/src/trafficsim/travel_demand.md
+++ b/book/src/trafficsim/travel_demand.md
@@ -60,6 +60,20 @@ different types of people (students, workers), give them a set of activities
 with durations (go to school for 7 hours, 1 hour lunch break), and then further
 pick specfic buildings to travel to using more OSM tags.
 
+### Census Based
+
+Trips are distributed based on where we believe people live. For the US, this
+information comes from the US Census. To take advantage of this model for areas
+outside the US, you'll need to add your data to the global `population_areas`
+file. This is one huge file that is shared across regions. This is more work up
+front, but makes adding individual cities relatively straight forward.
+
+#### Preparing the `population_areas` file
+
+See `popdat/scripts/build_population_areas.sh` for updating or adding to the
+existing population areas. Once rebuilt, you'll need to upload the file so that
+popdat can find it.
+
 ### Custom import
 
 If you have your own data, you can import it. The input format is JSON -- an

--- a/game/Cargo.toml
+++ b/game/Cargo.toml
@@ -17,6 +17,7 @@ wasm = ["map_gui/wasm", "wasm-bindgen", "widgetry/wasm-backend"]
 [dependencies]
 aabb-quadtree = "0.1.0"
 abstutil = { path = "../abstutil" }
+anyhow = "1.0.37"
 built = { version = "0.4.3", optional = true, features=["chrono"] }
 chrono = "0.4.15"
 collisions = { path = "../collisions" }

--- a/game/src/sandbox/gameplay/mod.rs
+++ b/game/src/sandbox/gameplay/mod.rs
@@ -1,3 +1,6 @@
+use core::future::Future;
+use core::pin::Pin;
+
 use rand_xorshift::XorShiftRng;
 
 use abstutil::{MapName, Timer};
@@ -81,6 +84,19 @@ pub enum LoadScenario {
     Nothing,
     Path(String),
     Scenario(Scenario),
+    // wasm futures are not `Send`, since they all ultimately run on the browser's single threaded
+    // runloop
+    #[cfg(target_arch = "wasm32")]
+    Future(Pin<Box<dyn Future<Output = anyhow::Result<Box<dyn Send + FnOnce(&App) -> Scenario>>>>>),
+    #[cfg(not(target_arch = "wasm32"))]
+    Future(
+        Pin<
+            Box<
+                dyn Send
+                    + Future<Output = anyhow::Result<Box<dyn Send + FnOnce(&App) -> Scenario>>>,
+            >,
+        >,
+    ),
 }
 
 impl GameplayMode {
@@ -118,11 +134,27 @@ impl GameplayMode {
         } else if name == "home_to_work" {
             LoadScenario::Scenario(ScenarioGenerator::proletariat_robot(map, &mut rng, timer))
         } else if name == "census" {
-            let config = popdat::Config::default();
-            LoadScenario::Scenario(
-                popdat::generate_scenario("typical monday", config, map, &mut rng)
-                    .expect("unable to build census scenario"),
-            )
+            let map_area = map.get_boundary_polygon().clone();
+            let map_bounds = map.get_gps_bounds().clone();
+            let mut rng = sim::fork_rng(&mut rng);
+
+            LoadScenario::Future(Box::pin(async move {
+                let areas = popdat::CensusArea::fetch_all_for_map(&map_area, &map_bounds).await?;
+
+                let scenario_from_app: Box<dyn Send + FnOnce(&App) -> Scenario> =
+                    Box::new(move |app: &App| {
+                        let config = popdat::Config::default();
+                        popdat::generate_scenario(
+                            "typical monday",
+                            areas,
+                            config,
+                            &app.primary.map,
+                            &mut rng,
+                        )
+                    });
+
+                Ok(scenario_from_app)
+            }))
         } else {
             LoadScenario::Path(abstutil::path_scenario(map.get_name(), &name))
         }

--- a/geom/src/polygon.rs
+++ b/geom/src/polygon.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{Angle, Bounds, Distance, HashablePt2D, PolyLine, Pt2D, Ring};
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(PartialEq, Serialize, Deserialize, Clone, Debug)]
 pub struct Polygon {
     points: Vec<Pt2D>,
     /// Groups of three indices make up the triangles

--- a/geom/src/ring.rs
+++ b/geom/src/ring.rs
@@ -34,18 +34,13 @@ impl Ring {
             seen_pts.insert(pt.to_hashable());
         }
         if seen_pts.len() != result.pts.len() - 1 {
-            // return Err(format!("Ring has repeat non-adjacent points"));
+            return Err(format!("Ring has repeat non-adjacent points"));
         }
 
         Ok(result)
     }
     pub fn must_new(pts: Vec<Pt2D>) -> Ring {
-        match Ring::new(pts) {
-            Ok(r) => r,
-            Err(e) => {
-                panic!("{}", e);
-            }
-        }
+        Ring::new(pts).unwrap()
     }
 
     /// Draws the ring with some thickness, with half of it straddling the interor of the ring, and

--- a/geom/src/ring.rs
+++ b/geom/src/ring.rs
@@ -34,13 +34,18 @@ impl Ring {
             seen_pts.insert(pt.to_hashable());
         }
         if seen_pts.len() != result.pts.len() - 1 {
-            return Err(format!("Ring has repeat non-adjacent points"));
+            // return Err(format!("Ring has repeat non-adjacent points"));
         }
 
         Ok(result)
     }
     pub fn must_new(pts: Vec<Pt2D>) -> Ring {
-        Ring::new(pts).unwrap()
+        match Ring::new(pts) {
+            Ok(r) => r,
+            Err(e) => {
+                panic!("{}", e);
+            }
+        }
     }
 
     /// Draws the ring with some thickness, with half of it straddling the interor of the ring, and

--- a/map_gui/Cargo.toml
+++ b/map_gui/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["Dustin Carlino <dabreegster@gmail.com>"]
 edition = "2018"
 
 [features]
-native = ["reqwest"]
-wasm = ["futures", "futures-channel", "js-sys", "wasm-bindgen", "wasm-bindgen-futures", "web-sys"]
+native = ["reqwest", "tokio"]
+wasm = ["js-sys", "wasm-bindgen", "wasm-bindgen-futures", "web-sys"]
 # Just a marker to not use localhost URLs
 wasm_s3 = []
 # A marker to use a named release from S3 instead of dev for updating files
@@ -15,11 +15,12 @@ release_s3 = []
 [dependencies]
 aabb-quadtree = "0.1.0"
 abstutil = { path = "../abstutil" }
+anyhow = "1.0.37"
 colorous = "1.0.3"
 contour = "0.3.0"
 flate2 = "1.0.19"
-futures = { version = "0.3.8", optional = true }
-futures-channel = { version = "0.3.8", optional = true }
+futures = { version = "0.3.8" }
+futures-channel = { version = "0.3.8"}
 geojson = "0.21.0"
 geom = { path = "../geom" }
 instant = "0.1.7"
@@ -29,6 +30,7 @@ map_model = { path = "../map_model" }
 reqwest = { version = "0.10.8", optional = true, default-features=false, features=["blocking", "rustls-tls"] }
 serde = "1.0.116"
 sim = { path = "../sim" }
+tokio = { version ="0.2", features=["rt-core"], optional = true }
 wasm-bindgen = { version = "0.2.68", optional = true }
 wasm-bindgen-futures = { version = "0.4.18", optional = true }
 webbrowser = "0.5.5"

--- a/popdat/Cargo.toml
+++ b/popdat/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 abstutil = { path = "../abstutil" }
 anyhow = "1.0.35"
-flatgeobuf = { version = "*" }
+flatgeobuf = { version = "0.4" }
 futures = "0.3.8"
 geo = "0.16.0"
 geojson = { version = "0.21.0", features = ["geo-types"] }

--- a/popdat/Cargo.toml
+++ b/popdat/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2018"
 [dependencies]
 abstutil = { path = "../abstutil" }
 anyhow = "1.0.35"
+flatgeobuf = { version = "*", path = "../../../georust/flatgeobuf/src/rust" }
+# flatgeobuf = { version = "*" }
 geo = "0.16.0"
 geojson = { version = "0.21.0", features = ["geo-types"] }
 geom = { path = "../geom" }

--- a/popdat/Cargo.toml
+++ b/popdat/Cargo.toml
@@ -7,15 +7,16 @@ edition = "2018"
 [dependencies]
 abstutil = { path = "../abstutil" }
 anyhow = "1.0.35"
-flatgeobuf = { version = "*", path = "../../../georust/flatgeobuf/src/rust" }
-# flatgeobuf = { version = "*" }
+flatgeobuf = { version = "*" }
+futures = "0.3.8"
 geo = "0.16.0"
-geozero-core = { version = "0.5.1" }
 geojson = { version = "0.21.0", features = ["geo-types"] }
 geom = { path = "../geom" }
+geozero-core = { version = "0.5.1" }
 log = "0.4.11"
 map_model = { path = "../map_model" }
 rand = "0.7.0"
 rand_xorshift = "0.2.0"
+tokio = "0.2.24"
 serde_json = "1.0.60"
 sim = { path = "../sim" }

--- a/popdat/Cargo.toml
+++ b/popdat/Cargo.toml
@@ -18,5 +18,6 @@ map_model = { path = "../map_model" }
 rand = "0.7.0"
 rand_xorshift = "0.2.0"
 tokio = "0.2.24"
+geo-booleanop = "0.3.2"
 serde_json = "1.0.60"
 sim = { path = "../sim" }

--- a/popdat/Cargo.toml
+++ b/popdat/Cargo.toml
@@ -10,6 +10,7 @@ anyhow = "1.0.35"
 flatgeobuf = { version = "*", path = "../../../georust/flatgeobuf/src/rust" }
 # flatgeobuf = { version = "*" }
 geo = "0.16.0"
+geozero-core = { version = "0.5.1" }
 geojson = { version = "0.21.0", features = ["geo-types"] }
 geom = { path = "../geom" }
 log = "0.4.11"

--- a/popdat/Cargo.toml
+++ b/popdat/Cargo.toml
@@ -17,7 +17,6 @@ log = "0.4.11"
 map_model = { path = "../map_model" }
 rand = "0.7.0"
 rand_xorshift = "0.2.0"
-tokio = "0.2.24"
 geo-booleanop = "0.3.2"
 serde_json = "1.0.60"
 sim = { path = "../sim" }

--- a/popdat/scripts/build_population_areas.sh
+++ b/popdat/scripts/build_population_areas.sh
@@ -1,0 +1,103 @@
+#!/bin/bash -e
+
+# Outputs a FlatGeoBuf of geometries and their corresponding population,
+# suitable for use in the popdat crate.
+#
+# You'll need to update the `configuration` section to get this to work on your
+# machine.
+# 
+# Note: I've only ever used this for US data, with "Census Blocks" as areas. In
+# theory other countries could also massage their data to fit into the combined
+# FlatGeoBuf.
+#
+# ## Input
+#
+# I wasn't able to find a reasonable solution using the official census.gov
+# files or API's. Instead I batch-downloaded all the census blocks and their
+# populations from the very nice nhgis.org
+#
+# Input files:
+# - a csv of populations with a GISJOIN field
+# - geometry shapefiles with the area boundaries and a GISJOIN field
+# 
+# Output:
+# An single FGB with a feature for each area which includes its population.
+
+# Configuration
+
+## Inputs
+
+geometry_shapefiles=$(ls source/nhgis_us_block_population/*.shp)
+population_csv=source/nhgis_us_block_population/nhgis0004_ds172_2010_block.csv
+population_column_name=H7V001
+
+# ## SpatiaLite
+#
+# Even though we're not doing spatial changes in sqlite, making *any* changes
+# to spatial tables, fires db triggers, which require you have the spatialite
+# lib linked.
+spatialite_bin=/usr/local/Cellar/sqlite/3.34.0/bin/sqlite3 
+spatialite_lib=/usr/local/lib/mod_spatialite.dylib
+
+# Main program follows
+
+gpkg_output=generated/population_areas.gpkg
+
+rm -f $gpkg_output
+
+echo "Importing geometries - start $(date)"
+
+for i in $geometry_shapefiles; do
+    filename=$(basename -- "$i")
+    extension="${filename##*.}"
+    layer_name="${filename%.*}"
+    if [ ! -f "$gpkg_output" ]; then
+		echo "starting with $i"
+        # first file - create the consolidated output file
+
+        # I tried selecting only the columns we needed here, but I got a "table
+        # not found" error, so instead we filter later when building the FGB
+        # ogr2ogr -f "GPKG" -nln areas -t_srs "WGS84" -dialect SQLite -sql "SELECT GISJOIN FROM $layer_name" $gpkg_output $i
+
+        # Note the `nlt` option addresses this warning:
+        # > Warning 1: A geometry of type MULTIPOLYGON is inserted into layer areas of geometry type POLYGON, which is not normally allowed by the GeoPackage specification, but the driver will however do it. To create a conformant GeoPackage, if using ogr2ogr, the -nlt option can be used to override the layer geometry type. This warning will no longer be emitted for this combination of layer and feature geometry type.
+        ogr2ogr -f "GPKG" -nlt MULTIPOLYGON -nln areas -t_srs "WGS84" $gpkg_output $i
+    else
+		echo "merging $i"
+        # update the output file with new file content
+        #ogr2ogr -f "GPKG" -nln areas -t_srs "WGS84" -dialect SQLite -sql "SELECT GISJOIN FROM $layer_name" -update -append $gpkg_output $i
+        ogr2ogr -f "GPKG" -nlt MULTIPOLYGON -nln areas -t_srs "WGS84" -update -append $gpkg_output $i
+    fi
+done
+
+echo "### Indexing geometries - start $(date)"
+echo "
+PRAGMA journal_mode = off;
+CREATE INDEX index_areas_on_gisjoin on areas(GISJOIN)
+" | $spatialite_bin $gpkg_output
+
+echo "## Importing and indexing populations data - start $(date)"
+
+echo "
+PRAGMA journal_mode = off;
+DROP TABLE IF EXISTS populations;
+.import --csv $population_csv populations
+ALTER TABLE populations RENAME COLUMN $population_column_name TO population;
+CREATE INDEX index_populations_on_GISJOIN ON populations(GISJOIN);
+" | $spatialite_bin $gpkg_output
+
+echo "## join populations and geometries - start $(date)"
+
+echo "
+PRAGMA journal_mode = off;
+.load $spatialite_lib
+ALTER TABLE areas ADD COLUMN population;
+update areas set population=(select population from populations where populations.GISJOIN=areas.GISJOIN);
+" | $spatialite_bin $gpkg_output
+
+echo "## outputting fgb - start $(date)"
+
+ogr2ogr generated/population_areas.fgb $gpkg_output -dialect SQLite -sql "SELECT geom, population, GISJOIN FROM areas"
+
+echo "## Done - $(date)"
+

--- a/popdat/scripts/build_population_areas.sh
+++ b/popdat/scripts/build_population_areas.sh
@@ -16,6 +16,27 @@
 # files or API's. Instead I batch-downloaded all the census blocks and their
 # populations from the very nice nhgis.org
 #
+# Specifically, at the time of writing the steps were:
+#   - create an account for nhgis.org and log in
+#   - select "Get Data"
+#   - Under "Apply Filters": 
+#     - Geographic Level: choose "Block", then "submit"
+#     - Years: "2010" (hopefully 2020 will be available before long)
+#     - Topics: choose "General: Total Population", then "submit"
+#   - Under "Select Data":
+#     - Select "Total Population"
+#   - Click "Continue" towards top right
+#   - Click "Continue" again towards top right
+#   - Source Tables:
+#     - You should see that you've selected "1 source table" 
+#       - This corresponds to a CSV file of the populations and GISJOIN id but
+#         no geometries 
+#     - Click "Geographic Extents" > "Select All" > Submit
+#       - This corresponds to shapefiles for every state + DC + Puerto Rico
+#         with a GISJOIN attribute to join to the population CSV
+#   - Enter a "Description" which is memorable to you like (2010 all US block populations)
+#   - Submit and wait for the batch to be prepared
+#
 # Input files:
 # - a csv of populations with a GISJOIN field
 # - geometry shapefiles with the area boundaries and a GISJOIN field

--- a/popdat/src/distribute_people.rs
+++ b/popdat/src/distribute_people.rs
@@ -1,8 +1,8 @@
+use geo::algorithm::{area::Area, contains::Contains};
 use rand::Rng;
 use rand_xorshift::XorShiftRng;
 
 use abstutil::prettyprint_usize;
-use geo::algorithm::{area::Area, contains::Contains};
 use map_model::Map;
 
 use crate::{CensusArea, CensusPerson, Config};

--- a/popdat/src/distribute_people.rs
+++ b/popdat/src/distribute_people.rs
@@ -2,7 +2,7 @@ use rand::Rng;
 use rand_xorshift::XorShiftRng;
 
 use abstutil::prettyprint_usize;
-use geom::Polygon;
+use geo::algorithm::{area::Area, contains::Contains};
 use map_model::Map;
 
 use crate::{CensusArea, CensusPerson, Config};
@@ -15,19 +15,23 @@ pub fn assign_people_to_houses(
 ) -> Vec<CensusPerson> {
     let mut people = Vec::new();
 
+    let map_boundary = geo::Polygon::from(map.get_boundary_polygon().clone());
     for area in areas {
         let bldgs: Vec<map_model::BuildingID> = map
             .all_buildings()
             .into_iter()
-            .filter(|b| area.polygon.contains_pt(b.label_center) && b.bldg_type.has_residents())
+            .filter(|b| {
+                area.polygon.contains(&geo::Point::from(b.label_center))
+                    && b.bldg_type.has_residents()
+            })
             .map(|b| b.id)
             .collect();
 
         // If the area is partly out-of-bounds, then scale down the number of residents linearly
         // based on area of the overlapping part of the polygon.
-        let pct_overlap = Polygon::union_all(area.polygon.intersection(map.get_boundary_polygon()))
-            .area()
-            / area.polygon.area();
+        use geo_booleanop::boolean::BooleanOp;
+        let pct_overlap =
+            area.polygon.intersection(&map_boundary).unsigned_area() / area.polygon.unsigned_area();
         let num_residents = (pct_overlap * (area.population as f64)) as usize;
         debug!(
             "Distributing {} residents to {} buildings. {}% of this area overlapped with the map, \

--- a/popdat/src/import_census.rs
+++ b/popdat/src/import_census.rs
@@ -76,10 +76,6 @@ impl CensusArea {
                     .first()
                     .ok_or(anyhow!("multipolygon was unexpectedly empty"))?;
                 if multi_poly.0.len() > 1 {
-                    // I haven't looked into why this is happening - but intuitively a census area
-                    // could include separate polygons - e.g. across bodies of
-                    // water. In practice they are a vast minority, so we
-                    // naively just take the first one for now.
                     warn!(
                         "dropping {} extra polygons from census area: {:?}",
                         multi_poly.0.len() - 1,

--- a/popdat/src/import_census.rs
+++ b/popdat/src/import_census.rs
@@ -91,12 +91,11 @@ impl CensusArea {
                     continue;
                 }
 
-                let mut geo_polygon = geo_polygon.clone();
-                geo_polygon.map_coords_inplace(|(x, y)| {
+                let mut polygon = geo_polygon.clone();
+                polygon.map_coords_inplace(|(x, y)| {
                     let point = geom::LonLat::new(*x, *y).to_pt(bounds);
                     (point.x(), point.y())
                 });
-                let polygon = geom::Polygon::from(geo_polygon);
                 results.push(CensusArea {
                     polygon,
                     population,

--- a/popdat/src/import_census.rs
+++ b/popdat/src/import_census.rs
@@ -33,6 +33,7 @@ impl CensusArea {
         });
 
         timer.start("opening FGB reader");
+        // See the import handbook for how to prepare this file.
         let mut fgb =
             HttpFgbReader::open("https://abstreet.s3.amazonaws.com/population_areas.fgb").await?;
         timer.stop("opening FGB reader");

--- a/popdat/src/import_census.rs
+++ b/popdat/src/import_census.rs
@@ -21,8 +21,7 @@ impl CensusArea {
 
         // See the import handbook for how to prepare this file.
         let mut fgb =
-            // HttpFgbReader::open("https://abstreet.s3.amazonaws.com/population_areas.fgb").await?;
-            HttpFgbReader::open("https://s3.amazonaws.com/mjk_asdf/abs/population_areas.fgb").await?;
+            HttpFgbReader::open("https://abstreet.s3.amazonaws.com/population_areas.fgb").await?;
 
         let bounding_rect = geo_map_area
             .bounding_rect()

--- a/popdat/src/import_census.rs
+++ b/popdat/src/import_census.rs
@@ -1,7 +1,4 @@
-use std::convert::TryFrom;
-
 use geo::algorithm::intersects::Intersects;
-use geojson::GeoJson;
 
 use abstutil::Timer;
 use map_model::Map;
@@ -9,67 +6,67 @@ use map_model::Map;
 use crate::CensusArea;
 
 impl CensusArea {
-    pub fn find_data_for_map(map: &Map, timer: &mut Timer) -> anyhow::Result<Vec<CensusArea>> {
+    pub fn fetch_all_for_map(map: &Map, timer: &mut Timer) -> anyhow::Result<Vec<CensusArea>> {
         timer.start("processing population areas fgb");
-        let mut fgb_result = Self::find_data_for_map_fgb(map, timer)?;
+        let areas = tokio::runtime::Runtime::new()
+            .expect("Failed to create Tokio runtime")
+            .block_on(Self::fetch_all_for_map_async(map, timer))?;
         timer.stop("processing population areas fgb");
-
-        timer.start("processing population areas geojson");
-        let mut geojson_result = Self::find_data_for_map_geojson(map, timer)?;
-        timer.stop("processing population areas geojson");
-
-        fgb_result.sort_by(|b, a| a.population.partial_cmp(&b.population).unwrap());
-        geojson_result.sort_by(|b, a| a.population.partial_cmp(&b.population).unwrap());
-
-        assert_eq!(fgb_result.len(), geojson_result.len());
-
-        debug!("fgb_result.len(): {:?}", fgb_result.len());
-        debug!("fgb_results: {:?}", &fgb_result[0..4]);
-        debug!("geojson_results: {:?}", &geojson_result[0..4]);
-
-        Ok(fgb_result)
+        Ok(areas)
     }
 
-    pub fn find_data_for_map_fgb(map: &Map, timer: &mut Timer) -> anyhow::Result<Vec<CensusArea>> {
-        use flatgeobuf::FgbReader;
-        use std::fs::File;
-        use std::io::BufReader;
+    async fn fetch_all_for_map_async(
+        map: &Map,
+        timer: &mut Timer<'_>,
+    ) -> anyhow::Result<Vec<CensusArea>> {
+        use flatgeobuf::HttpFgbReader;
         use geozero_core::geo_types::Geo;
-
-        let path = abstutil::path(format!(
-            "system/{}/population_areas.fgb",
-            map.get_name().city
-        ));
-        // let bytes = abstutil::slurp_file(&path).map_err(|s| anyhow!(s))?;
-        let mut filein = BufReader::new(File::open(&path)?);
-        let mut fgb = FgbReader::open(&mut filein)?;
-
-        let mut results = vec![];
 
         let map_area = map.get_boundary_polygon();
         let bounds = map.get_gps_bounds();
 
-        use geo::algorithm::{map_coords::MapCoordsInplace, bounding_rect::BoundingRect};
+        use geo::algorithm::{bounding_rect::BoundingRect, map_coords::MapCoordsInplace};
         let mut geo_map_area: geo::Polygon<_> = map_area.clone().into();
         geo_map_area.map_coords_inplace(|c| {
             let projected = geom::Pt2D::new(c.0, c.1).to_gps(bounds);
             (projected.x(), projected.y())
         });
 
-        let bounding_rect = geo_map_area.bounding_rect().ok_or(anyhow!("missing bound rect"))?;
-        fgb.select_bbox(bounding_rect.min().x, bounding_rect.min().y, bounding_rect.max().x, bounding_rect.max().y)?;
+        timer.start("opening FGB reader");
+        let mut fgb =
+            HttpFgbReader::open("https://abstreet.s3.amazonaws.com/population_areas.fgb").await?;
+        timer.stop("opening FGB reader");
 
-        debug!("reading features from fgb at path: {}", &path);
-        timer.start("reading featurs from fgb");
-        //while let Some(feature) = fgb.next()? {
-        //    let props = feature.properties()?;
-        //    println!("{}", props["population"]);
-        //}
-        while let Some(feature) = fgb.next()? {
+        timer.start("selecting bounding box");
+        let bounding_rect = geo_map_area
+            .bounding_rect()
+            .ok_or(anyhow!("missing bound rect"))?;
+        fgb.select_bbox(
+            bounding_rect.min().x,
+            bounding_rect.min().y,
+            bounding_rect.max().x,
+            bounding_rect.max().y,
+        )
+        .await?;
+        timer.stop("selecting bounding box");
+
+        timer.start("processing features");
+        let mut results = vec![];
+        while let Some(feature) = fgb.next().await? {
             // PERF TODO: how to parse into usize directly? And avoid parsing entire props dict?
             let props = feature.properties()?;
+            if !props.contains_key("population") {
+                warn!("skipping feature with missing population");
+                continue;
+            }
             let population: usize = props["population"].parse()?;
-            let geometry = feature.geometry().unwrap();
+            let geometry = match feature.geometry() {
+                Some(g) => g,
+                None => {
+                    warn!("skipping feature with missing geometry");
+                    continue;
+                }
+            };
             let mut geo = Geo::new();
             geometry.process(&mut geo, flatgeobuf::GeometryType::MultiPolygon)?;
             if let geo::Geometry::MultiPolygon(multi_poly) = geo.geometry() {
@@ -77,13 +74,15 @@ impl CensusArea {
                     .0
                     .first()
                     .ok_or(anyhow!("multipolygon was unexpectedly empty"))?;
-                if !multi_poly.0.is_empty() {
-                    // I haven't looked into why this is happening - but intuitively a census area could
-                    // include separate polygons - e.g. across bodies of water. In practice they are a
-                    // vast minority, so we naively just take the first one for now.
+                if multi_poly.0.len() > 1 {
+                    // I haven't looked into why this is happening - but intuitively a census area
+                    // could include separate polygons - e.g. across bodies of
+                    // water. In practice they are a vast minority, so we
+                    // naively just take the first one for now.
                     warn!(
-                        "dropping {} polygons from census area with multiple polygons",
-                        multi_poly.0.len()
+                        "dropping {} extra polygons from census area: {:?}",
+                        multi_poly.0.len() - 1,
+                        props
                     );
                 }
 
@@ -106,130 +105,11 @@ impl CensusArea {
                     population,
                 });
             } else {
-                panic!("unexpected geometry")
-            }
-        }
-        timer.stop("reading featurs from fgb");
-
-        Ok(results)
-    }
-
-    pub fn find_data_for_map_geojson(map: &Map, timer: &mut Timer) -> anyhow::Result<Vec<CensusArea>> {
-        // TODO eventually it'd be nice to lazily download the info needed. For now we expect a
-        // prepared geojson file to exist in data/system/<city>/population_areas.geojson
-        //
-        // expected geojson formatted contents like:
-        // {
-        //     "type": "FeatureCollection",
-        //     "features": [
-        //          {
-        //              "type": "Feature",
-        //              "properties": { "population": 123 },
-        //              "geometry": {
-        //                  "type": "MultiPolygon",
-        //                  "coordinates": [ [ [ [ -73.7, 40.8 ], [ -73.7, 40.8 ], ...] ] ] ]
-        //               }
-        //          },
-        //          {
-        //              "type": "Feature",
-        //              "properties": { "population": 249 },
-        //              "geometry": {
-        //                  "type": "MultiPolygon",
-        //                  "coordinates": [ [ [ [ -73.8, 40.8 ], [ -73.8, 40.8 ], ...] ] ]
-        //               }
-        //           },
-        //          ...
-        //      ]
-        // }
-        //
-        // Note: intuitively you might expect a collection of Polygon's rather than  MultiPolygons,
-        // but anecdotally, the census data I've seen uses MultiPolygons. In practice almost
-        // all are MultiPoly's with just one element, but some truly have multiple polygons.
-        //
-        // When we implement downloading, importer/src/utils.rs has a download() helper that we
-        // could copy here. (And later dedupe, after deciding how this crate will integrate with
-        // the importer)
-        let path = abstutil::path(format!(
-            "system/{}/population_areas.geojson",
-            map.get_name().city
-        ));
-        let bytes = abstutil::slurp_file(&path).map_err(|s| anyhow!(s))?;
-        debug!("parsing geojson at path: {}", &path);
-        timer.start("parsing geojson");
-        let geojson = GeoJson::from_reader(&*bytes)?;
-        timer.stop("parsing geojson");
-
-
-        let mut results = vec![];
-        let collection = geojson::FeatureCollection::try_from(geojson)?;
-
-        let map_area = map.get_boundary_polygon();
-        let bounds = map.get_gps_bounds();
-
-        use geo::algorithm::map_coords::MapCoordsInplace;
-        let mut geo_map_area: geo::Polygon<_> = map_area.clone().into();
-        geo_map_area.map_coords_inplace(|c| {
-            let projected = geom::Pt2D::new(c.0, c.1).to_gps(bounds);
-            (projected.x(), projected.y())
-        });
-
-        debug!("collection.features: {}", &collection.features.len());
-        timer.start("converting to `CensusArea`s");
-        for feature in collection.features.into_iter() {
-            let population = match feature
-                .property("population")
-                .ok_or(anyhow!("missing 'population' property"))?
-            {
-                serde_json::Value::Number(n) => n
-                    .as_u64()
-                    .ok_or(anyhow!("unexpected population number: {:?}", n))?
-                    as usize,
-                _ => {
-                    bail!(
-                        "unexpected format for 'population': {:?}",
-                        feature.property("population")
-                    );
-                }
-            };
-
-            let geometry = feature
-                .geometry
-                .ok_or(anyhow!("geojson feature missing geometry"))?;
-            let mut multi_poly = geo::MultiPolygon::<f64>::try_from(geometry.value)?;
-            let mut geo_polygon = multi_poly
-                .0
-                .pop()
-                .ok_or(anyhow!("multipolygon was unexpectedly empty"))?;
-            if !multi_poly.0.is_empty() {
-                // I haven't looked into why this is happening - but intuitively a census area could
-                // include separate polygons - e.g. across bodies of water. In practice they are a
-                // vast minority, so we naively just take the first one for now.
-                warn!(
-                    "dropping {} polygons from census area with multiple polygons",
-                    multi_poly.0.len()
-                );
-            }
-
-            if !geo_polygon.intersects(&geo_map_area) {
-                debug!(
-                    "skipping polygon outside of map area. polygon: {:?}, map_area: {:?}",
-                    geo_polygon, geo_map_area
-                );
+                warn!("skipping unexpected geometry");
                 continue;
             }
-
-            geo_polygon.map_coords_inplace(|(x, y)| {
-                let point = geom::LonLat::new(*x, *y).to_pt(bounds);
-                (point.x(), point.y())
-            });
-            let polygon = geom::Polygon::from(geo_polygon);
-            results.push(CensusArea {
-                polygon,
-                population,
-            });
         }
-        debug!("built {} CensusAreas within map bounds", results.len());
-        timer.stop("converting to `CensusArea`s");
+        timer.stop("processing features");
 
         Ok(results)
     }

--- a/popdat/src/import_census.rs
+++ b/popdat/src/import_census.rs
@@ -10,6 +10,111 @@ use crate::CensusArea;
 
 impl CensusArea {
     pub fn find_data_for_map(map: &Map, timer: &mut Timer) -> anyhow::Result<Vec<CensusArea>> {
+        timer.start("processing population areas fgb");
+        let mut fgb_result = Self::find_data_for_map_fgb(map, timer)?;
+        timer.stop("processing population areas fgb");
+
+        timer.start("processing population areas geojson");
+        let mut geojson_result = Self::find_data_for_map_geojson(map, timer)?;
+        timer.stop("processing population areas geojson");
+
+        fgb_result.sort_by(|b, a| a.population.partial_cmp(&b.population).unwrap());
+        geojson_result.sort_by(|b, a| a.population.partial_cmp(&b.population).unwrap());
+
+        assert_eq!(fgb_result.len(), geojson_result.len());
+
+        debug!("fgb_result.len(): {:?}", fgb_result.len());
+        debug!("fgb_results: {:?}", &fgb_result[0..4]);
+        debug!("geojson_results: {:?}", &geojson_result[0..4]);
+
+        Ok(fgb_result)
+    }
+
+    pub fn find_data_for_map_fgb(map: &Map, timer: &mut Timer) -> anyhow::Result<Vec<CensusArea>> {
+        use flatgeobuf::FgbReader;
+        use std::fs::File;
+        use std::io::BufReader;
+        use geozero_core::geo_types::Geo;
+
+        let path = abstutil::path(format!(
+            "system/{}/population_areas.fgb",
+            map.get_name().city
+        ));
+        // let bytes = abstutil::slurp_file(&path).map_err(|s| anyhow!(s))?;
+        let mut filein = BufReader::new(File::open(&path)?);
+        let mut fgb = FgbReader::open(&mut filein)?;
+
+        let mut results = vec![];
+
+        let map_area = map.get_boundary_polygon();
+        let bounds = map.get_gps_bounds();
+
+        use geo::algorithm::{map_coords::MapCoordsInplace, bounding_rect::BoundingRect};
+        let mut geo_map_area: geo::Polygon<_> = map_area.clone().into();
+        geo_map_area.map_coords_inplace(|c| {
+            let projected = geom::Pt2D::new(c.0, c.1).to_gps(bounds);
+            (projected.x(), projected.y())
+        });
+
+        let bounding_rect = geo_map_area.bounding_rect().ok_or(anyhow!("missing bound rect"))?;
+        fgb.select_bbox(bounding_rect.min().x, bounding_rect.min().y, bounding_rect.max().x, bounding_rect.max().y)?;
+
+        debug!("reading features from fgb at path: {}", &path);
+        timer.start("reading featurs from fgb");
+        //while let Some(feature) = fgb.next()? {
+        //    let props = feature.properties()?;
+        //    println!("{}", props["population"]);
+        //}
+        while let Some(feature) = fgb.next()? {
+            // PERF TODO: how to parse into usize directly? And avoid parsing entire props dict?
+            let props = feature.properties()?;
+            let population: usize = props["population"].parse()?;
+            let geometry = feature.geometry().unwrap();
+            let mut geo = Geo::new();
+            geometry.process(&mut geo, flatgeobuf::GeometryType::MultiPolygon)?;
+            if let geo::Geometry::MultiPolygon(multi_poly) = geo.geometry() {
+                let geo_polygon = multi_poly
+                    .0
+                    .first()
+                    .ok_or(anyhow!("multipolygon was unexpectedly empty"))?;
+                if !multi_poly.0.is_empty() {
+                    // I haven't looked into why this is happening - but intuitively a census area could
+                    // include separate polygons - e.g. across bodies of water. In practice they are a
+                    // vast minority, so we naively just take the first one for now.
+                    warn!(
+                        "dropping {} polygons from census area with multiple polygons",
+                        multi_poly.0.len()
+                    );
+                }
+
+                if !geo_polygon.intersects(&geo_map_area) {
+                    debug!(
+                        "skipping polygon outside of map area. polygon: {:?}, map_area: {:?}",
+                        geo_polygon, geo_map_area
+                    );
+                    continue;
+                }
+
+                let mut geo_polygon = geo_polygon.clone();
+                geo_polygon.map_coords_inplace(|(x, y)| {
+                    let point = geom::LonLat::new(*x, *y).to_pt(bounds);
+                    (point.x(), point.y())
+                });
+                let polygon = geom::Polygon::from(geo_polygon);
+                results.push(CensusArea {
+                    polygon,
+                    population,
+                });
+            } else {
+                panic!("unexpected geometry")
+            }
+        }
+        timer.stop("reading featurs from fgb");
+
+        Ok(results)
+    }
+
+    pub fn find_data_for_map_geojson(map: &Map, timer: &mut Timer) -> anyhow::Result<Vec<CensusArea>> {
         // TODO eventually it'd be nice to lazily download the info needed. For now we expect a
         // prepared geojson file to exist in data/system/<city>/population_areas.geojson
         //
@@ -53,6 +158,8 @@ impl CensusArea {
         timer.start("parsing geojson");
         let geojson = GeoJson::from_reader(&*bytes)?;
         timer.stop("parsing geojson");
+
+
         let mut results = vec![];
         let collection = geojson::FeatureCollection::try_from(geojson)?;
 

--- a/popdat/src/lib.rs
+++ b/popdat/src/lib.rs
@@ -25,7 +25,6 @@ extern crate log;
 use rand_xorshift::XorShiftRng;
 
 use abstutil::Timer;
-use geom::Polygon;
 use geom::{Distance, Time};
 use map_model::{BuildingID, Map};
 use sim::Scenario;
@@ -41,7 +40,7 @@ mod make_person;
 /// have two overlapping areas.
 #[derive(Debug, PartialEq)]
 pub struct CensusArea {
-    pub polygon: Polygon,
+    pub polygon: geo::Polygon<f64>,
     pub population: usize,
     // TODO Not sure what goes here, whatever census data actually has that could be useful
 }

--- a/popdat/src/lib.rs
+++ b/popdat/src/lib.rs
@@ -111,7 +111,7 @@ pub fn generate_scenario(
     // operator
     let mut timer = Timer::new("generate census scenario");
     timer.start("building population areas for map");
-    let areas = CensusArea::find_data_for_map(map, &mut timer).map_err(|e| e.to_string())?;
+    let areas = CensusArea::fetch_all_for_map(map, &mut timer).map_err(|e| e.to_string())?;
     timer.stop("building population areas for map");
 
     timer.start("assigning people to houses");

--- a/popdat/src/lib.rs
+++ b/popdat/src/lib.rs
@@ -39,6 +39,7 @@ mod make_person;
 /// blocks, depending what data we find. All of the areas should roughly partition the map -- we
 /// probably don't need to guarantee we cover every single building, but we definitely shouldn't
 /// have two overlapping areas.
+#[derive(Debug, PartialEq)]
 pub struct CensusArea {
     pub polygon: Polygon,
     pub population: usize,

--- a/popdat/src/lib.rs
+++ b/popdat/src/lib.rs
@@ -102,17 +102,15 @@ impl Config {
 /// appropriate census data, and use it to produce a Scenario.
 pub fn generate_scenario(
     scenario_name: &str,
+    areas: Vec<CensusArea>,
     config: Config,
     map: &Map,
     rng: &mut XorShiftRng,
-) -> Result<Scenario, String> {
+) -> Scenario {
+    let mut timer = Timer::new("building scenario");
+
     // find_data_for_map may return an error. If so, just plumb it back to the caller using the ?
     // operator
-    let mut timer = Timer::new("generate census scenario");
-    timer.start("building population areas for map");
-    let areas = CensusArea::fetch_all_for_map(map, &mut timer).map_err(|e| e.to_string())?;
-    timer.stop("building population areas for map");
-
     timer.start("assigning people to houses");
     let people = distribute_people::assign_people_to_houses(areas, map, rng, &config);
     timer.stop("assigning people to houses");
@@ -128,5 +126,5 @@ pub fn generate_scenario(
     scenario = scenario.remove_weird_schedules();
     timer.stop("removing weird schedules");
 
-    Ok(scenario)
+    scenario
 }


### PR DESCRIPTION
Rather than prepping a cropped geojson for each city, I've hosted an agglomerated flatgeobuf file with all the areas and their populations.

Because FGB's are quite efficient, I was able to store the most granular census area: "census blocks". A tract can be several times larger than a block, so getting this more fine grained information should give us a more accurate picture of where trips terminate.

I'm actually optimistic that it would be reasonable to serve other countries population areas in the same unified fgb file, and then we don't need any client changes, per-city handling, or server side logic about which census/population data we want - we "just" need to update the hosted FGB with the new data, and this code which requests based on the WGS84 bounding box will continue to work.

Preparing the fgb is currently a manual process, but hopefully we don't need to do it often. I've included a script to show what I did for the US data which could be adapted to incorporate other countries. I imagine if it gets more use it'd make sense to turn it into something more robust than a bash script.

The reason this is a draft is because app crashes in some cities. e.g. try to run it in South Seattle due to the census geometries containing invalid polygon rings.

The crash can be avoided with this change: https://github.com/dabreegster/abstreet/commit/7e382f5021c0f7ada349bc864d8713ba9ccf2f0d

...but I assume we don't want to wholesale disable ring validation... right? 

I've verified that, at least in the cases I inspected, the error is legit. They really are self intersecting (just `touching` in the cases I inspected), but I don't think that will stop the building population assignment from working.

One approach - rather than converting to an `abstreet::geom::Polygon` we could hang on to the geo::Polygon, which won't explode when faced with an invalid ring. WDYT?