### PR TITLE
custom buttons: checkboxes and switches

### DIFF
--- a/fifteen_min/src/find_home.rs
+++ b/fifteen_min/src/find_home.rs
@@ -30,7 +30,7 @@ impl FindHome {
             Widget::custom_row(
                 AmenityType::all()
                     .into_iter()
-                    .map(|at| Checkbox::switch(ctx, at.to_string(), None, false))
+                    .map(|at| Checkbox::switch(ctx, &at.to_string(), None, false))
                     .collect(),
             )
             .flex_wrap(ctx, Percent::int(50)),

--- a/game/src/info/person.rs
+++ b/game/src/info/person.rs
@@ -123,7 +123,7 @@ pub fn trips(
         };
         let trip = sim.trip_info(*t);
 
-        let (row_btn, hitbox) = Widget::custom_row(vec![
+        let (row_btn, _hitbox) = Widget::custom_row(vec![
             format!("Trip {} ", idx + 1)
                 .batch_text(ctx)
                 .centered_vert()
@@ -209,26 +209,26 @@ pub fn trips(
         .bg(app.cs.inner_panel)
         .to_geom(ctx, Some(0.3));
         rows.push(
-            Btn::custom(
-                row_btn.clone(),
-                row_btn.color(RewriteColor::Change(app.cs.inner_panel, app.cs.hovering)),
-                hitbox,
-                None,
-            )
-            .build(
-                ctx,
-                format!(
-                    "{} {}",
-                    if open_trips.contains_key(t) {
-                        "hide"
-                    } else {
-                        "show"
-                    },
-                    t
-                ),
-                None,
-            )
-            .margin_above(if idx == 0 { 0 } else { 16 }),
+            ctx.style()
+                .btn_primary_light()
+                .custom_batch(row_btn.clone(), ControlState::Default)
+                .custom_batch(
+                    row_btn.color(RewriteColor::Change(app.cs.inner_panel, app.cs.hovering)),
+                    ControlState::Hovered,
+                )
+                .build_widget(
+                    ctx,
+                    &format!(
+                        "{} {}",
+                        if open_trips.contains_key(t) {
+                            "hide"
+                        } else {
+                            "show"
+                        },
+                        t
+                    ),
+                )
+                .margin_above(if idx == 0 { 0 } else { 16 }),
         );
 
         if let Some(info) = maybe_info {

--- a/game/src/sandbox/speed.rs
+++ b/game/src/sandbox/speed.rs
@@ -79,7 +79,7 @@ impl SpeedControls {
                         .cs
                         .btn_plain_light()
                         .image_path("system/assets/speed/triangle.svg")
-                        .image_dims(ScreenDims::new(16.0, 22.0))
+                        .image_dims(ScreenDims::new(16.0, 26.0))
                         .bg_color(
                             app.cs.gui_style.btn_primary_light.bg_hover,
                             ControlState::Hovered,
@@ -141,7 +141,6 @@ impl SpeedControls {
                         app.cs.gui_style.btn_primary_light.bg_hover,
                         ControlState::Hovered,
                     )
-                    .font_size(18)
                     .image_dims(ScreenDims::square(20.0));
                 Widget::custom_row(vec![
                     buttons

--- a/parking_mapper/src/mapper.rs
+++ b/parking_mapper/src/mapper.rs
@@ -10,7 +10,8 @@ use map_model::{osm, RoadID};
 use osm::WayID;
 use widgetry::{
     Btn, Checkbox, Choice, Color, Drawable, EventCtx, GeomBatch, GfxCtx, HorizontalAlignment, Key,
-    Line, Menu, Outcome, Panel, State, Text, TextExt, Transition, VerticalAlignment, Widget,
+    Line, Menu, Outcome, Panel, State, StyledButtons, Text, TextExt, Transition, VerticalAlignment,
+    Widget,
 };
 
 type App = SimpleApp<()>;

--- a/santa/src/before_level.rs
+++ b/santa/src/before_level.rs
@@ -11,8 +11,9 @@ use map_gui::tools::PopupMsg;
 use map_gui::ID;
 use map_model::BuildingID;
 use widgetry::{
-    Btn, Color, Drawable, EventCtx, GeomBatch, GfxCtx, HorizontalAlignment, Key, Line, Outcome,
-    Panel, RewriteColor, State, Text, TextExt, VerticalAlignment, Widget,
+    Btn, ButtonBuilder, Color, ControlState, Drawable, EventCtx, GeomBatch, GfxCtx,
+    HorizontalAlignment, Key, Line, Outcome, Panel, RewriteColor, State, Text, TextExt,
+    VerticalAlignment, Widget,
 };
 
 use crate::buildings::{BldgState, Buildings};
@@ -249,10 +250,13 @@ fn make_vehicle_panel(ctx: &mut EventCtx, app: &App) -> Panel {
                     .padding(5)
                     .outline(2.0, Color::WHITE)
             } else {
-                let hitbox = batch.get_bounds().get_rectangle();
+                let _hitbox = batch.get_bounds().get_rectangle();
                 let normal = batch.clone().color(RewriteColor::MakeGrayscale);
                 let hovered = batch;
-                Btn::custom(normal, hovered, hitbox, None).build(ctx, name, None)
+                ButtonBuilder::new()
+                    .custom_batch(normal, ControlState::Default)
+                    .custom_batch(hovered, ControlState::Hovered)
+                    .build_widget(ctx, name)
             }
             .centered_vert(),
         );

--- a/santa/src/before_level.rs
+++ b/santa/src/before_level.rs
@@ -250,7 +250,6 @@ fn make_vehicle_panel(ctx: &mut EventCtx, app: &App) -> Panel {
                     .padding(5)
                     .outline(2.0, Color::WHITE)
             } else {
-                let _hitbox = batch.get_bounds().get_rectangle();
                 let normal = batch.clone().color(RewriteColor::MakeGrayscale);
                 let hovered = batch;
                 ButtonBuilder::new()

--- a/santa/src/music.rs
+++ b/santa/src/music.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use rodio::{Decoder, OutputStream, OutputStreamHandle, Sink};
 
 use widgetry::{
-    Btn, Checkbox, EventCtx, GfxCtx, HorizontalAlignment, Outcome, Panel, StyledButtons,
+    Checkbox, EventCtx, GfxCtx, HorizontalAlignment, Outcome, Panel, StyledButtons,
     VerticalAlignment,
 };
 

--- a/santa/src/music.rs
+++ b/santa/src/music.rs
@@ -4,7 +4,8 @@ use anyhow::Result;
 use rodio::{Decoder, OutputStream, OutputStreamHandle, Sink};
 
 use widgetry::{
-    Btn, Checkbox, EventCtx, GfxCtx, HorizontalAlignment, Outcome, Panel, VerticalAlignment,
+    Btn, Checkbox, EventCtx, GfxCtx, HorizontalAlignment, Outcome, Panel, StyledButtons,
+    VerticalAlignment,
 };
 
 // TODO Speed up when we're almost out of time, slow down when we're low on energy
@@ -109,8 +110,12 @@ impl Inner {
         let panel = Panel::new(
             Checkbox::new(
                 play_music,
-                Btn::svg_def("system/assets/tools/volume_off.svg").build(ctx, "play music", None),
-                Btn::svg_def("system/assets/tools/volume_on.svg").build(ctx, "mute music", None),
+                ctx.style()
+                    .btn_primary_light_icon("system/assets/tools/volume_off.svg")
+                    .build(ctx, "play music"),
+                ctx.style()
+                    .btn_primary_light_icon("system/assets/tools/volume_on.svg")
+                    .build(ctx, "mute music"),
             )
             .named("play music")
             .container(),

--- a/santa/src/title.rs
+++ b/santa/src/title.rs
@@ -138,7 +138,7 @@ fn unlocked_level(ctx: &mut EventCtx, app: &App, level: &Level, idx: usize) -> W
             Color::WHITE,
             ctx.style().hovering_color,
         ))
-        .build(ctx, &level.title, None)
+        .build_widget(ctx, &level.title)
 }
 
 struct Credits;

--- a/santa/src/title.rs
+++ b/santa/src/title.rs
@@ -1,8 +1,8 @@
 use geom::Percent;
 use map_gui::tools::open_browser;
 use widgetry::{
-    Btn, Color, EdgeInsets, EventCtx, GeomBatch, GfxCtx, Key, Line, Panel, RewriteColor,
-    SimpleState, State, StyledButtons, Text, TextExt, Widget,
+    Btn, ButtonBuilder, Color, ControlState, EdgeInsets, EventCtx, GeomBatch, GfxCtx, Key, Line,
+    Panel, RewriteColor, SimpleState, State, StyledButtons, Text, TextExt, Widget,
 };
 
 use crate::levels::Level;
@@ -133,11 +133,15 @@ fn locked_level(ctx: &mut EventCtx, app: &App, level: &Level, idx: usize) -> Wid
 }
 
 fn unlocked_level(ctx: &mut EventCtx, app: &App, level: &Level, idx: usize) -> Widget {
-    level_btn(ctx, app, level, idx)
-        .to_btn_custom(RewriteColor::Change(
-            Color::WHITE,
-            ctx.style().hovering_color,
-        ))
+    let normal = level_btn(ctx, app, level, idx);
+    let hovered = normal.clone().color(RewriteColor::Change(
+        Color::WHITE,
+        ctx.style().hovering_color,
+    ));
+
+    ButtonBuilder::new()
+        .custom_batch(normal, ControlState::Default)
+        .custom_batch(hovered, ControlState::Hovered)
         .build_widget(ctx, &level.title)
 }
 

--- a/widgetry/icons/checkbox.svg
+++ b/widgetry/icons/checkbox.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0V0z" fill="black"/><path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41L9 16.17z" fill="white"/></svg>

--- a/widgetry/icons/checkbox_checked.svg
+++ b/widgetry/icons/checkbox_checked.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">
+    <path d="M0 0h24v24H0V0z" fill="black"/>
+    <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41L9 16.17z" fill="white"/>
+</svg>

--- a/widgetry/icons/checkbox_unchecked.svg
+++ b/widgetry/icons/checkbox_unchecked.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">
+    <path d="M0 0h24v24H0V0z" fill="black"/>
+</svg>

--- a/widgetry/src/geom.rs
+++ b/widgetry/src/geom.rs
@@ -87,15 +87,6 @@ impl GeomBatch {
         DeferDraw::new(self)
     }
 
-    /// Turn this batch into a button.
-    #[deprecated]
-    pub fn to_btn_custom(self, rewrite: RewriteColor) -> ButtonBuilder<'static> {
-        let hovered = self.clone().color(rewrite);
-        ButtonBuilder::new()
-            .custom_batch(self, ControlState::Default)
-            .custom_batch(hovered, ControlState::Hovered)
-    }
-
     /// Compute the bounds of all polygons in this batch.
     pub fn get_bounds(&self) -> Bounds {
         let mut bounds = Bounds::new();

--- a/widgetry/src/style/buttons.rs
+++ b/widgetry/src/style/buttons.rs
@@ -272,7 +272,7 @@ fn plain_builder<'a>(color_scheme: &ButtonStyle) -> ButtonBuilder<'a> {
 
 // Captures some constants for uniform styling of icon-only buttons
 fn icon_button<'a>(builder: ButtonBuilder<'a>) -> ButtonBuilder<'a> {
-    builder.padding(8.0).image_dims(20.0)
+    builder.padding(8.0).image_dims(24.0)
 }
 
 fn back_button<'a>(builder: ButtonBuilder<'a>, title: &'a str) -> ButtonBuilder<'a> {

--- a/widgetry/src/style/buttons.rs
+++ b/widgetry/src/style/buttons.rs
@@ -73,6 +73,12 @@ pub trait StyledButtons<'a> {
     fn btn_plain_dark_icon(&self, image_path: &'a str) -> ButtonBuilder<'a> {
         icon_button(self.btn_plain_dark().image_path(image_path))
     }
+    fn btn_plain_dark_icon_text(&self, image_path: &'a str, text: &'a str) -> ButtonBuilder<'a> {
+        self.btn_plain_dark()
+            .label_text(text)
+            .image_path(image_path)
+            .image_dims(ScreenDims::square(18.0))
+    }
 
     fn btn_plain_light(&self) -> ButtonBuilder<'a>;
     fn btn_plain_light_text(&self, text: &'a str) -> ButtonBuilder<'a> {
@@ -80,6 +86,12 @@ pub trait StyledButtons<'a> {
     }
     fn btn_plain_light_icon(&self, image_path: &'a str) -> ButtonBuilder<'a> {
         icon_button(self.btn_plain_light().image_path(image_path))
+    }
+    fn btn_plain_light_icon_text(&self, image_path: &'a str, text: &'a str) -> ButtonBuilder<'a> {
+        self.btn_plain_light()
+            .label_text(text)
+            .image_path(image_path)
+            .image_dims(ScreenDims::square(18.0))
     }
 
     fn btn_plain_destructive(&self) -> ButtonBuilder<'a>;

--- a/widgetry/src/widgets/button.rs
+++ b/widgetry/src/widgets/button.rs
@@ -259,22 +259,6 @@ impl Btn {
             maybe_outline: Some(outline),
         }
     }
-
-    #[deprecated]
-    pub fn custom(
-        normal: GeomBatch,
-        hovered: GeomBatch,
-        hitbox: Polygon,
-        outline: Option<(f64, Color)>,
-    ) -> BtnBuilder {
-        BtnBuilder::Custom {
-            normal,
-            hovered,
-            hitbox,
-            maybe_tooltip: None,
-            maybe_outline: outline,
-        }
-    }
 }
 
 #[derive(Clone, Debug, Default)]

--- a/widgetry/src/widgets/checkbox.rs
+++ b/widgetry/src/widgets/checkbox.rs
@@ -1,7 +1,6 @@
 use crate::{
-    Btn, Button, Color, ControlState, EventCtx, GeomBatch, GfxCtx, Line, MultiKey, Outcome,
-    RewriteColor, ScreenDims, ScreenPt, StyledButtons, Text, TextExt, TextSpan, Widget, WidgetImpl,
-    WidgetOutput,
+    Button, Color, ControlState, EdgeInsets, EventCtx, GfxCtx, MultiKey, Outcome, RewriteColor,
+    ScreenDims, ScreenPt, StyledButtons, Text, TextSpan, Widget, WidgetImpl, WidgetOutput,
 };
 
 pub struct Checkbox {
@@ -11,204 +10,194 @@ pub struct Checkbox {
 }
 
 impl Checkbox {
-    // TODO Not typesafe! Gotta pass a button. Also, make sure to give an ID.
-    pub fn new(enabled: bool, false_btn: Widget, true_btn: Widget) -> Widget {
+    pub fn new(enabled: bool, false_btn: Button, true_btn: Button) -> Widget {
         if enabled {
             Widget::new(Box::new(Checkbox {
                 enabled,
-                btn: true_btn.take_btn(),
-                other_btn: false_btn.take_btn(),
+                btn: true_btn,
+                other_btn: false_btn,
             }))
         } else {
             Widget::new(Box::new(Checkbox {
                 enabled,
-                btn: false_btn.take_btn(),
-                other_btn: true_btn.take_btn(),
+                btn: false_btn,
+                other_btn: true_btn,
             }))
         }
     }
 
-    pub fn switch<I: Into<String>, MK: Into<Option<MultiKey>>>(
+    pub fn switch<MK: Into<Option<MultiKey>>>(
         ctx: &EventCtx,
-        label: I,
+        label: &str,
         hotkey: MK,
         enabled: bool,
     ) -> Widget {
-        let label = label.into();
-        let (off, hitbox) = Widget::row(vec![
-            GeomBatch::from_svg_contents(include_bytes!("../../icons/toggle_off.svg").to_vec())
-                .batch()
-                .centered_vert(),
-            label.clone().batch_text(ctx),
-        ])
-        .to_geom(ctx, None);
-        let (on, _) = Widget::row(vec![
-            GeomBatch::from_svg_contents(include_bytes!("../../icons/toggle_on.svg").to_vec())
-                .batch()
-                .centered_vert(),
-            label.clone().batch_text(ctx),
-        ])
-        .to_geom(ctx, None);
+        let mut buttons = ctx
+            .style()
+            .btn_plain_light_text(label)
+            .image_color(RewriteColor::NoOp, ControlState::Default);
 
-        let hotkey = hotkey.into();
+        if let Some(hotkey) = hotkey.into() {
+            buttons = buttons.hotkey(hotkey);
+        }
+
+        let off_button = buttons
+            .clone()
+            .image_path("../widgetry/icons/toggle_off.svg")
+            .build(ctx, label);
+        let on_button = buttons
+            .image_path("../widgetry/icons/toggle_on.svg")
+            .build(ctx, label);
+
+        Checkbox::new(enabled, off_button, on_button).named(label)
+    }
+
+    pub fn checkbox<MK: Into<Option<MultiKey>>>(
+        ctx: &EventCtx,
+        label: &str,
+        hotkey: MK,
+        enabled: bool,
+    ) -> Widget {
+        let mut buttons = ctx
+            .style()
+            .btn_plain_light()
+            .image_color(
+                RewriteColor::Change(Color::BLACK, ctx.style().btn_primary_light.bg),
+                ControlState::Default,
+            )
+            .image_color(
+                RewriteColor::Change(Color::BLACK, ctx.style().btn_primary_light.bg_hover),
+                ControlState::Hovered,
+            )
+            .image_color(
+                RewriteColor::Change(Color::BLACK, ctx.style().btn_primary_light.bg_disabled),
+                ControlState::Disabled,
+            )
+            .label_text(label)
+            .padding(4.0);
+
+        if let Some(hotkey) = hotkey.into() {
+            buttons = buttons.hotkey(hotkey);
+        }
+
+        let false_btn = buttons
+            .clone()
+            .image_path("../widgetry/icons/checkbox_unchecked.svg");
+        let true_btn = buttons.image_path("../widgetry/icons/checkbox_checked.svg");
+
         Checkbox::new(
             enabled,
-            Btn::custom(
-                off.clone(),
-                off.color(RewriteColor::Change(
-                    Color::hex("#F2F2F2"),
-                    ctx.style().hovering_color,
-                )),
-                hitbox.clone(),
-                None,
-            )
-            .build(ctx, &label, hotkey.clone()),
-            Btn::custom(
-                on.clone(),
-                on.color(RewriteColor::Change(
-                    Color::hex("#F2F2F2"),
-                    ctx.style().hovering_color,
-                )),
-                hitbox,
-                None,
-            )
-            .build(ctx, &label, hotkey),
+            false_btn.build(ctx, label),
+            true_btn.build(ctx, label),
         )
         .named(label)
     }
 
-    pub fn checkbox<I: Into<String>, MK: Into<Option<MultiKey>>>(
+    pub fn custom_checkbox<MK: Into<Option<MultiKey>>>(
         ctx: &EventCtx,
-        label: I,
-        hotkey: MK,
-        enabled: bool,
-    ) -> Widget {
-        let label = label.into();
-        let hotkey = hotkey.into();
-        Checkbox::new(
-            enabled,
-            Btn::text_fg(format!("[ ] {}", label)).build(ctx, &label, hotkey.clone()),
-            Btn::text_fg(format!("[X] {}", label)).build(ctx, &label, hotkey),
-        )
-        .outline(ctx.style().outline_thickness, ctx.style().outline_color)
-        .named(label)
-    }
-
-    pub fn custom_checkbox<I: Into<String>, MK: Into<Option<MultiKey>>>(
-        ctx: &EventCtx,
-        label: I,
+        action: &str,
         spans: Vec<TextSpan>,
         hotkey: MK,
         enabled: bool,
     ) -> Widget {
-        let label = label.into();
-        // TODO: get an svg checkbox! and use a image+text button
-        let mut off = vec![Line("[ ] ")];
-        let mut on = vec![Line("[X] ")];
-        off.extend(spans.clone());
-        on.extend(spans);
+        let mut buttons = ctx
+            .style()
+            .btn_plain_light()
+            .image_color(RewriteColor::NoOp, ControlState::Default)
+            .label_styled_text(Text::from_all(spans), ControlState::Default)
+            .padding(4.0);
 
-        let mut button = ctx.style().btn_secondary_light();
         if let Some(hotkey) = hotkey.into() {
-            button = button.hotkey(hotkey);
+            buttons = buttons.hotkey(hotkey);
         }
+
+        let false_btn = buttons
+            .clone()
+            .image_path("../widgetry/icons/checkbox_unchecked.svg");
+        let true_btn = buttons.image_path("../widgetry/icons/checkbox_checked.svg");
 
         Checkbox::new(
             enabled,
-            button
-                .clone()
-                .label_styled_text(Text::from_all(off), ControlState::Default)
-                .build_widget(ctx, &label),
-            button
-                .label_styled_text(Text::from_all(on), ControlState::Default)
-                .build_widget(ctx, &label),
+            false_btn.build(ctx, action),
+            true_btn.build(ctx, action),
         )
-        .named(label)
+        .named(action)
     }
 
     pub fn colored(ctx: &EventCtx, label: &str, color: Color, enabled: bool) -> Widget {
-        let (off, hitbox) = Widget::row(vec![
-            GeomBatch::from_svg_contents(include_bytes!("../../icons/checkbox.svg").to_vec())
-                .color(RewriteColor::ChangeAll(color.alpha(0.3)))
-                .batch()
-                .centered_vert(),
-            label.batch_text(ctx),
-        ])
-        .to_geom(ctx, None);
-        let (on, _) = Widget::row(vec![
-            GeomBatch::from_svg_contents(include_bytes!("../../icons/checkbox.svg").to_vec())
-                .color(RewriteColor::Change(Color::BLACK, color))
-                .batch()
-                .centered_vert(),
-            label.batch_text(ctx),
-        ])
-        .to_geom(ctx, None);
+        let buttons = ctx.style().btn_plain_light().label_text(label).padding(4.0);
+
+        let false_btn = buttons
+            .clone()
+            .image_path("../widgetry/icons/checkbox_unchecked.svg")
+            .image_color(
+                RewriteColor::Change(Color::BLACK, color.alpha(0.3)),
+                ControlState::Default,
+            );
+
+        let true_btn = buttons
+            .image_path("../widgetry/icons/checkbox_checked.svg")
+            .image_color(
+                RewriteColor::Change(Color::BLACK, color),
+                ControlState::Default,
+            );
 
         Checkbox::new(
             enabled,
-            Btn::custom(
-                off.clone(),
-                off.color(RewriteColor::Change(
-                    Color::WHITE,
-                    ctx.style().hovering_color,
-                )),
-                hitbox.clone(),
-                None,
-            )
-            .build(ctx, label, None),
-            Btn::custom(
-                on.clone(),
-                on.color(RewriteColor::Change(
-                    Color::WHITE,
-                    ctx.style().hovering_color,
-                )),
-                hitbox,
-                None,
-            )
-            .build(ctx, label, None),
+            false_btn.build(ctx, label),
+            true_btn.build(ctx, label),
         )
         .named(label)
     }
 
     // TODO These should actually be radio buttons
-    pub fn toggle<I: Into<String>, MK: Into<Option<MultiKey>>>(
+    pub fn toggle<MK: Into<Option<MultiKey>>>(
         ctx: &EventCtx,
-        label: I,
-        left_label: I,
-        right_label: I,
+        label: &str,
+        left_label: &str,
+        right_label: &str,
         hotkey: MK,
         enabled: bool,
     ) -> Widget {
-        let left_label = left_label.into();
-        let right_label = right_label.into();
-        let hotkey = hotkey.into();
-        let right =
-            GeomBatch::from_svg_contents(include_bytes!("../../icons/toggle_right.svg").to_vec());
-        let left =
-            GeomBatch::from_svg_contents(include_bytes!("../../icons/toggle_left.svg").to_vec());
-        let hitbox = right.get_bounds().get_rectangle();
+        let mut toggle_left_button = ctx
+            .style()
+            .btn_plain_light_icon("../widgetry/icons/toggle_left.svg")
+            .image_dims(ScreenDims::new(40.0, 40.0))
+            .padding(4)
+            .image_color(RewriteColor::NoOp, ControlState::Default);
 
+        if let Some(hotkey) = hotkey.into() {
+            toggle_left_button = toggle_left_button.hotkey(hotkey);
+        }
+
+        let toggle_right_button = toggle_left_button
+            .clone()
+            .image_path("../widgetry/icons/toggle_right.svg");
+
+        let left_text_button = ctx
+            .style()
+            .btn_plain_light_text(left_label)
+            // Cheat vertical padding to align with switch
+            .padding(EdgeInsets {
+                left: 2.0,
+                right: 2.0,
+                top: 8.0,
+                bottom: 14.0,
+            })
+            // TODO: make these clickable. Currently they would explode due to re-use of an action
+            .disabled()
+            .label_color(ctx.style().btn_secondary_light.fg, ControlState::Disabled);
+        let right_text_button = left_text_button.clone().label_text(right_label);
         Widget::row(vec![
-            left_label.clone().draw_text(ctx),
+            left_text_button.build_def(ctx).centered_vert(),
             Checkbox::new(
                 enabled,
-                Btn::custom(
-                    right.clone(),
-                    right.color(RewriteColor::ChangeAll(ctx.style().hovering_color)),
-                    hitbox.clone(),
-                    None,
-                )
-                .build(ctx, left_label, hotkey.clone()),
-                Btn::custom(
-                    left.clone(),
-                    left.color(RewriteColor::ChangeAll(ctx.style().hovering_color)),
-                    hitbox,
-                    None,
-                )
-                .build(ctx, right_label.clone(), hotkey),
+                toggle_right_button.build(ctx, right_label),
+                toggle_left_button.build(ctx, left_label),
             )
-            .named(label),
-            right_label.draw_text(ctx),
+            .named(label)
+            .centered_vert(),
+            right_text_button.build_def(ctx).centered_vert(),
         ])
     }
 }

--- a/widgetry/src/widgets/dropdown.rs
+++ b/widgetry/src/widgets/dropdown.rs
@@ -183,8 +183,8 @@ fn make_btn(ctx: &EventCtx, label: &str, tooltip: &str, is_persisten_split: bool
         // and it's front and center - we'll notice if something breaks.
         builder = builder
             .padding(EdgeInsets {
-                top: 13.0,
-                bottom: 13.0,
+                top: 15.0,
+                bottom: 15.0,
                 left: 8.0,
                 right: 8.0,
             })

--- a/widgetry/src/widgets/mod.rs
+++ b/widgetry/src/widgets/mod.rs
@@ -724,9 +724,6 @@ impl Widget {
         }
     }
 
-    pub(crate) fn take_btn(self) -> Button {
-        *self.widget.downcast::<Button>().ok().unwrap()
-    }
     pub(crate) fn take_menu<T: 'static + Clone>(self) -> Menu<T> {
         *self.widget.downcast::<Menu<T>>().ok().unwrap()
     }

--- a/widgetry/src/widgets/persistent_split.rs
+++ b/widgetry/src/widgets/persistent_split.rs
@@ -72,7 +72,6 @@ fn button_builder<'a>(ctx: &EventCtx) -> ButtonBuilder<'a> {
     use crate::{ControlState, StyledButtons};
     ctx.style()
         .btn_primary_light()
-        .font_size(18)
         .outline(0.0, Color::CLEAR, ControlState::Default)
 }
 

--- a/widgetry/src/widgets/table.rs
+++ b/widgetry/src/widgets/table.rs
@@ -1,7 +1,10 @@
 use abstutil::prettyprint_usize;
 use geom::Polygon;
 
-use crate::{Btn, Color, EventCtx, GeomBatch, Key, Line, Panel, Text, TextExt, Widget};
+use crate::{
+    Btn, Color, ControlState, EventCtx, GeomBatch, Key, Line, Panel, StyledButtons, Text, TextExt,
+    Widget,
+};
 
 const ROWS: usize = 8;
 
@@ -260,9 +263,12 @@ fn make_table(
         hovered.append(batch.clone());
 
         col.push(
-            Btn::custom(batch, hovered, rect, None)
+            ctx.style()
+                .btn_plain_light()
+                .custom_batch(batch, ControlState::Default)
+                .custom_batch(hovered, ControlState::Hovered)
                 .no_tooltip()
-                .build(ctx, label, None),
+                .build_widget(ctx, &label),
         );
     }
 

--- a/widgetry_demo/src/lib.rs
+++ b/widgetry_demo/src/lib.rs
@@ -378,11 +378,11 @@ fn make_controls(ctx: &mut EventCtx) -> Panel {
                 ctx.style()
                     .btn_primary_light_text("Pause")
                     .hotkey(Key::Space)
-                    .build_widget(ctx, "pause the stopwatch"),
+                    .build(ctx, "pause the stopwatch"),
                 ctx.style()
                     .btn_primary_light_text("Resume")
                     .hotkey(Key::Space)
-                    .build_widget(ctx, "resume the stopwatch"),
+                    .build(ctx, "resume the stopwatch"),
             )
             .named("paused"),
             PersistentSplit::widget(

--- a/widgetry_demo/src/lib.rs
+++ b/widgetry_demo/src/lib.rs
@@ -361,6 +361,22 @@ fn make_controls(ctx: &mut EventCtx) -> Panel {
                     .build_widget(ctx, "btn_secondary_light_icon_text"),
             ]),
         ]),
+        Text::from(
+            Line("Controls should be same height")
+                .big_heading_styled()
+                .size(18),
+        )
+        .draw(ctx),
+        Widget::row(vec![
+            btn.btn_primary_light_icon("system/assets/tools/layers.svg")
+                .build_widget(ctx, "btn_height_icon"),
+            btn.btn_primary_light_text("text")
+                .build_widget(ctx, "btn_height_text"),
+            btn.btn_secondary_light_icon_text("system/assets/tools/layers.svg", "icon+text")
+                .build_widget(ctx, "btn_height_icon_text"),
+            btn.btn_popup_light("popup")
+                .build_widget(ctx, "btn_height_popup"),
+        ]),
         Text::from(Line("Spinner").big_heading_styled().size(18)).draw(ctx),
         widgetry::Spinner::new(ctx, (0, 11), 1),
         Widget::row(vec![


### PR DESCRIPTION
![switches_2 mov](https://user-images.githubusercontent.com/217057/105256891-4187e800-5b4c-11eb-9bed-67f882d6020c.gif)
<img width="290" alt="switches_1" src="https://user-images.githubusercontent.com/217057/105256893-42b91500-5b4c-11eb-8d7b-83370da0398d.png">

A little finesse was required to update these button-based controls.

I'm super stoked to have actual checkboxes instead of the `[x]`
![checkbox_1 mov](https://user-images.githubusercontent.com/217057/105256885-3fbe2480-5b4c-11eb-8849-ee0d9133f3c1.gif)
