### PR TITLE
Recalculate the hovered lane in the road editor very carefully. Any time

### DIFF
--- a/game/src/edit/roads.rs
+++ b/game/src/edit/roads.rs
@@ -397,7 +397,10 @@ impl State<App> for RoadEditor {
                     return Transition::Replace(RoadEditor::new_state(ctx, app, l));
                 }
             }
-        } else if self.selected_lane.is_some() && ctx.normal_left_click() {
+        } else if self.selected_lane.is_some()
+            && ctx.canvas.get_cursor_in_map_space().is_some()
+            && ctx.normal_left_click()
+        {
             // Deselect the current lane
             self.selected_lane = None;
             self.hovering_on_lane = None;


### PR DESCRIPTION
the map is edited, lane IDs change. There were many possible crashes
before.

Example bug before: just click a lane and press backspace to delete it. I got a crash, because `hovering_on_lane` was set to a lane ID that had vanished.

I played around with the new approach and haven't found any crashes / unexpected behavior