### PR TITLE
Stop serializing turns. Generate them after loading the map. #746

### DIFF
--- a/map_model/src/map.rs
+++ b/map_model/src/map.rs
@@ -89,6 +89,7 @@ impl Map {
 
         self.edits = self.new_edits();
         self.recalculate_road_to_buildings();
+        self.recalculate_turns(timer);
         self.recalculate_all_movements(timer);
 
         // Enable to work on shrinking map file sizes. Never run this on the web though --
@@ -831,6 +832,16 @@ impl Map {
         );
         for (i, movements) in self.intersections.iter_mut().zip(movements.into_iter()) {
             i.movements = movements;
+        }
+    }
+
+    fn recalculate_turns(&mut self, timer: &mut Timer) {
+        let turns = timer.parallelize(
+            "generate turns",
+            self.intersections.iter().collect(),
+            |i| crate::make::turns::make_all_turns(self, i));
+        for t in turns.into_iter().flatten() {
+            self.intersections[t.id.parent.0].turns.push(t);
         }
     }
 

--- a/map_model/src/objects/intersection.rs
+++ b/map_model/src/objects/intersection.rs
@@ -43,6 +43,7 @@ pub struct Intersection {
     pub id: IntersectionID,
     /// This needs to be in clockwise orientation, or later rendering of sidewalk corners breaks.
     pub polygon: Polygon,
+    #[serde(skip_serializing, skip_deserializing)]
     pub turns: Vec<Turn>,
     pub elevation: Distance,
 


### PR DESCRIPTION
Turns can be generated from other data, so we can save space by not serializing them. Does it help?

- huge_seattle, release mode, native
  - before: 258MB, 11.8s to load in UI (read the file, create DrawMap)
  - after: 218MB, 10.1s
- central_seattle, debug mode, native
  - before: 54MB, 25.6s total
  - after: 43MB, 23.4s total
  - just deserializing the file drops from 8.4s to 6s
  - almost 1s spent reconstructing the turns

I'm now measuring on web. No parallelism there, so regenerating turns might be much slower.

Also need to silence the warnings when we generate turns; it's quite a spammy experience to just load a map.