### PR TITLE
Flatten the lane width controls into a single row, now that there's m…

### DIFF
--- a/game/src/edit/roads.rs
+++ b/game/src/edit/roads.rs
@@ -683,15 +683,17 @@ fn make_main_panel(
                     .icon("system/assets/tools/trash.svg")
                     .disabled(road.lanes_ltr().len() == 1)
                     .hotkey(Key::Backspace)
-                    .build_widget(ctx, "delete lane"),
+                    .build_widget(ctx, "delete lane")
+                    .centered_vert(),
                 ctx.style()
                     .btn_plain
                     .text("flip direction")
                     .disabled(!can_reverse(lane.lane_type))
                     .hotkey(Key::F)
-                    .build_def(ctx),
-                Line("Width").secondary().into_widget(ctx).centered_vert(),
-                Widget::col(vec![
+                    .build_def(ctx)
+                    .centered_vert(),
+                Widget::row(vec![
+                    Line("Width").secondary().into_widget(ctx).centered_vert(),
                     Widget::dropdown(ctx, "width preset", lane.width, width_choices(app, l)),
                     Spinner::widget_with_custom_rendering(
                         ctx,
@@ -707,9 +709,9 @@ fn make_main_panel(
                                 metric: false,
                             })
                         }),
-                    )
-                    .centered_horiz(),
-                ]),
+                    ),
+                ])
+                .section(ctx),
             ]),
         ])
     } else {


### PR DESCRIPTION
…ore room

Before:
![Screenshot from 2021-08-25 10-06-54](https://user-images.githubusercontent.com/1664407/130834523-e00f769b-f0ad-423b-8720-bb11477d468e.png)
After:
![Screenshot from 2021-08-25 10-07-16](https://user-images.githubusercontent.com/1664407/130834541-333ecbb5-0d24-460b-bca1-44d269fce6fe.png)

Having a dropdown and a spinner for lane width is already a bit funny, but hopefully the section style makes the grouping a bit more clear