### PR TITLE
better hotkey contrast, visible stroke around checkboxes for dark theme

### DIFF
--- a/widgetry/icons/checkbox_no_border_checked.svg
+++ b/widgetry/icons/checkbox_no_border_checked.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">
-    <rect x="0" y="0" width="24" height="24" stroke-width="2" stroke="white" fill="black"></rect>
+    <rect x="0" y="0" width="24" height="24" fill="black"></rect>
     <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41L9 16.17z" fill="white"/>
 </svg>

--- a/widgetry/icons/checkbox_no_border_unchecked.svg
+++ b/widgetry/icons/checkbox_no_border_unchecked.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">
+    <rect x="0" y="0" width="24" height="24" fill="black"></rect>
+</svg>

--- a/widgetry/icons/checkbox_unchecked.svg
+++ b/widgetry/icons/checkbox_unchecked.svg
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">
-    <path d="M0 0h24v24H0V0z" fill="black"/>
+    <rect x="0" y="0" width="24" height="24" stroke-width="2" stroke="white" fill="black"></rect>
 </svg>

--- a/widgetry/src/style/buttons.rs
+++ b/widgetry/src/style/buttons.rs
@@ -278,7 +278,7 @@ impl<'a> Style {
     fn btn_hotkey(&self, button_style: &ButtonStyle, label: &str, key: Key) -> ButtonBuilder<'a> {
         let default = {
             let mut txt = Text::new();
-            let key_txt = Line(key.describe()).fg(self.hotkey_color);
+            let key_txt = Line(key.describe()).fg(button_style.fg_hotkey);
             txt.append(key_txt);
             let label_text = Line(format!(" - {}", label)).fg(button_style.fg);
             txt.append(label_text);
@@ -287,7 +287,7 @@ impl<'a> Style {
 
         let disabled = {
             let mut txt = Text::new();
-            let key_txt = Line(key.describe()).fg(self.hotkey_color.alpha(0.3));
+            let key_txt = Line(key.describe()).fg(button_style.fg_hotkey.alpha(0.3));
             txt.append(key_txt);
             let label_text = Line(format!(" - {}", label)).fg(button_style.fg_disabled);
             txt.append(label_text);

--- a/widgetry/src/style/mod.rs
+++ b/widgetry/src/style/mod.rs
@@ -22,6 +22,7 @@ pub struct Style {
 pub struct ButtonStyle {
     pub fg: Color,
     pub fg_disabled: Color,
+    pub fg_hotkey: Color,
     pub outline: Color,
     pub bg: Color,
     pub bg_hover: Color,
@@ -42,6 +43,7 @@ impl Style {
             btn_solid_dark: ButtonStyle {
                 fg: hex("#4C4C4C"),
                 fg_disabled: hex("#4C4C4C").alpha(0.3),
+                fg_hotkey: hex("#EE702E"),
                 bg: Color::WHITE.alpha(0.8),
                 bg_hover: Color::WHITE,
                 bg_disabled: Color::grey(0.6),
@@ -50,6 +52,7 @@ impl Style {
             btn_outline_dark: ButtonStyle {
                 fg: hex("#4C4C4C"),
                 fg_disabled: hex("#4C4C4C").alpha(0.3),
+                fg_hotkey: hex("#EE702E"),
                 bg: Color::CLEAR,
                 bg_hover: hex("#4C4C4C").alpha(0.1),
                 bg_disabled: Color::grey(0.8),
@@ -58,6 +61,7 @@ impl Style {
             btn_solid_light: ButtonStyle {
                 fg: hex("#F2F2F2"),
                 fg_disabled: hex("#F2F2F2").alpha(0.3),
+                fg_hotkey: Color::GREEN,
                 bg: hex("#003046").alpha(0.8),
                 bg_hover: hex("#003046"),
                 bg_disabled: Color::grey(0.1),
@@ -66,6 +70,7 @@ impl Style {
             btn_outline_light: ButtonStyle {
                 fg: hex("#F2F2F2"),
                 fg_disabled: hex("#F2F2F2").alpha(0.3),
+                fg_hotkey: Color::GREEN,
                 bg: Color::CLEAR,
                 bg_hover: hex("#F2F2F2").alpha(0.1),
                 bg_disabled: Color::grey(0.5),
@@ -74,6 +79,7 @@ impl Style {
             btn_solid_destructive: ButtonStyle {
                 fg: hex("#F2F2F2"),
                 fg_disabled: hex("#F2F2F2").alpha(0.3),
+                fg_hotkey: Color::GREEN,
                 bg: hex("#FF5E5E").alpha(0.8),
                 bg_hover: hex("#FF5E5E"),
                 bg_disabled: Color::grey(0.1),
@@ -82,6 +88,7 @@ impl Style {
             btn_outline_destructive: ButtonStyle {
                 fg: hex("#FF5E5E"),
                 fg_disabled: hex("#FF5E5E").alpha(0.3),
+                fg_hotkey: Color::GREEN,
                 bg: Color::CLEAR,
                 bg_hover: hex("#FF5E5E").alpha(0.1),
                 bg_disabled: Color::grey(0.1),

--- a/widgetry/src/widgets/checkbox.rs
+++ b/widgetry/src/widgets/checkbox.rs
@@ -59,9 +59,11 @@ impl Checkbox {
         hotkey: MK,
         enabled: bool,
     ) -> Widget {
-        let mut buttons = ctx
+        let mut false_btn = ctx
             .style()
-            .btn_plain_light()
+            .btn_plain_light_icon_bytes(include_labeled_bytes!(
+                "../../icons/checkbox_unchecked.svg"
+            ))
             .image_color(
                 RewriteColor::Change(Color::BLACK, ctx.style().btn_solid_light.bg),
                 ControlState::Default,
@@ -74,18 +76,15 @@ impl Checkbox {
                 RewriteColor::Change(Color::BLACK, ctx.style().btn_solid_light.bg_disabled),
                 ControlState::Disabled,
             )
-            .label_text(label)
-            .padding(4.0);
+            .label_text(label);
 
         if let Some(hotkey) = hotkey.into() {
-            buttons = buttons.hotkey(hotkey);
+            false_btn = false_btn.hotkey(hotkey);
         }
 
-        let false_btn = buttons
+        let true_btn = false_btn
             .clone()
-            .image_bytes(include_labeled_bytes!("../../icons/checkbox_unchecked.svg"));
-        let true_btn =
-            buttons.image_bytes(include_labeled_bytes!("../../icons/checkbox_checked.svg"));
+            .image_bytes(include_labeled_bytes!("../../icons/checkbox_checked.svg"));
 
         Checkbox::new(
             enabled,
@@ -102,9 +101,11 @@ impl Checkbox {
         hotkey: MK,
         enabled: bool,
     ) -> Widget {
-        let mut buttons = ctx
+        let mut false_btn = ctx
             .style()
-            .btn_plain_light()
+            .btn_plain_light_icon_bytes(include_labeled_bytes!(
+                "../../icons/checkbox_unchecked.svg"
+            ))
             .image_color(
                 RewriteColor::Change(Color::BLACK, ctx.style().btn_solid_light.bg),
                 ControlState::Default,
@@ -117,18 +118,15 @@ impl Checkbox {
                 RewriteColor::Change(Color::BLACK, ctx.style().btn_solid_light.bg_disabled),
                 ControlState::Disabled,
             )
-            .label_styled_text(Text::from_all(spans), ControlState::Default)
-            .padding(4.0);
+            .label_styled_text(Text::from_all(spans), ControlState::Default);
 
         if let Some(hotkey) = hotkey.into() {
-            buttons = buttons.hotkey(hotkey);
+            false_btn = false_btn.hotkey(hotkey);
         }
 
-        let false_btn = buttons
+        let true_btn = false_btn
             .clone()
-            .image_bytes(include_labeled_bytes!("../../icons/checkbox_unchecked.svg"));
-        let true_btn =
-            buttons.image_bytes(include_labeled_bytes!("../../icons/checkbox_checked.svg"));
+            .image_bytes(include_labeled_bytes!("../../icons/checkbox_checked.svg"));
 
         Checkbox::new(
             enabled,
@@ -143,14 +141,18 @@ impl Checkbox {
 
         let false_btn = buttons
             .clone()
-            .image_bytes(include_labeled_bytes!("../../icons/checkbox_unchecked.svg"))
+            .image_bytes(include_labeled_bytes!(
+                "../../icons/checkbox_no_border_unchecked.svg"
+            ))
             .image_color(
                 RewriteColor::Change(Color::BLACK, color.alpha(0.3)),
                 ControlState::Default,
             );
 
         let true_btn = buttons
-            .image_bytes(include_labeled_bytes!("../../icons/checkbox_checked.svg"))
+            .image_bytes(include_labeled_bytes!(
+                "../../icons/checkbox_no_border_checked.svg"
+            ))
             .image_color(
                 RewriteColor::Change(Color::BLACK, color),
                 ControlState::Default,

--- a/widgetry_demo/src/lib.rs
+++ b/widgetry_demo/src/lib.rs
@@ -504,6 +504,11 @@ fn make_controls(ctx: &mut EventCtx) -> Panel {
                         .map(|_| widgetry::Spinner::new(ctx, (0, 11), 1))
                         .collect::<Vec<_>>(),
                 ),
+                Widget::col(
+                    (0..row_height)
+                        .map(|_| widgetry::Checkbox::checkbox(ctx, "checkbox", None, true))
+                        .collect::<Vec<_>>(),
+                ),
             ])
         },
     ])) // end panel


### PR DESCRIPTION
Slightly better contrast for hotkeys in dark mode:
<img width="523" alt="Screen Shot 2021-01-24 at 11 26 07 AM" src="https://user-images.githubusercontent.com/217057/105638187-f49b5e80-5e36-11eb-9952-e3a641d589c9.png">

Add stroke to checkboxes:
**before**
<img width="618" alt="Screen Shot 2021-01-24 at 11 23 48 AM" src="https://user-images.githubusercontent.com/217057/105638273-67a4d500-5e37-11eb-8395-a2afbcd84e53.png">

**after**
<img width="538" alt="Screen Shot 2021-01-24 at 10 57 04 AM" src="https://user-images.githubusercontent.com/217057/105638272-670c3e80-5e37-11eb-9cd9-7863053570a1.png">


I left the colored checkboxes without a stroke, since it was unnecessary, and felt noisy:

<img width="209" alt="Screen Shot 2021-01-24 at 10 56 56 AM" src="https://user-images.githubusercontent.com/217057/105638248-40e69e80-5e37-11eb-965d-0905a308a937.png">
