### PR TITLE
Convert a SUMO network to an ABST map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3763,7 +3763,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 name = "sumo"
 version = "0.1.0"
 dependencies = [
+ "abstio",
  "abstutil",
+ "anyhow",
  "geom",
  "map_model",
  "quick-xml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2989,6 +2989,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26aab6b48e2590e4a64d1ed808749ba06257882b461d01ca71baeb747074a6dd"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3748,6 +3758,17 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "sumo"
+version = "0.1.0"
+dependencies = [
+ "abstutil",
+ "geom",
+ "map_model",
+ "quick-xml",
+ "serde",
+]
 
 [[package]]
 name = "svg_face"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
   "popdat",
   "santa",
   "sim",
+  "sumo",
   "tests",
   "traffic_seitan",
   "traffic_signal_data",

--- a/book/src/dev/README.md
+++ b/book/src/dev/README.md
@@ -152,6 +152,7 @@ Other:
 - `fifteen_min`: a standalone tool to explore 15-minute neighborhoods
 - `popdat`: use census data to produce traffic simulation input
 - `traffic_signal_data`: manual timing overrides for some traffic signals
+- `sumo`: interoperability with SUMO
 
 ## Code conventions
 

--- a/book/src/dev/README.md
+++ b/book/src/dev/README.md
@@ -152,7 +152,7 @@ Other:
 - `fifteen_min`: a standalone tool to explore 15-minute neighborhoods
 - `popdat`: use census data to produce traffic simulation input
 - `traffic_signal_data`: manual timing overrides for some traffic signals
-- `sumo`: interoperability with SUMO
+- `sumo`: interoperability with [SUMO](https://www.eclipse.org/sumo)
 
 ## Code conventions
 

--- a/game/src/app.rs
+++ b/game/src/app.rs
@@ -672,7 +672,7 @@ impl PerMap {
                     .choose(&mut rng)
                     .and_then(|l| per_map.canonical_point(ID::Lane(l.id)))
             })
-            .expect("Can't get canonical_point of a random building or lane");
+            .unwrap_or_else(|| per_map.map.get_bounds().center());
 
         if splash {
             ctx.canvas.center_on_map_pt(rand_focus_pt);

--- a/geom/src/polyline.rs
+++ b/geom/src/polyline.rs
@@ -97,7 +97,11 @@ impl PolyLine {
         if self_width <= boundary_width || self.length() <= boundary_width + EPSILON_DIST {
             return None;
         }
-        let slice = self.exact_slice(boundary_width / 2.0, self.length() - boundary_width / 2.0);
+        // TODO exact_slice() used to work fine here, but the SUMO montlake map triggers a problem
+        // there
+        let slice = self
+            .maybe_exact_slice(boundary_width / 2.0, self.length() - boundary_width / 2.0)
+            .ok()?;
         Some(
             slice
                 .to_thick_ring(self_width - boundary_width)

--- a/map_model/src/make/mod.rs
+++ b/map_model/src/make/mod.rs
@@ -11,7 +11,7 @@ use crate::raw::{OriginalRoad, RawMap};
 use crate::{
     connectivity, osm, AccessRestrictions, Area, AreaID, AreaType, ControlStopSign,
     ControlTrafficSignal, Direction, Intersection, IntersectionID, IntersectionType, Lane, LaneID,
-    Map, MapEdits, Movement, PathConstraints, Position, Road, RoadID, Zone,
+    Map, MapEdits, Movement, PathConstraints, Position, Road, RoadID, Turn, Zone,
 };
 
 mod bridges;
@@ -359,6 +359,7 @@ impl Map {
         intersections: Vec<Intersection>,
         roads: Vec<Road>,
         lanes: Vec<Lane>,
+        turns: Vec<Turn>,
     ) -> Map {
         let mut map = Map::blank();
         map.name = name;
@@ -369,6 +370,7 @@ impl Map {
         map.intersections = intersections;
         map.roads = roads;
         map.lanes = lanes;
+        map.turns = turns.into_iter().map(|turn| (turn.id, turn)).collect();
 
         let stop_signs = map
             .intersections

--- a/map_model/src/make/mod.rs
+++ b/map_model/src/make/mod.rs
@@ -3,7 +3,8 @@
 
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
-use abstutil::{MapName, Parallelism, Tags, Timer};
+use abstio::MapName;
+use abstutil::{Parallelism, Tags, Timer};
 use geom::{Bounds, Distance, FindClosest, GPSBounds, HashablePt2D, Speed, EPSILON_DIST};
 
 use crate::pathfind::Pathfinder;

--- a/map_model/src/objects/road.rs
+++ b/map_model/src/objects/road.rs
@@ -104,7 +104,8 @@ pub struct Road {
     pub zorder: isize,
 
     /// Invariant: A road must contain at least one child
-    pub(crate) lanes_ltr: Vec<(LaneID, Direction, LaneType)>,
+    // TODO Only public for Map::import_minimal. Can we avoid this?
+    pub lanes_ltr: Vec<(LaneID, Direction, LaneType)>,
 
     /// The physical center of the road, including sidewalks, after trimming. The order implies
     /// road orientation. No edits ever change this.

--- a/sumo/Cargo.toml
+++ b/sumo/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "sumo"
+version = "0.1.0"
+authors = ["Dustin Carlino <dabreegster@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+abstutil = { path = "../abstutil" }
+geom = { path = "../geom" }
+map_model = { path = "../map_model" }
+quick-xml = { version = "0.20.0", features=["serialize"] }
+serde = "1.0.116"

--- a/sumo/Cargo.toml
+++ b/sumo/Cargo.toml
@@ -5,7 +5,9 @@ authors = ["Dustin Carlino <dabreegster@gmail.com>"]
 edition = "2018"
 
 [dependencies]
+abstio = { path = "../abstio" }
 abstutil = { path = "../abstutil" }
+anyhow = "1.0.37"
 geom = { path = "../geom" }
 map_model = { path = "../map_model" }
 quick-xml = { version = "0.20.0", features=["serialize"] }

--- a/sumo/README.md
+++ b/sumo/README.md
@@ -1,0 +1,26 @@
+# SUMO interoperability
+
+The purpose of this crate is to explore possible interactions between A/B Street
+and [SUMO](https://www.eclipse.org/sumo/). Some of the ideas:
+
+- Convert SUMO networks to ABST maps, to make use of SUMO's traffic signal
+  heuristics and junction joining
+- Convert SUMO demand to ABST scenarios, to leverage all of the existing
+  [demand generation](https://sumo.dlr.de/docs/Demand/Introduction_to_demand_modelling_in_SUMO.html)
+  techniques
+- Prototype a new SUMO frontend by gluing ABST UI code to
+  [TraCI](https://sumo.dlr.de/docs/TraCI.html)
+
+## Usage
+
+A quick SUMO primer. To convert an OSM file into a SUMO network:
+
+`netconvert --osm-files data/input/seattle/osm/montlake.osm --output.street-names -o montlake.net.xml`
+
+To convert the network into an ABST map:
+
+`cargo run --bin sumo montlake.net.xml`
+
+To view it in ABST:
+
+`cargo run --bin game -- --dev data/system/sumo/maps/montlake.bin`

--- a/sumo/README.md
+++ b/sumo/README.md
@@ -15,7 +15,7 @@ and [SUMO](https://www.eclipse.org/sumo/). Some of the ideas:
 
 A quick SUMO primer. To convert an OSM file into a SUMO network:
 
-`netconvert --osm-files data/input/seattle/osm/montlake.osm --output.street-names -o montlake.net.xml`
+`netconvert --osm-files data/input/seattle/osm/montlake.osm --output.street-names --keep-edges.components 1 -o montlake.net.xml`
 
 To convert the network into an ABST map:
 

--- a/sumo/src/lib.rs
+++ b/sumo/src/lib.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 
 use geom::{Distance, PolyLine, Polygon, Pt2D, Speed};
 
-pub use self::raw::{EdgeID, LaneID, NodeID};
+pub use self::raw::{Connection, Direction, EdgeID, LaneID, NodeID};
 
 mod normalize;
 mod raw;
@@ -14,13 +14,15 @@ mod raw;
 /// transformations:
 ///
 /// - Any unspecified edge and lane attributes are inherited from `types` or set to defaults
-/// - Edges without a `from` or `to` are filtered out
-/// - Internal edges and junctions are filtered out
+/// - Internal edges are represented separately
+/// - Internal junctions are filtered out
 /// - The Y coordinate is inverted, so that Y decreases northbound
 pub struct Network {
     pub location: raw::Location,
-    pub edges: BTreeMap<EdgeID, Edge>,
+    pub normal_edges: BTreeMap<EdgeID, Edge>,
+    pub internal_edges: BTreeMap<EdgeID, InternalEdge>,
     pub junctions: BTreeMap<NodeID, Junction>,
+    pub connections: Vec<Connection>,
 }
 
 pub struct Edge {
@@ -42,6 +44,20 @@ pub struct Lane {
     pub length: Distance,
     pub width: Distance,
     pub center_line: PolyLine,
+    pub allow: Vec<String>,
+}
+
+pub struct InternalEdge {
+    pub id: EdgeID,
+    pub lanes: Vec<InternalLane>,
+}
+
+pub struct InternalLane {
+    pub id: LaneID,
+    pub index: usize,
+    pub speed: Speed,
+    pub length: Distance,
+    pub center_line: Option<PolyLine>,
     pub allow: Vec<String>,
 }
 

--- a/sumo/src/lib.rs
+++ b/sumo/src/lib.rs
@@ -1,0 +1,55 @@
+//! This crate provides a Rust interface to different parts of the [SUMO](https://www.eclipse.org/sumo/) traffic simulator.
+
+use std::collections::BTreeMap;
+
+use geom::{Distance, PolyLine, Polygon, Pt2D, Speed};
+
+pub use self::raw::{EdgeID, LaneID, NodeID};
+
+mod normalize;
+mod raw;
+
+/// A normalized form of a SUMO
+/// [network](https://sumo.dlr.de/docs/Networks/SUMO_Road_Networks.html). A `raw::Network` is a direct representation of a .net.xml file. That's further simplified to produce this structure, which should be easier to work with. The
+/// transformations:
+///
+/// - Any unspecified edge and lane attributes are inherited from `types` or set to defaults
+/// - Edges without a `from` or `to` are filtered out
+/// - Internal edges and junctions are filtered out
+/// - The Y coordinate is inverted, so that Y decreases northbound
+pub struct Network {
+    pub location: raw::Location,
+    pub edges: BTreeMap<EdgeID, Edge>,
+    pub junctions: BTreeMap<NodeID, Junction>,
+}
+
+pub struct Edge {
+    pub id: EdgeID,
+    pub edge_type: String,
+    pub name: Option<String>,
+    pub from: NodeID,
+    pub to: NodeID,
+    pub priority: usize,
+    pub lanes: Vec<Lane>,
+    pub center_line: PolyLine,
+}
+
+pub struct Lane {
+    pub id: LaneID,
+    /// 0 is the rightmost lane
+    pub index: usize,
+    pub speed: Speed,
+    pub length: Distance,
+    pub width: Distance,
+    pub center_line: PolyLine,
+    pub allow: Vec<String>,
+}
+
+pub struct Junction {
+    pub id: NodeID,
+    pub junction_type: String,
+    pub pt: Pt2D,
+    pub incoming_lanes: Vec<LaneID>,
+    pub internal_lanes: Vec<LaneID>,
+    pub shape: Polygon,
+}

--- a/sumo/src/lib.rs
+++ b/sumo/src/lib.rs
@@ -1,10 +1,13 @@
 //! This crate provides a Rust interface to different parts of the [SUMO](https://www.eclipse.org/sumo/) traffic simulator.
 
+#[macro_use]
+extern crate anyhow;
+
 use std::collections::BTreeMap;
 
 use geom::{Distance, PolyLine, Polygon, Pt2D, Speed};
 
-pub use self::raw::{Connection, Direction, EdgeID, LaneID, NodeID};
+pub use self::raw::{Connection, Direction, EdgeID, InternalLaneID, LaneID, NodeID};
 
 mod normalize;
 mod raw;
@@ -44,21 +47,22 @@ pub struct Lane {
     pub length: Distance,
     pub width: Distance,
     pub center_line: PolyLine,
-    pub allow: Vec<String>,
+    pub allow: Vec<VehicleClass>,
 }
 
+/// See https://sumo.dlr.de/docs/Networks/SUMO_Road_Networks.html#internal_edges
 pub struct InternalEdge {
     pub id: EdgeID,
     pub lanes: Vec<InternalLane>,
 }
 
 pub struct InternalLane {
-    pub id: LaneID,
+    pub id: InternalLaneID,
     pub index: usize,
     pub speed: Speed,
     pub length: Distance,
     pub center_line: Option<PolyLine>,
-    pub allow: Vec<String>,
+    pub allow: Vec<VehicleClass>,
 }
 
 pub struct Junction {
@@ -66,6 +70,16 @@ pub struct Junction {
     pub junction_type: String,
     pub pt: Pt2D,
     pub incoming_lanes: Vec<LaneID>,
-    pub internal_lanes: Vec<LaneID>,
+    pub internal_lanes: Vec<InternalLaneID>,
     pub shape: Polygon,
+}
+
+#[derive(PartialEq)]
+pub enum VehicleClass {
+    Pedestrian,
+    Bicycle,
+    RailUrban,
+    // TODO Use all values from
+    // https://sumo.dlr.de/docs/Definition_of_Vehicles,_Vehicle_Types,_and_Routes.html#abstract_vehicle_class
+    Other(String),
 }

--- a/sumo/src/main.rs
+++ b/sumo/src/main.rs
@@ -1,0 +1,141 @@
+//! Converts a SUMO .net.xml into an A/B Street map.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use abstutil::{CmdArgs, MapName, Tags, Timer};
+use geom::Distance;
+use map_model::{
+    osm, raw, AccessRestrictions, Direction, Intersection, IntersectionID, IntersectionType, Lane,
+    LaneID, LaneType, Map, Road, RoadID,
+};
+
+use sumo::{Network, NodeID};
+
+fn main() {
+    let mut timer = Timer::new("convert SUMO network");
+    let mut args = CmdArgs::new();
+    let input = args.required_free();
+    args.done();
+
+    let network = Network::load(&input, &mut timer).unwrap();
+    let map = convert(&input, network);
+    map.save();
+}
+
+fn convert(orig_path: &str, network: Network) -> Map {
+    let mut intersections = Vec::new();
+    let mut ids_intersections: BTreeMap<NodeID, IntersectionID> = BTreeMap::new();
+    for (_, junction) in network.junctions {
+        let id = IntersectionID(intersections.len());
+        intersections.push(Intersection {
+            id,
+            polygon: junction.shape,
+            turns: BTreeSet::new(),
+            elevation: Distance::ZERO,
+            intersection_type: IntersectionType::StopSign,
+            orig_id: osm::NodeID(123),
+            incoming_lanes: Vec::new(),
+            outgoing_lanes: Vec::new(),
+            roads: BTreeSet::new(),
+        });
+        ids_intersections.insert(junction.id, id);
+    }
+    let mut roads: Vec<Road> = Vec::new();
+    let mut lanes = Vec::new();
+    for (_, edge) in network.edges {
+        let src_i = ids_intersections[&edge.from];
+        let dst_i = ids_intersections[&edge.to];
+        // SUMO has one edge in each direction, but ABST has bidirectional roads. Detect if this
+        // edge is the reverse of one we've already handled.
+        let (road_id, direction) =
+            if let Some(r) = roads.iter().find(|r| r.dst_i == src_i && r.src_i == dst_i) {
+                (r.id, Direction::Back)
+            } else {
+                (RoadID(roads.len()), Direction::Fwd)
+            };
+
+        let mut lanes_rtl: Vec<(LaneID, Direction, LaneType)> = Vec::new();
+        for lane in &edge.lanes {
+            let lane_id = LaneID(lanes.len());
+            let lane_type = if lane.allow == vec!["pedestrian".to_string()] {
+                LaneType::Sidewalk
+            } else if lane.allow == vec!["bicycle".to_string()] {
+                LaneType::Biking
+            } else if lane.allow == vec!["rail_urban".to_string()] {
+                LaneType::LightRail
+            } else {
+                LaneType::Driving
+            };
+            lanes.push(Lane {
+                id: lane_id,
+                parent: road_id,
+                lane_type,
+                lane_center_pts: lane.center_line.clone(),
+                width: lane.width,
+
+                src_i,
+                dst_i,
+
+                bus_stops: BTreeSet::new(),
+
+                driving_blackhole: false,
+                biking_blackhole: false,
+            });
+            // These seem to appear in the XML from right to left
+            lanes_rtl.push((lane_id, direction, lane_type));
+        }
+
+        if direction == Direction::Fwd {
+            // Make a new road
+            intersections[src_i.0].roads.insert(road_id);
+            intersections[dst_i.0].roads.insert(road_id);
+            let speed_limit = edge.lanes[0].speed;
+
+            let mut tags = BTreeMap::new();
+            tags.insert("id".to_string(), edge.id.0.clone());
+            if let Some(name) = &edge.name {
+                tags.insert("name".to_string(), name.clone());
+            }
+            let parts: Vec<&str> = edge.edge_type.split(".").collect();
+            // "highway.footway"
+            if parts.len() == 2 {
+                tags.insert(parts[0].to_string(), parts[1].to_string());
+            }
+            let mut lanes_ltr = lanes_rtl;
+            lanes_ltr.reverse();
+
+            roads.push(Road {
+                id: road_id,
+                osm_tags: Tags::new(tags),
+                turn_restrictions: Vec::new(),
+                complicated_turn_restrictions: Vec::new(),
+                orig_id: raw::OriginalRoad::new(123, (456, 789)),
+                speed_limit,
+                access_restrictions: AccessRestrictions::new(),
+                zorder: 0,
+
+                lanes_ltr,
+
+                center_pts: edge.center_line,
+
+                src_i,
+                dst_i,
+            });
+        } else {
+            // TODO Should we check that the attributes are the same for both directions?
+            let mut lanes_ltr = lanes_rtl;
+            lanes_ltr.extend(roads[road_id.0].lanes_ltr.clone());
+            roads[road_id.0].lanes_ltr = lanes_ltr;
+        }
+    }
+
+    Map::import_minimal(
+        // Double basename because "foo.net.xml" just becomes "foo.net"
+        MapName::new("sumo", &abstutil::basename(abstutil::basename(orig_path))),
+        network.location.converted_boundary,
+        network.location.orig_boundary,
+        intersections,
+        roads,
+        lanes,
+    )
+}

--- a/sumo/src/normalize.rs
+++ b/sumo/src/normalize.rs
@@ -1,0 +1,128 @@
+//! Transforms a `raw::Network` into a `Network` that's easier to reason about.
+
+use std::collections::BTreeMap;
+use std::error::Error;
+
+use abstutil::Timer;
+use geom::{Distance, PolyLine, Pt2D, Ring};
+
+use crate::{raw, Edge, Junction, Lane, Network};
+
+impl Network {
+    /// Reads a .net.xml file and return the normalized SUMO network.
+    pub fn load(path: &str, timer: &mut Timer) -> Result<Network, Box<dyn Error>> {
+        let raw = raw::Network::parse(path, timer)?;
+        timer.start("normalize");
+        let network = Network::from_raw(raw);
+        timer.stop("normalize");
+        Ok(network)
+    }
+
+    fn from_raw(raw: raw::Network) -> Network {
+        let mut network = Network {
+            location: raw.location,
+            edges: BTreeMap::new(),
+            junctions: BTreeMap::new(),
+        };
+
+        let types: BTreeMap<String, raw::Type> =
+            raw.types.into_iter().map(|t| (t.id.clone(), t)).collect();
+
+        for junction in raw.junctions {
+            if junction.junction_type == "internal" {
+                continue;
+            }
+            network.junctions.insert(
+                junction.id.clone(),
+                Junction {
+                    pt: junction.pt(),
+                    id: junction.id,
+                    junction_type: junction.junction_type,
+                    incoming_lanes: junction.incoming_lanes,
+                    internal_lanes: junction.internal_lanes,
+                    shape: junction.shape.unwrap(),
+                },
+            );
+        }
+
+        for edge in raw.edges {
+            if edge.function == raw::Function::Internal {
+                continue;
+            }
+            let (from, to) = match (edge.from, edge.to) {
+                (Some(from), Some(to)) => (from, to),
+                _ => {
+                    continue;
+                }
+            };
+            let template = &types[edge.edge_type.as_ref().unwrap()];
+
+            let raw_center_line = match edge.shape {
+                Some(pl) => pl,
+                None => {
+                    PolyLine::must_new(vec![network.junctions[&from].pt, network.junctions[&to].pt])
+                }
+            };
+            // TODO I tried interpreting the docs and shifting left/right by 1x or 0.5x of the total
+            // road width, but the results don't look right.
+            let center_line = match edge.spread_type {
+                raw::SpreadType::Center => raw_center_line,
+                raw::SpreadType::Right => raw_center_line,
+                raw::SpreadType::RoadCenter => raw_center_line,
+            };
+
+            let mut lanes = Vec::new();
+            for lane in edge.lanes {
+                lanes.push(Lane {
+                    id: lane.id,
+                    index: lane.index,
+                    speed: lane.speed,
+                    length: lane.length,
+                    // https://sumo.dlr.de/docs/Simulation/SublaneModel.html
+                    width: lane.width.unwrap_or(Distance::meters(3.2)),
+                    center_line: lane.shape.unwrap(),
+                    allow: lane.allow,
+                });
+            }
+
+            network.edges.insert(
+                edge.id.clone(),
+                Edge {
+                    id: edge.id,
+                    edge_type: edge.edge_type.unwrap(),
+                    name: edge.name,
+                    from,
+                    to,
+                    priority: edge.priority.unwrap_or_else(|| template.priority),
+                    lanes,
+                    center_line,
+                },
+            );
+        }
+
+        network.fix_coordinates();
+        network
+    }
+
+    fn fix_coordinates(&mut self) {
+        // I tried netconvert's --flip-y-axis option, but it makes all of the y coordinates
+        // extremely negative.
+
+        let max_y = self.location.converted_boundary.max_y;
+        let fix = |pt: &Pt2D| Pt2D::new(pt.x(), max_y - pt.y());
+
+        for junction in self.junctions.values_mut() {
+            junction.pt = fix(&junction.pt);
+            junction.shape =
+                Ring::must_new(junction.shape.points().iter().map(fix).collect()).to_polygon();
+        }
+        for edge in self.edges.values_mut() {
+            edge.center_line =
+                PolyLine::must_new(edge.center_line.points().iter().map(fix).collect());
+            for lane in &mut edge.lanes {
+                lane.center_line =
+                    PolyLine::must_new(lane.center_line.points().iter().map(fix).collect());
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is the first step exploring integration between SUMO and ABST: a tool to read a .net.xml, then write an abst map. So far, only lanes, intersections, and turns are transformed. There are problems, but the results so far are a start:
![Screenshot from 2020-12-24 14-16-03](https://user-images.githubusercontent.com/1664407/103107386-92aac780-45f2-11eb-96b4-7dd2a617782d.png)
![Screenshot from 2020-12-25 15-01-50](https://user-images.githubusercontent.com/1664407/103142983-46c75380-46c2-11eb-9afc-dd7adae3f4c6.png)
![Screenshot from 2020-12-25 15-02-04](https://user-images.githubusercontent.com/1664407/103142986-4a5ada80-46c2-11eb-944e-91a2c4d93d2c.png)

The conversion happens in 3 layers:
1) First we just deserialize a .net.xml using `quick-xml` and [serde](https://serde.rs/). No attempt to transform the network structure yet, except for massaging some of the types into `geom`.
2) Normalizing the SUMO network in a few ways. Mainly, resolving missing values by applying defaults or inheriting values from the template [types](https://sumo.dlr.de/docs/Networks/PlainXML.html#type_descriptions)
3) Transforming into an abst map. The main trick here so far is to find two SUMO edges that point opposite directions and treat them as a single bidirecional ABST road.

An incomplete list of bugs / next steps:
- The map boundary is huge and empty if you're using .osm files from the abst repo, because we use the `osmupdate` tool and it pulls in some changes from very far away. ABST trims out these disconnected pieces of the graph, but I couldn't figure out how to make `netconvert` do that
- Road center lines are wrong. Not sure how to interpret `spreadType` yet.
- Not handling internal junctions yet
- Converting connections into turns sort of works, but there are some U-turns everywhere that may be bugs
- Not handling traffic signals yet

@michaelkirk, please review at your leisure. Since this is new code that'll potentially get used by other people, I'm trying to make extra effort to keep things clean from the start. :)

SUMO folks -- @behrisch, @namdre, @RobertHilbrich -- let me know if you'd like to be looped in on these initial exploratory PRs, or if you'd prefer to wait until there are some more concrete results. Also, I have a slight question about exactly what format the `.net.xml` files produced by `netconvert` are in. It seems to be the detailed [format](https://sumo.dlr.de/docs/Networks/SUMO_Road_Networks.html), but that page doesn't document many tags, like `spreadType`, but the [PlainXML](https://sumo.dlr.de/docs/Networks/PlainXML.html) page does. Are the docs a little backwards, or am I confused?