### PR TITLE
use "disabled" rather than draw_svg_transform

### DIFF
--- a/game/src/devtools/story.rs
+++ b/game/src/devtools/story.rs
@@ -324,42 +324,21 @@ fn make_panel(ctx: &mut EventCtx, story: &StoryMap, mode: &Mode, dirty: bool) ->
             ctx.style().btn_close_widget(ctx),
         ]),
         Widget::row(vec![
-            if let Mode::PlacingMarker = mode {
-                Widget::draw_svg_transform(
-                    ctx,
-                    "system/assets/timeline/goal_pos.svg",
-                    RewriteColor::Change(Color::hex("#5B5B5B"), Color::hex("#4CA7E9")),
-                )
-            } else {
-                ctx.style()
-                    .btn_plain_light_icon("system/assets/timeline/goal_pos.svg")
-                    .hotkey(Key::M)
-                    .build_widget(ctx, "new marker")
-            },
-            if let Mode::View = mode {
-                Widget::draw_svg_transform(
-                    ctx,
-                    "system/assets/tools/pan.svg",
-                    RewriteColor::ChangeAll(Color::hex("#4CA7E9")),
-                )
-            } else {
-                ctx.style()
-                    .btn_plain_light_icon("system/assets/tools/pan.svg")
-                    .hotkey(Key::Escape)
-                    .build_widget(ctx, "pan")
-            },
-            match mode {
-                Mode::Freehand(_) => Widget::draw_svg_transform(
-                    ctx,
-                    "system/assets/tools/select.svg",
-                    RewriteColor::ChangeAll(Color::hex("#4CA7E9")),
-                ),
-                _ => ctx
-                    .style()
-                    .btn_plain_light_icon("system/assets/tools/select.svg")
-                    .hotkey(Key::P)
-                    .build_widget(ctx, "draw freehand"),
-            },
+            ctx.style()
+                .btn_plain_light_icon("system/assets/timeline/goal_pos.svg")
+                .disabled(matches!(mode, Mode::PlacingMarker))
+                .hotkey(Key::M)
+                .build_widget(ctx, "new marker"),
+            ctx.style()
+                .btn_plain_light_icon("system/assets/tools/pan.svg")
+                .disabled(matches!(mode, Mode::View))
+                .hotkey(Key::Escape)
+                .build_widget(ctx, "pan"),
+            ctx.style()
+                .btn_plain_light_icon("system/assets/tools/select.svg")
+                .disabled(matches!(mode, Mode::Freehand(_)))
+                .hotkey(Key::P)
+                .build_widget(ctx, "draw freehand"),
         ])
         .evenly_spaced(),
     ]))

--- a/game/src/edit/traffic_signals/mod.rs
+++ b/game/src/edit/traffic_signals/mod.rs
@@ -502,33 +502,17 @@ fn make_top_panel(ctx: &mut EventCtx, app: &App, can_undo: bool, can_redo: bool)
             .btn_solid_dark_text("Preview")
             .hotkey(lctrl(Key::P))
             .build_def(ctx),
-        (if can_undo {
-            ctx.style()
-                .btn_plain_light_icon("system/assets/tools/undo.svg")
-                .hotkey(lctrl(Key::Z))
-                .build_widget(ctx, "undo")
-        } else {
-            Widget::draw_svg_transform(
-                ctx,
-                "system/assets/tools/undo.svg",
-                RewriteColor::ChangeAll(Color::WHITE.alpha(0.5)),
-            )
-        })
-        .centered_vert(),
-        (if can_redo {
-            ctx.style()
-                .btn_plain_light_icon("system/assets/tools/redo.svg")
-                // TODO ctrl+shift+Z!
-                .hotkey(lctrl(Key::Y))
-                .build_widget(ctx, "redo")
-        } else {
-            Widget::draw_svg_transform(
-                ctx,
-                "system/assets/tools/redo.svg",
-                RewriteColor::ChangeAll(Color::WHITE.alpha(0.5)),
-            )
-        })
-        .centered_vert(),
+        ctx.style()
+            .btn_plain_light_icon("system/assets/tools/undo.svg")
+            .disabled(!can_undo)
+            .hotkey(lctrl(Key::Z))
+            .build_widget(ctx, "undo"),
+        ctx.style()
+            .btn_plain_light_icon("system/assets/tools/redo.svg")
+            .disabled(!can_redo)
+            // TODO ctrl+shift+Z!
+            .hotkey(lctrl(Key::Y))
+            .build_widget(ctx, "redo"),
         ctx.style()
             .btn_plain_destructive_text("Cancel")
             .hotkey(Key::Escape)


### PR DESCRIPTION
I did an audit I believe these to be the last places we were using draw_svg_transform to draw a disabled "button" instead of the new button `disabled` functionality.