### PR TITLE
Make LTN cell calculations account for one-way roads

### DIFF
--- a/apps/ltn/src/neighbourhood.rs
+++ b/apps/ltn/src/neighbourhood.rs
@@ -243,6 +243,8 @@ fn floodfill(
             },
         );
 
+        let current_oneway_dir = current.oneway_for_driving();
+
         for i in [current.src_i, current.dst_i] {
             // It's possible for one border intersection to have two roads in the interior of the
             // neighbourhood. Don't consider a turn between those roads through this intersection as
@@ -253,6 +255,15 @@ fn floodfill(
                 continue;
             }
 
+            // TODO This seems redundant given below. Maybe only do this when we happen to start on
+            // a one-way?
+            // Don't search against the one-way direction
+            if (current_oneway_dir == Some(Direction::Fwd) && i == current.src_i)
+                || (current_oneway_dir == Some(Direction::Back) && i == current.dst_i)
+            {
+                continue;
+            }
+
             for next in &map.get_i(i).roads {
                 let next_road = map.get_r(*next);
                 if let Some(filter) = edits.intersections.get(&i) {
@@ -260,6 +271,18 @@ fn floodfill(
                         continue;
                     }
                 }
+
+                // TODO It might be simpler to search by intersections and start from borders?
+                // TODO More generally, is it possible to turn into the road this way?
+                if let Some(dir) = next_road.oneway_for_driving() {
+                    if dir == Direction::Fwd && i == next_road.dst_i {
+                        continue;
+                    }
+                    if dir == Direction::Back && i == next_road.src_i {
+                        continue;
+                    }
+                }
+
                 if let Some(filter) = edits.roads.get(next) {
                     // Which ends of the filtered road have we reached?
                     let mut visited_start = next_road.src_i == i;


### PR DESCRIPTION
Problem: Sometimes one-ways can effectively block off part of an area:
![Screenshot from 2023-01-16 14-58-04](https://user-images.githubusercontent.com/1664407/212707914-68a8ea61-d68e-4ade-b42c-62984731674a.png)
There's just one large purple cell, though, because the current calculation ignores direction of the roads.

This PR is a start to taking them into account:
![Screenshot from 2023-01-16 15-00-14](https://user-images.githubusercontent.com/1664407/212708345-f96a91af-5ff2-4fd8-a3da-5adc9b3b190a.png)

But even this example gets confusing. Why is there the tiny blue cell at the bottom? There are "spurious" changes in cells based on the order we happen to floodfill. For example we have both:
![Screenshot from 2023-01-16 15-01-31](https://user-images.githubusercontent.com/1664407/212708514-689ed4cc-f560-44bb-bf04-5670163f73ae.png)
and
![Screenshot from 2023-01-16 15-02-46](https://user-images.githubusercontent.com/1664407/212708748-be25f2ef-19b9-4b4d-96a7-190b011338ae.png)

I think this idea has potential, but there are subtleties. A cell is meant to represent everywhere you can reach without leaving the area. One-ways throw that off.