### PR TITLE
Label "Pedestrian" -> "Walk" for reasonable panel width

### DIFF
--- a/map_gui/src/render/agents.rs
+++ b/map_gui/src/render/agents.rs
@@ -212,7 +212,7 @@ impl UnzoomedAgents {
             Checkbox::colored(ctx, "Car", self.car_color, self.cars).margin_right(24),
             Checkbox::colored(ctx, "Bike", self.bike_color, self.bikes).margin_right(24),
             Checkbox::colored(ctx, "Bus", self.bus_color, self.buses_and_trains).margin_right(24),
-            Checkbox::colored(ctx, "Pedestrian", self.ped_color, self.peds).margin_right(8),
+            Checkbox::colored(ctx, "Walk", self.ped_color, self.peds).margin_right(8),
         ])
     }
 
@@ -221,7 +221,7 @@ impl UnzoomedAgents {
             Checkbox::colored(ctx, "Car", self.car_color, self.cars),
             Checkbox::colored(ctx, "Bike", self.bike_color, self.bikes),
             Checkbox::colored(ctx, "Bus", self.bus_color, self.buses_and_trains),
-            Checkbox::colored(ctx, "Pedestrian", self.ped_color, self.peds),
+            Checkbox::colored(ctx, "Walk", self.ped_color, self.peds),
         ])
     }
 
@@ -229,6 +229,6 @@ impl UnzoomedAgents {
         self.cars = panel.is_checked("Car");
         self.bikes = panel.is_checked("Bike");
         self.buses_and_trains = panel.is_checked("Bus");
-        self.peds = panel.is_checked("Pedestrian");
+        self.peds = panel.is_checked("Walk");
     }
 }


### PR DESCRIPTION
Not 100% ideal because we're using a verb for this mode and a noun for the others (bike,car,bus), but I think it's not that awkward linguistically - I think it's worth it for the tighter panel layout.

**before**
<img width="591" alt="Screen Shot 2021-01-24 at 10 15 57 AM" src="https://user-images.githubusercontent.com/217057/105636253-290a1d00-5e2d-11eb-9b90-3004df83fa8d.png">

**after**

<img width="546" alt="Screen Shot 2021-01-24 at 10 14 32 AM" src="https://user-images.githubusercontent.com/217057/105636221-fbbd6f00-5e2c-11eb-9abe-9a00adf4a4e5.png">

**alternatively** we could shrink the text size, but it's nice to avoid one-off font tweaks.