### PR TITLE
Swap edited / unedited map for routing.

### DIFF
--- a/game/src/common/mod.rs
+++ b/game/src/common/mod.rs
@@ -309,11 +309,7 @@ impl CommonState {
             return Some(Transition::Push(warp::DebugWarp::new_state(ctx)));
         }
         if app.secondary.is_some() && ctx.input.pressed(lctrl(Key::Tab)) {
-            // This swaps the primary and secondary PerMaps. Depending on what state the rest of
-            // the app is in, things like IDs might totally change! This is very much a debug tool.
-            let secondary = app.secondary.take().unwrap();
-            let primary = std::mem::replace(&mut app.primary, secondary);
-            app.secondary = Some(primary);
+            app.swap_map();
         }
         None
     }

--- a/game/src/lib.rs
+++ b/game/src/lib.rs
@@ -236,6 +236,7 @@ fn setup_app(ctx: &mut EventCtx, mut setup: Setup) -> (App, Vec<Box<dyn State<Ap
         let app = App {
             primary,
             secondary,
+            store_unedited_map_in_secondary: false,
             cs,
             opts: setup.opts.clone(),
             per_obj: crate::app::PerObjectActions::new(),
@@ -269,6 +270,7 @@ fn setup_app(ctx: &mut EventCtx, mut setup: Setup) -> (App, Vec<Box<dyn State<Ap
         let mut app = App {
             primary,
             secondary,
+            store_unedited_map_in_secondary: false,
             cs,
             opts: setup.opts.clone(),
             per_obj: crate::app::PerObjectActions::new(),
@@ -383,6 +385,9 @@ fn finish_app_setup(
     edits: Option<MapEdits>,
     setup: Setup,
 ) -> Vec<Box<dyn State<App>>> {
+    if setup.ungap {
+        app.store_unedited_map_in_secondary = true;
+    }
     if let Some(edits) = edits {
         ctx.loading_screen("apply initial edits", |ctx, mut timer| {
             crate::edit::apply_map_edits(ctx, app, edits);

--- a/game/src/ungap/predict.rs
+++ b/game/src/ungap/predict.rs
@@ -349,9 +349,9 @@ impl ModeShiftData {
         timer: &mut Timer,
     ) -> ModeShiftData {
         let unedited_map = app
-            .primary
-            .unedited_map
+            .secondary
             .as_ref()
+            .map(|x| &x.map)
             .unwrap_or(&app.primary.map);
         let all_candidate_trips = timer
             .parallelize(
@@ -407,9 +407,9 @@ impl ModeShiftData {
 
     fn recalculate_gaps(&mut self, ctx: &mut EventCtx, app: &App, timer: &mut Timer) {
         let unedited_map = app
-            .primary
-            .unedited_map
+            .secondary
             .as_ref()
+            .map(|x| &x.map)
             .unwrap_or(&app.primary.map);
 
         // Find all high-stress roads, since we'll filter by them next

--- a/game/src/ungap/trip/results.rs
+++ b/game/src/ungap/trip/results.rs
@@ -10,7 +10,7 @@ use widgetry::{
     ScreenDims, Series, Text, Widget,
 };
 
-use super::RoutingPreferences;
+use super::{before_after_button, RoutingPreferences};
 use crate::app::{App, Transition};
 
 /// A temporary structure that the caller should unpack and use as needed.
@@ -373,6 +373,7 @@ fn make_detail_widget(
 
     Widget::col(vec![
         Line("Route details").small_heading().into_widget(ctx),
+        before_after_button(ctx, app),
         Text::from_all(vec![
             Line("Distance: ").secondary(),
             Line(stats.total_distance.to_string(&app.opts.units)),


### PR DESCRIPTION
I mentioned this as one of the features I'd like to launch with. Particularly in the "Your trip" mode, I think it's quite helpful to evaluate the "test case" of the trip against the original map and the current proposal. Here's a button to switch back and forth:
![screencast](https://user-images.githubusercontent.com/1664407/137645520-79ff68f4-880a-4312-b283-d856e4d3043c.gif)
Button placement, syling, and wording all placeholder. Just wanted to initially see if this makes sense.

The generalization would be easily listing out a few alternatives and being able to switch quickly between them -- like 'Current conditions', '2024 master plan (full build)', '2024 master plan (50% funding cut)', 'XYZ's vision'. You'd be able to evaluate individual routes against a set of proposals. I think in imagining some of the LTN stuff for the future, we've arrived at a similar idea. And I think this pattern could also be useful in A/B Street's edit mode. Not sure yet about implementation. To swap between proposals quickly, we probably can't afford to apply the map edits and rebuild parts of the DrawMap. But at some point, with large maps and a few proposals, it might be lots of normal and GPU memory to hold onto everything... need to benchmark.