### PR TITLE
road editor design tweaks

### DIFF
--- a/widgetry/src/widgets/mod.rs
+++ b/widgetry/src/widgets/mod.rs
@@ -527,20 +527,17 @@ impl Widget {
     }
 
     pub fn horiz_separator(ctx: &mut EventCtx, pct_container_width: f64) -> Widget {
-        GeomBatch::from(vec![(
-            ctx.style().btn_outline.fg,
-            Polygon::rectangle(0.0, 2.0),
-        )])
-        .into_widget(ctx)
-        .container()
-        .bg(ctx.style().btn_outline.fg)
-        .force_width_parent_pct(pct_container_width)
-        .centered_horiz()
+        GeomBatch::from(vec![(Color::CLEAR, Polygon::rectangle(0.0, 2.0))])
+            .into_widget(ctx)
+            .container()
+            .bg(ctx.style().section_outline.1)
+            .force_width_parent_pct(pct_container_width)
+            .centered_horiz()
     }
 
     pub fn vert_separator(ctx: &mut EventCtx, height_px: f64) -> Widget {
         GeomBatch::from(vec![(
-            ctx.style().btn_outline.fg,
+            ctx.style().section_outline.1,
             Polygon::rectangle(2.0, height_px),
         )])
         .into_widget(ctx)


### PR DESCRIPTION
**before**
<img width="437" alt="Screen Shot 2021-08-25 at 12 11 50 PM" src="https://user-images.githubusercontent.com/217057/130850891-64900c64-f71f-43dd-9a98-7885d3c87873.png">


**after**
<img width="484" alt="Screen Shot 2021-08-25 at 12 10 23 PM" src="https://user-images.githubusercontent.com/217057/130850778-54fb7ce8-500d-47e9-81aa-f4cb85769943.png">

- move panel away from edge
- make "tab" metaphor more obvious with slight "shadow" on bottom of unselected tabs
- regroup sections to avoid undesirable inner rounding in top sections