### PR TITLE
Exploring designs: thicker lines unzoomed

### DIFF
--- a/game/src/common/waypoints.rs
+++ b/game/src/common/waypoints.rs
@@ -212,9 +212,11 @@ impl InputWaypoints {
         world: &mut World<T>,
         wrap_id: F,
         zorder: usize,
+        thickness: f64,
     ) {
         for (idx, waypoint) in self.waypoints.iter().enumerate() {
-            let hitbox = Circle::new(waypoint.center, Distance::meters(30.0)).to_polygon();
+            let hitbox =
+                Circle::new(waypoint.center, thickness * Distance::meters(30.0)).to_polygon();
             let color = self.get_waypoint_color(idx);
 
             let mut draw_normal = GeomBatch::new();
@@ -222,6 +224,7 @@ impl InputWaypoints {
             draw_normal.append(
                 Text::from(Line(get_waypoint_text(idx).to_string()).fg(Color::WHITE))
                     .render(ctx)
+                    .scale(thickness)
                     .centered_on(waypoint.center),
             );
 

--- a/widgetry/src/canvas.rs
+++ b/widgetry/src/canvas.rs
@@ -223,7 +223,7 @@ impl Canvas {
         // By popular request, some limits ;)
         self.cam_zoom = 1.1_f64
             .powf(old_zoom.log(1.1) + delta * (self.settings.canvas_scroll_speed as f64 / 10.0))
-            //.max(self.min_zoom())
+            .max(self.min_zoom())
             .min(self.max_zoom());
 
         // Make screen_to_map of the focus point still point to the same thing after


### PR DESCRIPTION
Problem: in larger maps, scaling routes in map-space stops looking reasonable when you zoom far out:
![before](https://user-images.githubusercontent.com/1664407/137545910-a1ec508a-5341-4628-8151-8051d0dfe5b4.gif)


Possible solution: thicken polylines and scale up circles as we zoom out:
![after](https://user-images.githubusercontent.com/1664407/137545722-fcbb2f1f-ac78-4aa2-a389-a0c0af56aadf.gif)

The first question: does this look better? Is it more usable?

## How to implement: ad-hoc + caching

This PR does an ad-hoc approach, discretizing zoom like we do for labels and the bike network layer, then recalculating _everything_ when that zoom changes. The outer-most / application level has to be aware of zoom and trigger recalculating everything. If we want to actually cache drawables and the `World` per discretized zoom instead of just storing one at a time, the code probably gets even grosser.

## Alt: abstract with something like `ToggledZoomed`

`ToggleZoomed` hides the fact that one of two things get drawn, based on zoom. App-level code just treats it as something drawable; it's simpler from that perspective.

Could we generalize? The performance-intensive but simple answer is to precalculate things for all of the discretized zoom levels upfront, and just switch between them. This might be quite slow; every single time we want to redraw a route as we drag a waypoint around, we would thicken a polyline not just once, but 5 or 10 times! Even though it's unlikely that the zoom level is changing as we drag.

The less simple approach would have some kind of app-level callback to regenerate a `GeomBatch` given a zoom or thickness parameter as input. The lifetimes / borrowing rules might make this tricky. For example, if a `State` struct contains this `CacheZoomed` helper, and to calculate for a new zoom level, we need to borrow all of the fields in the `State` struct, we might have a double borrow problem, like we have with `Cached` today sometimes.

### Another problem with this approach

The second complication is that sometimes we don't want to just recalculate something to draw based on zoom; we also need its hitbox to click on it. The polygon editor recently changed to use the new `World` API, but we scale everything there based on zoom, so we recalculate the entire `World` for different zooms: https://github.com/a-b-street/abstreet/blob/7d57deb8ae2706d2379e0ff103ee7bb94967108e/game/src/devtools/polygon.rs#L16

If we wanted to stop recalculating everything for different zooms (the ad-hoc + caching approach described earlier, aka, this PR), we might need to teach `World` how to do this natively. Maybe it can handle adjusting the quadtree and drawables as needed.

### Builder API

The common case is thickening polylines different amounts. Maybe we can make an object that holds onto the polyline, base width, and color, then generates the scaled stuff as needed.

Except it's rarely that simple. In this PR, we also see examples of needing to scale circles and text for the waypoints. And for drawing alternate routes, we need to turn a thickened polyline into an outline/border too. It seems more general-purpose and simple to write a function to draw stuff, given a zoom/thickness.

## Alt: Shader?

We just have one shader today that can translate and scale stuff. For drawing in "screen-space", we just temporarily override the parameters for those. Should we start a second shader designed to draw things that have a certain map-space position, but can scale up? Can this work for anything in general (circles, text, thick polylines), or would it just be for polylines? How does it work -- always draw things with a certain size on the screen -- like a polyline with 10 pixels thickness -- but adjusting the position to match the current camera?

I need to find examples of how most maps handle this today. https://mattdesl.svbtle.com/drawing-lines-is-hard "expanding in a vertex shader" looks like a good lead.

Pushing this into the shader doesn't solve everything -- what about hitboxes for clicking the unzoomed route? Maybe we have a new structure, that plays with `World`, that remembers the original polyline and base thickness, projects the cursor onto the nearest line segment, and checks if that distance is within the current threshold.