### PR TITLE
Fix grid2demand import

### DIFF
--- a/apps/game/src/edit/traffic_signals/edits.rs
+++ b/apps/game/src/edit/traffic_signals/edits.rs
@@ -202,7 +202,7 @@ pub fn edit_entire_signal(
         .session
         .last_gmns_timing_csv
         .as_ref()
-        .map(|(path, _)| format!("import from GMNS {}", path));
+        .map(|(path, _)| format!("import from GMNS {}", abstutil::basename(path)));
     let gmns_all = "import all traffic signals from a new GMNS timing.csv";
 
     let mut choices = vec![use_template.to_string()];

--- a/apps/game/src/edit/traffic_signals/gmns.rs
+++ b/apps/game/src/edit/traffic_signals/gmns.rs
@@ -159,7 +159,7 @@ pub fn import_all(
 
     PopupMsg::new_state(
         ctx,
-        &format!("Import from {}", path),
+        &format!("Import from {}", abstutil::basename(path)),
         vec![
             format!("{} traffic signals successfully imported", successes),
             format!("{} intersections without any data", failures_no_match),

--- a/apps/ltn/src/save/proposals_ui.rs
+++ b/apps/ltn/src/save/proposals_ui.rs
@@ -189,7 +189,12 @@ fn load_picker_ui(
                     Box::new(move |ctx, app, maybe_file| {
                         match maybe_file {
                             Ok(Some((path, bytes))) => {
-                                match Proposal::load_from_bytes(ctx, app, &path, Ok(bytes)) {
+                                match Proposal::load_from_bytes(
+                                    ctx,
+                                    app,
+                                    &abstutil::basename(&path),
+                                    Ok(bytes),
+                                ) {
                                     Some(err_state) => Transition::Replace(err_state),
                                     None => preserve_state.switch_to_state(ctx, app),
                                 }

--- a/map_gui/src/tools/ui.rs
+++ b/map_gui/src/tools/ui.rs
@@ -36,7 +36,8 @@ impl FilePicker {
                 }
                 // Can't get map() or and_then() to work with async
                 let result = if let Some(handle) = builder.pick_file().await {
-                    Some((handle.file_name(), handle.read().await))
+                    let path = handle.path().to_string_lossy().into_owned();
+                    Some((path, handle.read().await))
                 } else {
                     None
                 };


### PR DESCRIPTION
Fixes #1132 

The issue was related to FilePicker not returning a path but rather just the filename. That fix is split into 2 commits: one ensures that filename is used for cases where only the filename was relevant (dialogs). The other modifies FilePicker to return a path. IIUC it may not work with non-UTF8 characters in paths on Windows (� will be used), but neither would the original code. Fixing non-UTF8 paths requires changes to `abstio`.

After that, another issue prevented the file from #1132 being imported - lack of whitespace handling in LINESTRING entries in the input csv, which the 3rd commit fixes.

I clicked through import dialogs I could find, and things seem to work with the exception of KML - before my change it suffered from the same FilePicker issue, after the change it breaks on KML format itself.

DISCLAIMER: I'm relatively new to Rust, so pls do extra scrutiny on this one